### PR TITLE
docs: release versioning and self-hosted-first approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ docs/
   naming.md             # Name research and background
   decisions/            # Architecture Decision Records (ADR format)
     README.md           # Index of all ADRs + open decisions
-    ADR-NNN-title.md    # Individual decision records (17 so far)
+    ADR-NNN-title.md    # Individual decision records (19 so far)
   autonomy-model.md     # Three-tier trust model for agent actions
   user-profile.md       # Persistent user preferences across projects
 ```
@@ -78,6 +78,8 @@ docs/
 - Three-tier autonomy model ([ADR-015](docs/decisions/ADR-015-three-tier-autonomy.md))
 - User profile as first-class concept ([ADR-016](docs/decisions/ADR-016-user-profile.md))
 - Devkit as reference implementation ([ADR-017](docs/decisions/ADR-017-devkit-reference.md))
+- Three-phase release: alpha, beta, v1.0 ([ADR-018](docs/decisions/ADR-018-release-versioning.md))
+- Self-hosted-first development ([ADR-019](docs/decisions/ADR-019-self-hosted-first.md))
 
 ## References
 

--- a/docs/decisions/ADR-018-release-versioning.md
+++ b/docs/decisions/ADR-018-release-versioning.md
@@ -1,0 +1,82 @@
+# ADR-018: Release Versioning and V1 Scope
+
+## Status
+
+Accepted
+
+## Context
+
+The project had 17 ADRs, 22 issues, and no defined release milestones. "V1 scope" was listed as an open decision blocking prioritization of all downstream work.
+
+Discussion clarified that V1 is not the minimum viable loop -- it is a stable, feature-complete system ready for public use. The minimum viable loop is alpha. Between alpha and public release sits a beta that proves all major subsystems work together.
+
+## Decision
+
+Samverk uses a three-phase release model:
+
+### v0.0.1 -- Alpha (Single Loop Proof)
+
+The minimum that demonstrates the core async loop works end-to-end.
+
+**In scope:**
+
+- Go project scaffold (module, directory structure, Makefile, CI)
+- Forge abstraction interface with Gitea implementation (primary target)
+- Issue schema as machine-readable spec
+- Dispatcher agent (watches issues, routes to agents)
+- One specialist agent (code-gen) + its QC mirror
+- Autonomy config loader (.samverk/autonomy.yaml)
+- Basic check-in digest (Tier 3 pending, Tier 2 summary)
+- Claude API as the cloud model provider
+- Self-hosted deployment on home server
+
+**Out of scope:** Multi-model failover, local agents, GitHub support, user profile, multiple specialist types, mobile-specific features.
+
+**Success criteria:** User creates a task via Gitea issue, dispatcher routes it, code-gen agent produces output, QC validates, result appears on the issue. User reviews at next check-in.
+
+### v0.1 -- Beta (Multi-System Integration)
+
+Proves all major subsystems work together with real workloads.
+
+**Adds to alpha:**
+
+- Multi-model capability (Claude + at least one alternative cloud provider)
+- Local agent execution via Ollama (RTX 3090 Ti, 24GB VRAM)
+- Model routing: local for narrow tasks, cloud for complex reasoning
+- GitHub forge implementation (second platform, validates abstraction)
+- Multiple specialist agents (code-gen, test, docs, research)
+- Basic user profile (project conventions, tech preferences)
+- Cost tracking and budget awareness
+
+**Success criteria:** Samverk builds a non-trivial feature across multiple agent types, using local models for routine work and cloud for complex decisions, on a self-hosted Gitea instance. Cost per task is tracked and reported.
+
+### v1.0 -- Public Release
+
+Stable, polished, all features at production quality.
+
+**Adds to beta:**
+
+- All specialist agent types operational and tested
+- User profile fully functional with Devkit ingestion
+- Check-in digest polished for 10-minute review sessions
+- Multi-device access validated (phone, tablet, desktop)
+- Documentation, onboarding flow, installation guide
+- Security hardening (API key management, network isolation)
+- Performance optimization (cold start, throughput)
+- Error recovery and resilience (forge outage, model unavailability)
+
+**Success criteria:** A new user can install Samverk on their own server, connect their repos, and have agents working on their project within an hour. The system runs unattended for days without intervention.
+
+## Consequences
+
+- Alpha is achievable with focused effort -- limited scope, one forge, one agent type
+- Beta requires real hardware deployment (home server with GPU)
+- V1 is a high bar -- stability and polish take longer than features
+- Milestones on GitHub align to these release phases
+- Server platform decision (Unraid/Proxmox/Windows) must be made before beta
+
+## References
+
+- [ADR-019: Self-Hosted-First Development](ADR-019-self-hosted-first.md)
+- [Architecture](../architecture.md)
+- [Autonomy Model](../autonomy-model.md)

--- a/docs/decisions/ADR-019-self-hosted-first.md
+++ b/docs/decisions/ADR-019-self-hosted-first.md
@@ -1,0 +1,65 @@
+# ADR-019: Self-Hosted-First Development
+
+## Status
+
+Accepted
+
+## Context
+
+The original architecture described GitHub as the primary forge with Gitea as an alternative. However, the founder's actual development environment is a home network with:
+
+- Gitea already running and available for testing
+- An RTX 3090 Ti (24GB VRAM) available for a dedicated project server
+- Multiple server platform options (Unraid, Proxmox, Windows)
+
+Building against cloud services first (GitHub, Claude API) would mean:
+
+- API rate limits constrain development speed
+- Every test run costs money
+- The local agent story is deferred to "later"
+- The forge abstraction is not validated until a second implementation exists
+
+Building against local infrastructure first inverts these tradeoffs.
+
+## Decision
+
+Samverk development targets self-hosted infrastructure as the primary environment:
+
+- **Gitea** is the primary forge target (first implementation of the forge abstraction)
+- **Ollama** on local GPU is the primary model target for specialist agents
+- **Cloud APIs** (Claude, GPT-4) are used for complex reasoning and as fallback
+- **GitHub** support is the second forge implementation, validating the abstraction
+
+Development and testing happen on the home network. Cloud services are added as the system matures, not as the starting point.
+
+### Infrastructure
+
+- **Available now:** Gitea instance for testing, existing server hardware
+- **Planned:** Dedicated project server with RTX 3090 Ti for Ollama
+- **Platform decision pending:** Unraid, Proxmox, or Windows as the server OS
+
+### Local Model Capabilities (RTX 3090 Ti, 24GB VRAM)
+
+The 3090 Ti can run substantial models:
+
+- **Code generation:** CodeLlama 34B (Q4 quantized), DeepSeek Coder 33B
+- **General reasoning:** Mixtral 8x7B, Llama 3 70B (Q4)
+- **Fast/small tasks:** Llama 3 8B, Phi-3, CodeGemma 7B
+- **Multiple models simultaneously:** Smaller models can share VRAM
+
+This means local agents are not limited to toy models. Serious code generation, test writing, and documentation tasks can run entirely on local hardware.
+
+## Consequences
+
+- No cloud API costs during early development and testing
+- Gitea forge implementation is exercised from day one
+- Forge abstraction is validated early (Gitea first, GitHub second)
+- Server platform decision becomes a near-term prerequisite
+- Network configuration and security are development concerns from the start
+- GitHub-specific features (Actions, Copilot integration) are deferred
+
+## References
+
+- [ADR-013: Abstract Git Forge Behind Interface](ADR-013-forge-abstraction.md)
+- [ADR-018: Release Versioning and V1 Scope](ADR-018-release-versioning.md)
+- [ADR-007: Hybrid Local/Cloud Agent Model](ADR-007-hybrid-local-cloud.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -21,6 +21,8 @@ Decisions are recorded as ADR files in this directory.
 | [015](ADR-015-three-tier-autonomy.md) | Three-Tier Autonomy Model | Accepted |
 | [016](ADR-016-user-profile.md) | User Profile as First-Class Concept | Accepted |
 | [017](ADR-017-devkit-reference.md) | Devkit as Reference Implementation | Accepted |
+| [018](ADR-018-release-versioning.md) | Release Versioning and V1 Scope | Accepted |
+| [019](ADR-019-self-hosted-first.md) | Self-Hosted-First Development | Accepted |
 
 ## Open Decisions
 
@@ -29,5 +31,4 @@ Decisions are recorded as ADR files in this directory.
 - Cost management -- token budget tracking and enforcement
 - Licensing -- BSL 1.1 / Apache 2.0 dual or different?
 - Domain selection -- samverk.io vs samverk.ai
-- V1 scope -- minimum viable framework
-- Hosting model -- self-hosted, hosted service, or both?
+- Server platform selection -- Unraid, Proxmox, or Windows for the project server

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -82,7 +82,8 @@ Problems that must be resolved before or during development.
 
 ## Business and Product
 
-- **V1 scope.** What's the minimum that proves the concept?
-- **Hosting model.** Is Samverk a hosted service, self-hosted tool, or both?
+- ~~**V1 scope.**~~ Resolved in [ADR-018](decisions/ADR-018-release-versioning.md). Three-phase: v0.0.1 alpha, v0.1 beta, v1.0 public.
+- ~~**Hosting model.**~~ Resolved in [ADR-019](decisions/ADR-019-self-hosted-first.md). Self-hosted-first, cloud as fallback.
+- **Server platform.** Unraid vs Proxmox vs Windows for the dedicated project server. RTX 3090 Ti available. Needs research spike.
 - **Dogfooding.** How does Samverk itself get built -- can Subnetree serve as the dogfood project?
 - **Licensing model.** What fits the target user -- subscription, usage-based, open core?


### PR DESCRIPTION
## Summary

- ADR-018: Three-phase release model (v0.0.1 alpha -> v0.1 beta -> v1.0 public)
- ADR-019: Self-hosted-first development (Gitea + Ollama on home server, cloud as fallback)
- Resolved V1 scope and hosting model open questions
- Restructured milestones: Phase 1 renamed to "v0.0.1: Alpha", added "v0.1: Beta"
- Created 3 new issues: server platform evaluation (#24), local model survey (#25), Gitea setup (#26)

## Test plan

- [ ] ADR index matches actual files
- [ ] Open questions reflect resolved status
- [ ] Milestone structure visible on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)