### PR TITLE
feat: initialize Go project structure with Cobra CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          install-mode: goinstall
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./cmd/samverk/
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go test -race ./...
+
+  markdown:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@
 *.dll
 *.so
 *.dylib
-samverk
+/samverk
 
 # Go build
 /bin/
 /dist/
+coverage.out
 
 # IDE
 .vscode/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,44 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - gosec
+    - gocritic
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - misspell
+    - bodyclose
+    - noctx
+    - sqlclosecheck
+    - durationcheck
+    - exhaustive
+    - nilerr
+    - prealloc
+
+linters-settings:
+  gosec:
+    excludes:
+      - G104  # Unhandled errors on deferred Close -- acceptable in tests
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - style
+      - performance
+    disabled-checks:
+      - hugeParam  # Structs passed by value intentionally in some places
+  exhaustive:
+    default-signifies-exhaustive: true
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gosec
+        - errcheck
+    - path: cmd/
+      linters:
+        - noctx  # CLI entry points don't always need request context

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,40 @@
+version: 2
+project_name: samverk
+
+builds:
+  - id: samverk
+    main: ./cmd/samverk/
+    binary: samverk
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/herbhall/samverk/internal/version.Version={{.Version}}
+      - -X github.com/herbhall/samverk/internal/version.GitCommit={{.Commit}}
+      - -X github.com/herbhall/samverk/internal/version.BuildDate={{.Date}}
+
+archives:
+  - id: samverk
+    name_template: "samverk_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: '^feat'
+    - title: Bug Fixes
+      regexp: '^fix'
+    - title: Documentation
+      regexp: '^docs'
+    - title: Other
+      order: 999

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,42 @@
-.PHONY: install build test lint run
+.PHONY: build test test-race test-coverage lint lint-md run clean
 
-install:
-	@echo "No dependencies yet -- concept phase"
+# Binary
+BIN=samverk
+
+# Version injection
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+VERSION_PKG = github.com/herbhall/samverk/internal/version
+
+LDFLAGS=-ldflags "-s -w \
+	-X $(VERSION_PKG).Version=$(VERSION) \
+	-X $(VERSION_PKG).GitCommit=$(COMMIT) \
+	-X $(VERSION_PKG).BuildDate=$(DATE)"
 
 build:
-	@echo "No build targets yet -- concept phase"
+	go build $(LDFLAGS) -o bin/$(BIN) ./cmd/samverk/
 
 test:
-	@echo "No tests yet -- concept phase"
+	go test ./...
+
+test-race:
+	go test -race ./...
+
+test-coverage:
+	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	go tool cover -func=coverage.out
 
 lint:
-	@echo "Linting markdown..."
+	@which golangci-lint > /dev/null 2>&1 || (echo "golangci-lint not found. Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest" && exit 1)
+	golangci-lint run ./...
+
+lint-md:
 	npx markdownlint-cli2 "**/*.md" "#node_modules"
 
-run:
-	@echo "No runnable targets yet -- concept phase"
+run: build
+	./bin/$(BIN) serve
+
+clean:
+	rm -rf bin/ coverage.out
+	go clean

--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/herbhall/samverk/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	root := &cobra.Command{
+		Use:   "samverk",
+		Short: "Async background development engine",
+		Long:  "Samverk keeps side projects building while you live your life.",
+	}
+
+	root.AddCommand(serveCmd())
+	root.AddCommand(dispatchCmd())
+	root.AddCommand(versionCmd())
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func serveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "serve",
+		Short: "Start the HTTP server (MCP + API + dashboard)",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("samverk serve: not yet implemented")
+		},
+	}
+}
+
+func dispatchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "dispatch",
+		Short: "Start the dispatcher agent (watches issue tracker, routes work)",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("samverk dispatch: not yet implemented")
+		},
+	}
+}
+
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("samverk %s (commit: %s, built: %s)\n",
+				version.Version, version.GitCommit, version.BuildDate)
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/herbhall/samverk
+
+go 1.25.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/agent/doc.go
+++ b/internal/agent/doc.go
@@ -1,0 +1,2 @@
+// Package agent provides the agent runtime and container management for specialist agents.
+package agent

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,0 +1,2 @@
+// Package api provides REST API handlers for the web dashboard.
+package api

--- a/internal/autonomy/doc.go
+++ b/internal/autonomy/doc.go
@@ -1,0 +1,2 @@
+// Package autonomy implements the three-tier trust model for agent action evaluation.
+package autonomy

--- a/internal/cost/doc.go
+++ b/internal/cost/doc.go
@@ -1,0 +1,2 @@
+// Package cost provides token tracking, budget management, and cost attribution.
+package cost

--- a/internal/dispatcher/doc.go
+++ b/internal/dispatcher/doc.go
@@ -1,0 +1,2 @@
+// Package dispatcher watches the issue tracker, routes tasks to agents, and manages dependencies.
+package dispatcher

--- a/internal/forge/doc.go
+++ b/internal/forge/doc.go
@@ -1,0 +1,2 @@
+// Package forge provides the IssueTracker interface and implementations for GitHub, Gitea, and GitLab.
+package forge

--- a/internal/mcp/doc.go
+++ b/internal/mcp/doc.go
@@ -1,0 +1,2 @@
+// Package mcp implements the Model Context Protocol (MCP) Streamable HTTP handler.
+package mcp

--- a/internal/profile/doc.go
+++ b/internal/profile/doc.go
@@ -1,0 +1,2 @@
+// Package profile manages the persistent user profile for preferences and conventions.
+package profile

--- a/internal/provider/doc.go
+++ b/internal/provider/doc.go
@@ -1,0 +1,2 @@
+// Package provider implements AI provider clients for Claude, OpenAI, Gemini, and Ollama.
+package provider

--- a/internal/server/doc.go
+++ b/internal/server/doc.go
@@ -1,0 +1,2 @@
+// Package server provides the HTTP server that serves MCP, REST API, and embedded SPA.
+package server

--- a/internal/store/doc.go
+++ b/internal/store/doc.go
@@ -1,0 +1,2 @@
+// Package store provides the SQLite persistence layer for sessions, cost, and audit data.
+package store

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,9 @@
+// Package version provides build-injected version information.
+package version
+
+// These variables are set at build time via -ldflags.
+var (
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)

--- a/pkg/models/doc.go
+++ b/pkg/models/doc.go
@@ -1,0 +1,2 @@
+// Package models defines shared types used across the Samverk system.
+package models


### PR DESCRIPTION
## Summary

- Initialize Go module (`go.mod`) and Cobra CLI with `serve`, `dispatch`, `version` subcommands
- Create package placeholders for all 12 internal modules and `pkg/models`
- Add Makefile with build/test/lint targets and version injection via ldflags
- Add `.golangci.yml`, `.goreleaser.yaml`, and GitHub Actions CI workflow

Closes #14

## Test plan

- [x] `go build ./...` compiles all packages
- [x] `go test ./...` passes (no test files yet)
- [x] `go vet ./...` passes
- [x] `make build` produces `bin/samverk` with version injection
- [x] `./bin/samverk version` prints build info
- [x] `./bin/samverk serve` and `./bin/samverk dispatch` print stub messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)