### PR TITLE
docs: add tech stack reference and web dashboard ADR

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,21 @@
+{
+  "default": true,
+
+  "MD003": { "style": "atx" },
+  "MD004": { "style": "dash" },
+  "MD007": { "indent": 2 },
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD029": { "style": "ordered" },
+  "MD033": {
+    "allowed_elements": ["br", "details", "summary", "img", "a", "sub", "sup"]
+  },
+  "MD035": { "style": "---" },
+  "MD036": false,
+  "MD041": false,
+  "MD046": { "style": "fenced" },
+  "MD048": { "style": "backtick" },
+  "MD049": { "style": "asterisk" },
+  "MD050": { "style": "asterisk" },
+  "MD060": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,30 +17,53 @@ make run       # Start the system
 ## Project Structure
 
 ```text
-docs/
-  architecture.md       # Chat front-end / git back-end agent model
-  communication-protocol.md  # Issue schema, labels, dispatcher, QC flow
-  competitive.md        # Market landscape and positioning
-  concept.md            # Problem space, target user, value proposition
-  cost-model.md         # Tiered cost model and comparisons
-  mcp-server.md         # MCP server requirements and tool definitions
-  user-interface.md     # Check-in model and device flexibility spec
-  open-questions.md     # Unresolved design and business questions
-  naming.md             # Name research and background
-  decisions/            # Architecture Decision Records (ADR format)
-    README.md           # Index of all ADRs + open decisions
-    ADR-NNN-title.md    # Individual decision records (19 so far)
-  autonomy-model.md     # Three-tier trust model for agent actions
-  user-profile.md       # Persistent user preferences across projects
+samverk/
+├── cmd/samverk/               # Single binary entrypoint (cobra subcommands)
+├── internal/
+│   ├── server/                # HTTP server (MCP + API + embedded SPA)
+│   ├── api/                   # REST API handlers for dashboard
+│   ├── mcp/                   # MCP protocol handler (Streamable HTTP)
+│   ├── dispatcher/            # Issue watcher, task router, dependency DAG
+│   ├── forge/                 # IssueTracker interface + GitHub/Gitea impls
+│   ├── agent/                 # Agent runtime, container management
+│   ├── provider/              # AI provider clients (Claude, OpenAI, Ollama)
+│   ├── autonomy/              # Trust tier evaluation engine
+│   ├── profile/               # User profile management
+│   ├── cost/                  # Token tracking, budget, attribution
+│   └── store/                 # SQLite persistence layer
+├── pkg/models/                # Shared types (Issue, Agent, Action, etc.)
+├── web/                       # React SPA dashboard (Vite + TypeScript)
+├── docs/                      # Design docs and ADRs
+│   ├── architecture.md        # System design and components
+│   ├── tech-stack.md          # Full technology choices and libraries
+│   ├── communication-protocol.md  # Issue schema, labels, dispatcher, QC flow
+│   ├── concept.md             # Problem space, target user, value proposition
+│   ├── cost-model.md          # Tiered cost model and comparisons
+│   ├── mcp-server.md          # MCP server requirements and tool definitions
+│   ├── user-interface.md      # Check-in model and device flexibility spec
+│   ├── autonomy-model.md      # Three-tier trust model for agent actions
+│   ├── user-profile.md        # Persistent user preferences across projects
+│   ├── open-questions.md      # Unresolved design and business questions
+│   └── decisions/             # Architecture Decision Records (20 so far)
+├── .samverk/                  # Runtime config (gitignored)
+├── .github/workflows/         # CI/CD pipelines
+└── Makefile                   # Build and development tasks
 ```
 
 ## Tech Stack
 
-- **Language**: Go (orchestrator), local models via Ollama in Docker
-- **AI Providers**: Multi-model -- Claude (primary), GPT-4, Gemini, local fallback
-- **Testing**: TBD
-- **Build**: Make
-- **CI/CD**: GitHub Actions
+- **Language:** Go -- single binary with subcommands (`samverk serve`, `samverk dispatch`, `samverk config`)
+- **AI Providers:** Anthropic Claude API (primary), OpenAI/GPT-4, Gemini, Ollama (local containers)
+- **Web Dashboard:** React + TypeScript + Vite, embedded in Go binary via `embed.FS`
+- **Frontend:** shadcn/ui, Tailwind CSS, TanStack Query, Zustand, Recharts
+- **State:** Git issues (tasks) + SQLite (sessions, cost, audit) + YAML (config)
+- **Git Forge:** GitHub (primary), Gitea (self-hosted), abstracted behind `IssueTracker` interface
+- **Testing:** Go stdlib + table-driven tests, Vitest + Testing Library (frontend)
+- **Build:** Make + GoReleaser
+- **CI/CD:** GitHub Actions
+- **Linting:** golangci-lint (Go), ESLint + TypeScript (frontend), markdownlint (docs)
+
+For full details including specific libraries, what NOT to use, and project structure rationale, see [docs/tech-stack.md](docs/tech-stack.md).
 
 ## Development Workflow
 
@@ -81,10 +104,12 @@ docs/
 - Devkit as reference implementation ([ADR-017](docs/decisions/ADR-017-devkit-reference.md))
 - Three-phase release: alpha, beta, v1.0 ([ADR-018](docs/decisions/ADR-018-release-versioning.md))
 - Self-hosted-first development ([ADR-019](docs/decisions/ADR-019-self-hosted-first.md))
+- Web dashboard for operations ([ADR-020](docs/decisions/ADR-020-web-dashboard.md))
 
 ## References
 
 - [Architecture](docs/architecture.md)
+- [Tech Stack](docs/tech-stack.md)
 - [Communication Protocol](docs/communication-protocol.md)
 - [Concept](docs/concept.md)
 - [Competitive Landscape](docs/competitive.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 > **Samverk is a conversational project manager backed by a working agent team.**
 
-The chat IS the interface. Not a dashboard, not a web portal, not a special app. A conversation. On any device that can run Claude.
+The chat IS the primary interface. A conversation on any device that can run Claude. A web dashboard complements it for operational concerns -- configuration, monitoring, logs, and troubleshooting ([ADR-020](decisions/ADR-020-web-dashboard.md)).
 
 ## Two Core Components
 
@@ -44,6 +44,7 @@ The scope is tighter than originally described because we're building on existin
 | Project storage | Git (already exists) |
 | Task system | GitHub/Gitea issues (already exists) |
 | **MCP server -- repo + issue access** | **Samverk builds this** |
+| **Web dashboard -- ops, config, monitoring** | **Samverk builds this** |
 | **Dispatcher agent** | **Samverk builds this** |
 | **Specialist execution agents** | **Samverk builds this** |
 | **Issue schema + conventions** | **Samverk defines this** |
@@ -98,6 +99,22 @@ Cold start latency (30-90 seconds to spin up a container and load a model) is NO
           QC        QC        QC        QC
       (validates each agent's output)
 ```
+
+## Web Dashboard
+
+The chat handles project progress and decisions. The web dashboard handles infrastructure and operations. See [ADR-020](decisions/ADR-020-web-dashboard.md) for the decision rationale.
+
+The Go server serves three HTTP surfaces on the same port:
+
+| Path | Purpose | Consumer |
+| ---- | ------- | -------- |
+| `/mcp` | MCP Streamable HTTP (JSON-RPC) | Claude (any device) |
+| `/api/v1/` | REST API | Dashboard SPA |
+| `/` | Embedded SPA static files | Browser |
+
+The React SPA is embedded in the Go binary via `embed.FS`. Single binary deployment is preserved -- no separate web server, no CORS, no reverse proxy.
+
+Dashboard scope: system health, agent monitoring, cost dashboards, structured log viewer, autonomy configuration, project settings, task timeline, and user profile management. See [Tech Stack](tech-stack.md) for full dashboard section details.
 
 ## The QC Mirror
 
@@ -194,10 +211,16 @@ The profile can be bootstrapped from an existing Devkit-style repo, repo analysi
 
 ## Implementation Stack
 
-- **Language:** Go (consistent with Subnetree project)
+- **Language:** Go ([ADR-005](decisions/ADR-005-go-language.md))
 - **Primary platform:** Windows (developer's primary environment)
-- **AI Providers:** Anthropic Claude API (primary), multi-provider failover
-- **Local models:** Ollama in Docker containers
-- **Git forge:** GitHub (primary), Gitea (self-hosted option)
+- **Deployment:** Single binary with subcommands (`samverk serve`, `samverk dispatch`, `samverk config`)
+- **AI Providers:** Anthropic Claude API (primary), OpenAI/GPT-4, Gemini, Ollama (local)
+- **Local models:** Ollama in Docker containers, per-agent-type profiles
+- **Web dashboard:** React + TypeScript SPA, embedded via `embed.FS` ([ADR-020](decisions/ADR-020-web-dashboard.md))
+- **Git forge:** GitHub (primary), Gitea (self-hosted option), abstracted behind `IssueTracker` interface
+- **State persistence:** Git issues (task state) + SQLite (sessions, cost, audit) + YAML (config)
 - **Agent communication:** Git issues (see [Communication Protocol](communication-protocol.md))
-- **Orchestration:** Custom -- not built on LangChain/LangGraph/CrewAI
+- **Orchestration:** Custom -- not built on LangChain/LangGraph/CrewAI ([ADR-004](decisions/ADR-004-custom-orchestration.md))
+- **CI/CD:** GitHub Actions + GoReleaser
+
+For the full technology stack including specific libraries and project structure, see [Tech Stack](tech-stack.md).

--- a/docs/decisions/ADR-020-web-dashboard.md
+++ b/docs/decisions/ADR-020-web-dashboard.md
@@ -1,0 +1,66 @@
+# ADR-020: Web Dashboard for Operations
+
+**Status**: Accepted
+**Date**: 2026-02-27
+
+## Context
+
+[ADR-011](ADR-011-chat-as-interface.md) established the chat (Claude + MCP) as the primary user interface for project progress, decisions, and direction. This works well for the async check-in model -- the user's 5-15 minute interaction with their project.
+
+However, operational concerns do not fit naturally into a conversational interface:
+
+- **Configuration management** -- editing autonomy tiers, API keys, model priority, forge connections
+- **System monitoring** -- dispatcher health, agent container status, queue depth, resource usage
+- **Cost visibility** -- burn rate graphs, per-project spend, budget alerts, historical trends
+- **Log inspection** -- structured log viewing with filtering by agent, severity, and task
+- **Troubleshooting** -- diagnosing failed agents, reviewing QC cycles, dependency graph visualization
+
+These are visual, data-dense, and often require scanning rather than asking. A chat interface would either produce walls of text or require many back-and-forth queries to surface the same information a dashboard shows at a glance.
+
+## Decision
+
+Add a web dashboard embedded in the Go binary alongside the MCP server. The dashboard is an operational admin panel, not a replacement for the chat interface.
+
+### Clear Boundary
+
+The chat handles **what** (project progress, decisions, direction). The dashboard handles **how** (infrastructure, operations, diagnostics).
+
+| Chat (Claude + MCP) | Dashboard (Web UI) |
+|---------------------|-------------------|
+| "How's my project?" | System health metrics |
+| "Approve this merge" | Agent container status |
+| "Change priority on #42" | Cost graphs and trends |
+| "What got done today?" | Log viewer and search |
+| Give direction, make decisions | Edit autonomy config visually |
+| | Troubleshoot failed agents |
+| | API key management |
+
+### Implementation
+
+- React + TypeScript SPA, built with Vite
+- Embedded in the Go binary via `embed.FS`
+- Served on the same port as the MCP server
+- Three HTTP surfaces: `/mcp` (Claude), `/api/v1/` (dashboard REST API), `/` (SPA static files)
+- No separate web server process, no CORS, no reverse proxy
+
+## Consequences
+
+**Positive:**
+
+- Single binary deployment preserved -- dashboard ships with the server
+- Operational visibility without cluttering the check-in conversation
+- Familiar technology (React) consistent with SubNetree project
+- REST API created for dashboard also enables future integrations and automation
+- Dashboard accessible from any browser on the local network or via Tailscale
+
+**Negative:**
+
+- Adds frontend build tooling (Node.js, Vite, npm/pnpm) to the development workflow
+- More code to maintain (React components, API handlers, REST endpoints)
+- Dashboard must not become a second primary interface -- the boundary must be enforced through design, not just documentation
+
+## Related
+
+- [ADR-011: Chat as Primary Interface](ADR-011-chat-as-interface.md) -- establishes chat for project interaction
+- [ADR-019: Self-Hosted First](ADR-019-self-hosted-first.md) -- dashboard runs on the same self-hosted server
+- [Tech Stack](../tech-stack.md) -- full technology choices including frontend libraries

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,6 +23,7 @@ Decisions are recorded as ADR files in this directory.
 | [017](ADR-017-devkit-reference.md) | Devkit as Reference Implementation | Accepted |
 | [018](ADR-018-release-versioning.md) | Release Versioning and V1 Scope | Accepted |
 | [019](ADR-019-self-hosted-first.md) | Self-Hosted-First Development | Accepted |
+| [020](ADR-020-web-dashboard.md) | Web Dashboard for Operations | Accepted |
 
 ## Open Decisions
 

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -18,7 +18,7 @@ Problems that must be resolved before or during development.
 
 ## User Interface
 
-- **Primary interface.** Web app, desktop app, CLI, API? What ships first?
+- ~~**Primary interface.**~~ Resolved: Chat (Claude + MCP) is the primary interface ([ADR-011](decisions/ADR-011-chat-as-interface.md)). Web dashboard handles operations ([ADR-020](decisions/ADR-020-web-dashboard.md)). See [Tech Stack](tech-stack.md).
 - **Mobile experience.** Native app, PWA, or mobile web?
 - **Developer tool integration.** How does Samverk integrate with VS Code, GitHub, etc.?
 - **Check-in digest design.** What does the check-in digest look like? How is blocked work prioritized for display?

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,0 +1,174 @@
+# Tech Stack
+
+Comprehensive technology choices for Samverk. For architectural decisions, see [Architecture](architecture.md) and the [ADR index](decisions/README.md).
+
+## Core Language: Go
+
+Decided in [ADR-005](decisions/ADR-005-go-language.md). Single-binary deployment, strong concurrency (goroutines for dispatcher and agent watchers), cross-platform compilation, consistent with SubNetree project experience.
+
+## Deployment Model: Single Binary
+
+One binary with subcommands:
+
+```text
+samverk serve      # MCP server + REST API + embedded dashboard
+samverk dispatch   # Issue watcher, task router, agent orchestrator
+samverk config     # Setup, configuration management
+samverk version    # Version info
+```
+
+Can be split into separate binaries later if deployment topology demands it. Single binary is simpler to build, test, and deploy for v0.0.1.
+
+## Go Libraries
+
+### Core Dependencies
+
+| Need | Library | Why |
+|------|---------|-----|
+| HTTP server | `net/http` (stdlib) | MCP Streamable HTTP is JSON-RPC over HTTP. No framework needed. Go 1.22+ routing patterns are sufficient. |
+| CLI framework | `spf13/cobra` | Standard Go CLI framework, subcommand pattern |
+| GitHub API | `google/go-github/v68` | Mature, well-maintained, covers full Issues/PRs API |
+| Gitea API | `code.gitea.io/sdk/gitea` | Official SDK, mirrors GitHub API patterns |
+| Claude API | `anthropics/anthropic-sdk-go` | Official Go SDK |
+| OpenAI/GPT-4 | `sashabaranov/go-openai` | Most popular Go client, supports all endpoints |
+| Ollama (local) | Raw `net/http` | Ollama's REST API is trivial (3 endpoints). No SDK needed. |
+| Docker mgmt | `docker/docker/client` | Manage local agent containers programmatically |
+| Config (YAML) | `gopkg.in/yaml.v3` | Direct YAML parsing for `.samverk/*.yaml`. Viper is overkill -- no env var layering needed since config is file-based. |
+| Logging | `uber-go/zap` | Structured logging, fast, consistent with SubNetree |
+| SQLite | `modernc.org/sqlite` | Pure Go (no CGO required), for local state persistence |
+
+### What NOT to Use
+
+| Avoided | Why |
+|---------|-----|
+| LangChain / LangGraph / CrewAI | Custom orchestration per [ADR-004](decisions/ADR-004-custom-orchestration.md) |
+| gRPC / protobuf | MCP spec uses JSON-RPC over HTTP, not gRPC |
+| PostgreSQL / MySQL | SQLite is sufficient for single-host state. Git issues are the primary "database" for task state. |
+| Redis | No caching layer needed. Dispatcher polls or receives webhooks. |
+| Gemini SDK | `sashabaranov/go-openai` supports Gemini's OpenAI-compatible endpoint. Separate SDK unnecessary unless using Gemini-specific features. |
+| Web framework (gin / echo / fiber) | `net/http` with Go 1.22+ routing patterns handles MCP + REST API endpoints |
+
+## Web Dashboard
+
+The chat (Claude + MCP) is the primary interface for project progress and decisions ([ADR-011](decisions/ADR-011-chat-as-interface.md)). The web dashboard handles operational concerns: configuration, monitoring, logs, troubleshooting ([ADR-020](decisions/ADR-020-web-dashboard.md)).
+
+### Frontend Stack
+
+| Choice | Pick | Why |
+|--------|------|-----|
+| Framework | React + TypeScript | Consistent with SubNetree experience, reusable patterns |
+| Build tool | Vite | Fast builds, proven in SubNetree |
+| UI components | shadcn/ui + Tailwind CSS | Composable, accessible, same as SubNetree |
+| Server state | TanStack Query | Cache management, background refetching |
+| Client state | Zustand | Lightweight, no boilerplate |
+| Charts/metrics | Recharts | Known quirks documented, adequate for dashboards |
+| Routing | React Router | Standard SPA routing |
+
+### Embedding
+
+The React SPA is embedded in the Go binary via `embed.FS`. Single binary deployment stays intact -- no separate web server process, no CORS, no reverse proxy.
+
+### Dashboard Scope
+
+| Section | Purpose |
+|---------|---------|
+| System Health | Dispatcher status, agent containers, forge connectivity, model availability |
+| Agent Monitor | Running agents, queue depth, current tasks, container resource usage |
+| Cost Dashboard | Burn rate by provider, per-project spend, budget alerts, historical trends |
+| Logs | Structured log viewer with filtering (agent, severity, task), real-time tail |
+| Autonomy Config | Edit trust tiers, view pending Tier 3 actions, override history |
+| Project Config | Forge connections, API keys (masked), model priority, polling intervals |
+| Task Timeline | Task execution timeline, dependency graph visualization |
+| User Profile | View/edit persistent preferences, conventions, standing decisions |
+
+### Chat vs Dashboard Boundary
+
+```text
+CHAT (Claude + MCP)              DASHBOARD (web UI)
+---------------------            ---------------------
+"How's my project?"              System health metrics
+"Approve this merge"             Agent container status
+"Change priority on #42"         Cost graphs and trends
+"What got done today?"           Log viewer and search
+Give direction, make decisions   Edit autonomy config visually
+                                 Troubleshoot failed agents
+                                 API key management
+```
+
+## Agent Containers
+
+Local agents run in Docker via Ollama. Each agent type gets its own container profile:
+
+```text
+samverk-agent-codegen   -> ollama + code generation model (e.g., deepseek-coder)
+samverk-agent-test      -> ollama + reasoning model
+samverk-agent-docs      -> ollama + general model
+samverk-agent-qc        -> ollama + reasoning model (or cloud fallback)
+```
+
+Managed via `docker/docker/client` SDK. Container definitions stored as Go structs, not docker-compose -- more control over lifecycle, health checks, and timeout handling.
+
+## State Persistence
+
+| State | Where | Why |
+|-------|-------|-----|
+| Task state | Git issues | Human-readable, multi-device, core design principle |
+| Agent session state | SQLite | Survives restarts, queryable, single-file backup |
+| Cost tracking | SQLite | Per-task attribution, historical trends, budget queries |
+| Audit log | Git issue comments + SQLite | Issues for visibility, SQLite for querying |
+| User profile | YAML (`.samverk/profile.yaml`) | Version-controlled, portable |
+| Autonomy config | YAML (`.samverk/autonomy.yaml`) | Already specified in [Autonomy Model](autonomy-model.md) |
+| Server config | YAML (`.samverk/server.yaml`) | Already specified in [MCP Server](mcp-server.md) |
+| Auth keys | YAML (`.samverk/auth.yaml`) | Never committed to git |
+
+## CI/CD
+
+- **GitHub Actions** for CI (lint, test, build, cross-compile verification)
+- **GoReleaser** for cross-platform binary releases (Linux/Windows/Darwin, amd64/arm64)
+- **Docker images** via GoReleaser for the server/dispatcher (deploy to Proxmox)
+- **golangci-lint** for Go linting
+- **markdownlint** for documentation quality
+- **ESLint + TypeScript** for frontend linting
+
+## HTTP Surfaces
+
+The Go server serves three concerns on the same port:
+
+| Path | Purpose | Consumer |
+|------|---------|----------|
+| `/mcp` | MCP Streamable HTTP (JSON-RPC) | Claude (any device) |
+| `/api/v1/` | REST API | Dashboard SPA |
+| `/` | Embedded SPA static files | Browser |
+
+## Project Structure
+
+```text
+samverk/
+├── cmd/samverk/               # Single binary entrypoint (cobra)
+├── internal/
+│   ├── server/                # HTTP server (MCP + API + embedded SPA)
+│   ├── api/                   # REST API handlers for dashboard
+│   ├── mcp/                   # MCP protocol handler (Streamable HTTP)
+│   ├── dispatcher/            # Issue watcher, task router, dependency DAG
+│   ├── forge/                 # IssueTracker interface + GitHub/Gitea impls
+│   ├── agent/                 # Agent runtime, container management
+│   ├── provider/              # AI provider clients (Claude, OpenAI, Ollama)
+│   ├── autonomy/              # Trust tier evaluation engine
+│   ├── profile/               # User profile management
+│   ├── cost/                  # Token tracking, budget, attribution
+│   └── store/                 # SQLite persistence layer
+├── pkg/models/                # Shared types (Issue, Agent, Action, etc.)
+├── web/                       # React SPA (Vite + TypeScript)
+│   ├── src/
+│   │   ├── components/        # Reusable UI components
+│   │   ├── pages/             # Route pages (dashboard, logs, config, etc.)
+│   │   ├── api/               # API client (TanStack Query hooks)
+│   │   └── App.tsx
+│   ├── package.json
+│   └── vite.config.ts
+├── docs/                      # Design docs and ADRs
+├── .samverk/                  # Runtime config (gitignored)
+├── .github/workflows/         # CI/CD pipelines
+├── Makefile                   # Build and development tasks
+└── .goreleaser.yaml           # Release configuration
+```


### PR DESCRIPTION
## Summary

- Add comprehensive tech stack reference (`docs/tech-stack.md`) covering Go libraries, frontend stack (React + TypeScript + Vite embedded via `embed.FS`), agent containers, state persistence, CI/CD, and project structure
- Record ADR-020: Web Dashboard for Operations -- establishes the boundary between chat interface (project progress and decisions) and web dashboard (infrastructure and operations)
- Update `docs/architecture.md` with web dashboard section and three HTTP surfaces (`/mcp`, `/api/v1/`, `/`)
- Expand `CLAUDE.md` tech stack and project structure sections
- Add project-level `.markdownlint.json` config
- Mark primary interface question as resolved in `docs/open-questions.md`

## Test plan

- [x] All modified markdown files pass `npx markdownlint-cli2` (0 errors)
- [x] All internal doc links use valid relative paths
- [x] ADR numbering is sequential (020 follows 019)
- [x] No contradictions between architecture.md, tech-stack.md, and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)