### PR TITLE
feat: IssueTracker interface and GitHub adapter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,12 @@ module github.com/herbhall/samverk
 go 1.25.0
 
 require (
+	github.com/google/go-github/v68 v68.0.0
+	github.com/spf13/cobra v1.10.2
+)
+
+require (
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,11 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
+github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -7,4 +14,5 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/forge/doc.go
+++ b/internal/forge/doc.go
@@ -1,2 +1,0 @@
-// Package forge provides the IssueTracker interface and implementations for GitHub, Gitea, and GitLab.
-package forge

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -1,0 +1,114 @@
+// Package forge provides the IssueTracker interface and implementations
+// for GitHub, Gitea, and GitLab.
+//
+// The interface abstracts git forge operations so the dispatcher, agents,
+// and MCP server work identically regardless of the underlying platform.
+// See docs/forge-compatibility.md for the API surface comparison.
+package forge
+
+import (
+	"context"
+	"time"
+)
+
+// State represents the open/closed state of an issue.
+type State string
+
+const (
+	StateOpen   State = "open"
+	StateClosed State = "closed"
+)
+
+// EventType identifies what changed on the forge.
+type EventType string
+
+const (
+	EventIssueOpened    EventType = "issue.opened"
+	EventIssueClosed    EventType = "issue.closed"
+	EventIssueLabeled   EventType = "issue.labeled"
+	EventIssueAssigned  EventType = "issue.assigned"
+	EventIssueCommented EventType = "issue.commented"
+	EventIssueEdited    EventType = "issue.edited"
+)
+
+// IssueTracker is the platform-agnostic interface for git forge issue operations.
+// Implementations exist for GitHub (internal/forge/github) and Gitea (planned).
+type IssueTracker interface {
+	// Issues
+	CreateIssue(ctx context.Context, req *CreateIssueRequest) (*Issue, error)
+	GetIssue(ctx context.Context, number int) (*Issue, error)
+	UpdateIssue(ctx context.Context, number int, req *UpdateIssueRequest) (*Issue, error)
+	ListIssues(ctx context.Context, opts *ListOptions) ([]*Issue, error)
+
+	// Comments
+	AddComment(ctx context.Context, number int, body string) (*Comment, error)
+	ListComments(ctx context.Context, number int) ([]*Comment, error)
+
+	// Labels
+	SetLabels(ctx context.Context, number int, labels []string) error
+	AddLabel(ctx context.Context, number int, label string) error
+	RemoveLabel(ctx context.Context, number int, label string) error
+
+	// Assignment
+	Assign(ctx context.Context, number int, assignee string) error
+	Unassign(ctx context.Context, number int, assignee string) error
+
+	// Event watching (polling-based initially; webhook support planned via issue #8)
+	Watch(ctx context.Context, handler func(Event)) error
+}
+
+// Issue represents a forge issue in Samverk's domain.
+type Issue struct {
+	Number    int
+	Title     string
+	Body      string
+	State     State
+	Labels    []string
+	Assignees []string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ClosedAt  *time.Time
+}
+
+// Comment represents a single comment on an issue.
+type Comment struct {
+	ID        int64
+	Body      string
+	Author    string
+	CreatedAt time.Time
+}
+
+// Event represents a change detected on the forge.
+type Event struct {
+	Type        EventType
+	IssueNumber int
+	Issue       *Issue
+	Comment     *Comment
+	Label       string
+	Assignee    string
+}
+
+// CreateIssueRequest contains the fields needed to create a new issue.
+type CreateIssueRequest struct {
+	Title     string
+	Body      string
+	Labels    []string
+	Assignees []string
+}
+
+// UpdateIssueRequest contains the fields to update on an existing issue.
+// Nil pointer fields are left unchanged.
+type UpdateIssueRequest struct {
+	Title *string
+	Body  *string
+	State *State
+}
+
+// ListOptions controls filtering and pagination for issue listing.
+type ListOptions struct {
+	State    State
+	Labels   []string
+	Assignee string
+	Page     int
+	PerPage  int
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1,0 +1,373 @@
+// Package github implements the forge.IssueTracker interface for GitHub
+// using the google/go-github SDK.
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	gogithub "github.com/google/go-github/v68/github"
+
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+// Compile-time interface check.
+var _ forge.IssueTracker = (*Client)(nil)
+
+// Client implements forge.IssueTracker for GitHub repositories.
+type Client struct {
+	gh    *gogithub.Client
+	owner string
+	repo  string
+
+	// polling state for Watch
+	pollInterval time.Duration
+}
+
+// New creates a GitHub IssueTracker client for the given owner/repo.
+// The httpClient should carry authentication (e.g., via oauth2.TokenSource).
+// If httpClient is nil, unauthenticated requests are made (60 req/hr limit).
+func New(owner, repo string, httpClient *http.Client) *Client {
+	return &Client{
+		gh:           gogithub.NewClient(httpClient),
+		owner:        owner,
+		repo:         repo,
+		pollInterval: 30 * time.Second,
+	}
+}
+
+// SetBaseURL overrides the GitHub API base URL (useful for GitHub Enterprise
+// or test servers). The URL must include a trailing slash.
+func (c *Client) SetBaseURL(url string) {
+	c.gh.BaseURL.Host = ""
+	c.gh.BaseURL.Path = ""
+
+	parsed, err := c.gh.BaseURL.Parse(url)
+	if err == nil {
+		c.gh.BaseURL = parsed
+	}
+}
+
+// SetPollInterval configures the polling interval for Watch.
+func (c *Client) SetPollInterval(d time.Duration) {
+	c.pollInterval = d
+}
+
+// CreateIssue creates a new issue on the repository.
+func (c *Client) CreateIssue(ctx context.Context, req *forge.CreateIssueRequest) (*forge.Issue, error) {
+	ghReq := &gogithub.IssueRequest{
+		Title: gogithub.Ptr(req.Title),
+		Body:  gogithub.Ptr(req.Body),
+	}
+	if len(req.Labels) > 0 {
+		ghReq.Labels = &req.Labels
+	}
+	if len(req.Assignees) > 0 {
+		ghReq.Assignees = &req.Assignees
+	}
+
+	issue, _, err := c.gh.Issues.Create(ctx, c.owner, c.repo, ghReq)
+	if err != nil {
+		return nil, fmt.Errorf("github: create issue: %w", err)
+	}
+
+	return convertIssue(issue), nil
+}
+
+// GetIssue retrieves a single issue by number.
+func (c *Client) GetIssue(ctx context.Context, number int) (*forge.Issue, error) {
+	issue, _, err := c.gh.Issues.Get(ctx, c.owner, c.repo, number)
+	if err != nil {
+		return nil, fmt.Errorf("github: get issue #%d: %w", number, err)
+	}
+
+	return convertIssue(issue), nil
+}
+
+// UpdateIssue modifies an existing issue. Nil fields in the request are left unchanged.
+func (c *Client) UpdateIssue(ctx context.Context, number int, req *forge.UpdateIssueRequest) (*forge.Issue, error) {
+	ghReq := &gogithub.IssueRequest{}
+	if req.Title != nil {
+		ghReq.Title = req.Title
+	}
+	if req.Body != nil {
+		ghReq.Body = req.Body
+	}
+	if req.State != nil {
+		s := string(*req.State)
+		ghReq.State = &s
+	}
+
+	issue, _, err := c.gh.Issues.Edit(ctx, c.owner, c.repo, number, ghReq)
+	if err != nil {
+		return nil, fmt.Errorf("github: update issue #%d: %w", number, err)
+	}
+
+	return convertIssue(issue), nil
+}
+
+// ListIssues returns issues matching the given filter options.
+func (c *Client) ListIssues(ctx context.Context, opts *forge.ListOptions) ([]*forge.Issue, error) {
+	ghOpts := &gogithub.IssueListByRepoOptions{
+		ListOptions: gogithub.ListOptions{
+			Page:    opts.Page,
+			PerPage: opts.PerPage,
+		},
+	}
+	if opts.State != "" {
+		ghOpts.State = string(opts.State)
+	}
+	if len(opts.Labels) > 0 {
+		ghOpts.Labels = opts.Labels
+	}
+	if opts.Assignee != "" {
+		ghOpts.Assignee = opts.Assignee
+	}
+
+	issues, _, err := c.gh.Issues.ListByRepo(ctx, c.owner, c.repo, ghOpts)
+	if err != nil {
+		return nil, fmt.Errorf("github: list issues: %w", err)
+	}
+
+	result := make([]*forge.Issue, 0, len(issues))
+	for i := range issues {
+		result = append(result, convertIssue(issues[i]))
+	}
+
+	return result, nil
+}
+
+// AddComment posts a new comment on the given issue.
+func (c *Client) AddComment(ctx context.Context, number int, body string) (*forge.Comment, error) {
+	comment, _, err := c.gh.Issues.CreateComment(ctx, c.owner, c.repo, number, &gogithub.IssueComment{
+		Body: gogithub.Ptr(body),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("github: add comment to #%d: %w", number, err)
+	}
+
+	return convertComment(comment), nil
+}
+
+// ListComments returns all comments on the given issue.
+func (c *Client) ListComments(ctx context.Context, number int) ([]*forge.Comment, error) {
+	comments, _, err := c.gh.Issues.ListComments(ctx, c.owner, c.repo, number, &gogithub.IssueListCommentsOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("github: list comments on #%d: %w", number, err)
+	}
+
+	result := make([]*forge.Comment, 0, len(comments))
+	for i := range comments {
+		result = append(result, convertComment(comments[i]))
+	}
+
+	return result, nil
+}
+
+// SetLabels replaces all labels on the given issue.
+func (c *Client) SetLabels(ctx context.Context, number int, labels []string) error {
+	_, _, err := c.gh.Issues.ReplaceLabelsForIssue(ctx, c.owner, c.repo, number, labels)
+	if err != nil {
+		return fmt.Errorf("github: set labels on #%d: %w", number, err)
+	}
+
+	return nil
+}
+
+// AddLabel adds a single label to the given issue.
+func (c *Client) AddLabel(ctx context.Context, number int, label string) error {
+	_, _, err := c.gh.Issues.AddLabelsToIssue(ctx, c.owner, c.repo, number, []string{label})
+	if err != nil {
+		return fmt.Errorf("github: add label %q to #%d: %w", label, number, err)
+	}
+
+	return nil
+}
+
+// RemoveLabel removes a single label from the given issue.
+func (c *Client) RemoveLabel(ctx context.Context, number int, label string) error {
+	_, err := c.gh.Issues.RemoveLabelForIssue(ctx, c.owner, c.repo, number, label)
+	if err != nil {
+		return fmt.Errorf("github: remove label %q from #%d: %w", label, number, err)
+	}
+
+	return nil
+}
+
+// Assign adds an assignee to the given issue.
+func (c *Client) Assign(ctx context.Context, number int, assignee string) error {
+	_, _, err := c.gh.Issues.AddAssignees(ctx, c.owner, c.repo, number, []string{assignee})
+	if err != nil {
+		return fmt.Errorf("github: assign %q to #%d: %w", assignee, number, err)
+	}
+
+	return nil
+}
+
+// Unassign removes an assignee from the given issue.
+func (c *Client) Unassign(ctx context.Context, number int, assignee string) error {
+	_, _, err := c.gh.Issues.RemoveAssignees(ctx, c.owner, c.repo, number, []string{assignee})
+	if err != nil {
+		return fmt.Errorf("github: unassign %q from #%d: %w", assignee, number, err)
+	}
+
+	return nil
+}
+
+// Watch polls the GitHub API for issue changes and calls handler for each detected event.
+// It blocks until the context is cancelled. The initial poll establishes baseline state;
+// subsequent polls emit events for changes.
+func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
+	known := make(map[int]*forge.Issue)
+	var mu sync.Mutex
+
+	// Initial load.
+	issues, err := c.ListIssues(ctx, &forge.ListOptions{State: forge.StateOpen, PerPage: 100})
+	if err != nil {
+		return fmt.Errorf("github: watch initial load: %w", err)
+	}
+
+	mu.Lock()
+	for _, iss := range issues {
+		known[iss.Number] = iss
+	}
+	mu.Unlock()
+
+	ticker := time.NewTicker(c.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			current, err := c.ListIssues(ctx, &forge.ListOptions{State: forge.StateOpen, PerPage: 100})
+			if err != nil {
+				continue // transient errors are retried on next tick
+			}
+
+			mu.Lock()
+			c.diffAndEmit(known, current, handler)
+			mu.Unlock()
+		}
+	}
+}
+
+// diffAndEmit compares known state with current issues and emits events.
+// Caller must hold mu.
+func (c *Client) diffAndEmit(known map[int]*forge.Issue, current []*forge.Issue, handler func(forge.Event)) {
+	seen := make(map[int]bool, len(current))
+
+	for _, iss := range current {
+		seen[iss.Number] = true
+		prev, exists := known[iss.Number]
+
+		if !exists {
+			handler(forge.Event{
+				Type:        forge.EventIssueOpened,
+				IssueNumber: iss.Number,
+				Issue:       iss,
+			})
+			known[iss.Number] = iss
+			continue
+		}
+
+		// Detect label changes.
+		if !stringSliceEqual(prev.Labels, iss.Labels) {
+			handler(forge.Event{
+				Type:        forge.EventIssueLabeled,
+				IssueNumber: iss.Number,
+				Issue:       iss,
+			})
+		}
+
+		// Detect assignee changes.
+		if !stringSliceEqual(prev.Assignees, iss.Assignees) {
+			handler(forge.Event{
+				Type:        forge.EventIssueAssigned,
+				IssueNumber: iss.Number,
+				Issue:       iss,
+			})
+		}
+
+		// Detect edits (title or body changed).
+		if prev.Title != iss.Title || prev.Body != iss.Body {
+			handler(forge.Event{
+				Type:        forge.EventIssueEdited,
+				IssueNumber: iss.Number,
+				Issue:       iss,
+			})
+		}
+
+		known[iss.Number] = iss
+	}
+
+	// Detect closed issues (present in known but not in current open list).
+	for num, iss := range known {
+		if !seen[num] {
+			handler(forge.Event{
+				Type:        forge.EventIssueClosed,
+				IssueNumber: num,
+				Issue:       iss,
+			})
+			delete(known, num)
+		}
+	}
+}
+
+// convertIssue transforms a GitHub SDK issue into a forge.Issue.
+func convertIssue(gh *gogithub.Issue) *forge.Issue {
+	issue := &forge.Issue{
+		Number:    gh.GetNumber(),
+		Title:     gh.GetTitle(),
+		Body:      gh.GetBody(),
+		State:     forge.State(gh.GetState()),
+		CreatedAt: gh.GetCreatedAt().Time,
+		UpdatedAt: gh.GetUpdatedAt().Time,
+	}
+
+	if gh.ClosedAt != nil {
+		t := gh.GetClosedAt().Time
+		issue.ClosedAt = &t
+	}
+
+	issue.Labels = make([]string, 0, len(gh.Labels))
+	for i := range gh.Labels {
+		issue.Labels = append(issue.Labels, gh.Labels[i].GetName())
+	}
+
+	issue.Assignees = make([]string, 0, len(gh.Assignees))
+	for i := range gh.Assignees {
+		issue.Assignees = append(issue.Assignees, gh.Assignees[i].GetLogin())
+	}
+
+	return issue
+}
+
+// convertComment transforms a GitHub SDK comment into a forge.Comment.
+func convertComment(gh *gogithub.IssueComment) *forge.Comment {
+	return &forge.Comment{
+		ID:        gh.GetID(),
+		Body:      gh.GetBody(),
+		Author:    gh.GetUser().GetLogin(),
+		CreatedAt: gh.GetCreatedAt().Time,
+	}
+}
+
+// stringSliceEqual reports whether two string slices have the same elements.
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1,0 +1,493 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gogithub "github.com/google/go-github/v68/github"
+
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+// newTestClient creates a Client pointed at a test HTTP server.
+func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c := New("owner", "repo", nil)
+	c.SetBaseURL(srv.URL + "/")
+
+	return c, srv
+}
+
+// writeJSON is a test helper that writes a JSON response.
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode json: %v", err)
+	}
+}
+
+func TestCreateIssue(t *testing.T) {
+	var gotBody gogithub.IssueRequest
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusCreated, &gogithub.Issue{
+			Number:    gogithub.Ptr(42),
+			Title:     gotBody.Title,
+			Body:      gotBody.Body,
+			State:     gogithub.Ptr("open"),
+			CreatedAt: &gogithub.Timestamp{Time: time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)},
+			UpdatedAt: &gogithub.Timestamp{Time: time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	issue, err := c.CreateIssue(context.Background(), &forge.CreateIssueRequest{
+		Title:  "Test issue",
+		Body:   "Test body",
+		Labels: []string{"bug"},
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	if issue.Number != 42 {
+		t.Errorf("Number = %d, want 42", issue.Number)
+	}
+	if issue.Title != "Test issue" {
+		t.Errorf("Title = %q, want %q", issue.Title, "Test issue")
+	}
+	if issue.State != forge.StateOpen {
+		t.Errorf("State = %q, want %q", issue.State, forge.StateOpen)
+	}
+	if gotBody.Labels == nil || len(*gotBody.Labels) != 1 || (*gotBody.Labels)[0] != "bug" {
+		t.Errorf("request labels = %v, want [bug]", gotBody.Labels)
+	}
+}
+
+func TestGetIssue(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/issues/1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.Issue{
+			Number: gogithub.Ptr(1),
+			Title:  gogithub.Ptr("Found issue"),
+			Body:   gogithub.Ptr("Body text"),
+			State:  gogithub.Ptr("open"),
+			Labels: []*gogithub.Label{
+				{Name: gogithub.Ptr("priority:high")},
+				{Name: gogithub.Ptr("type:task")},
+			},
+			Assignees: []*gogithub.User{
+				{Login: gogithub.Ptr("agent-1")},
+			},
+			CreatedAt: &gogithub.Timestamp{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+			UpdatedAt: &gogithub.Timestamp{Time: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	issue, err := c.GetIssue(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+
+	if issue.Number != 1 {
+		t.Errorf("Number = %d, want 1", issue.Number)
+	}
+	if issue.Title != "Found issue" {
+		t.Errorf("Title = %q, want %q", issue.Title, "Found issue")
+	}
+	if len(issue.Labels) != 2 {
+		t.Errorf("Labels = %v, want 2 labels", issue.Labels)
+	}
+	if len(issue.Assignees) != 1 || issue.Assignees[0] != "agent-1" {
+		t.Errorf("Assignees = %v, want [agent-1]", issue.Assignees)
+	}
+}
+
+func TestGetIssue_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/issues/999", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusNotFound, &gogithub.ErrorResponse{
+			Message: "Not Found",
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.GetIssue(context.Background(), 999)
+	if err == nil {
+		t.Fatal("GetIssue(999): expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "get issue #999") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "get issue #999")
+	}
+}
+
+func TestUpdateIssue(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /repos/owner/repo/issues/5", func(w http.ResponseWriter, r *http.Request) {
+		var body gogithub.IssueRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		title := "Updated"
+		if body.Title != nil {
+			title = *body.Title
+		}
+
+		writeJSON(t, w, http.StatusOK, &gogithub.Issue{
+			Number:    gogithub.Ptr(5),
+			Title:     gogithub.Ptr(title),
+			State:     body.State,
+			CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+			UpdatedAt: &gogithub.Timestamp{Time: time.Now()},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	newTitle := "New title"
+	closed := forge.StateClosed
+	issue, err := c.UpdateIssue(context.Background(), 5, &forge.UpdateIssueRequest{
+		Title: &newTitle,
+		State: &closed,
+	})
+	if err != nil {
+		t.Fatalf("UpdateIssue: %v", err)
+	}
+
+	if issue.Number != 5 {
+		t.Errorf("Number = %d, want 5", issue.Number)
+	}
+	if issue.Title != "New title" {
+		t.Errorf("Title = %q, want %q", issue.Title, "New title")
+	}
+}
+
+func TestListIssues(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		state := r.URL.Query().Get("state")
+		if state != "open" {
+			t.Errorf("state param = %q, want %q", state, "open")
+		}
+
+		writeJSON(t, w, http.StatusOK, []*gogithub.Issue{
+			{
+				Number:    gogithub.Ptr(1),
+				Title:     gogithub.Ptr("First"),
+				State:     gogithub.Ptr("open"),
+				CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+				UpdatedAt: &gogithub.Timestamp{Time: time.Now()},
+			},
+			{
+				Number:    gogithub.Ptr(2),
+				Title:     gogithub.Ptr("Second"),
+				State:     gogithub.Ptr("open"),
+				CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+				UpdatedAt: &gogithub.Timestamp{Time: time.Now()},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	issues, err := c.ListIssues(context.Background(), &forge.ListOptions{
+		State:   forge.StateOpen,
+		PerPage: 50,
+	})
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+
+	if len(issues) != 2 {
+		t.Fatalf("len(issues) = %d, want 2", len(issues))
+	}
+	if issues[0].Title != "First" {
+		t.Errorf("issues[0].Title = %q, want %q", issues[0].Title, "First")
+	}
+}
+
+func TestAddComment(t *testing.T) {
+	var gotBody gogithub.IssueComment
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /repos/owner/repo/issues/10/comments", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusCreated, &gogithub.IssueComment{
+			ID:        gogithub.Ptr(int64(100)),
+			Body:      gotBody.Body,
+			User:      &gogithub.User{Login: gogithub.Ptr("samverk-bot")},
+			CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	comment, err := c.AddComment(context.Background(), 10, "Agent result: task complete")
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+
+	if comment.ID != 100 {
+		t.Errorf("ID = %d, want 100", comment.ID)
+	}
+	if comment.Body != "Agent result: task complete" {
+		t.Errorf("Body = %q, want %q", comment.Body, "Agent result: task complete")
+	}
+	if comment.Author != "samverk-bot" {
+		t.Errorf("Author = %q, want %q", comment.Author, "samverk-bot")
+	}
+}
+
+func TestListComments(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/issues/3/comments", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, []*gogithub.IssueComment{
+			{
+				ID:        gogithub.Ptr(int64(1)),
+				Body:      gogithub.Ptr("First comment"),
+				User:      &gogithub.User{Login: gogithub.Ptr("user1")},
+				CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+			},
+			{
+				ID:        gogithub.Ptr(int64(2)),
+				Body:      gogithub.Ptr("Second comment"),
+				User:      &gogithub.User{Login: gogithub.Ptr("user2")},
+				CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	comments, err := c.ListComments(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("ListComments: %v", err)
+	}
+
+	if len(comments) != 2 {
+		t.Fatalf("len(comments) = %d, want 2", len(comments))
+	}
+	if comments[0].Author != "user1" {
+		t.Errorf("comments[0].Author = %q, want %q", comments[0].Author, "user1")
+	}
+}
+
+func TestSetLabels(t *testing.T) {
+	var gotLabels []string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /repos/owner/repo/issues/7/labels", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotLabels); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusOK, []*gogithub.Label{
+			{Name: gogithub.Ptr("priority:high")},
+			{Name: gogithub.Ptr("status:claimed")},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	err := c.SetLabels(context.Background(), 7, []string{"priority:high", "status:claimed"})
+	if err != nil {
+		t.Fatalf("SetLabels: %v", err)
+	}
+
+	if len(gotLabels) != 2 {
+		t.Errorf("sent %d labels, want 2", len(gotLabels))
+	}
+}
+
+func TestAddLabel(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /repos/owner/repo/issues/7/labels", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, []*gogithub.Label{
+			{Name: gogithub.Ptr("new-label")},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	err := c.AddLabel(context.Background(), 7, "new-label")
+	if err != nil {
+		t.Fatalf("AddLabel: %v", err)
+	}
+}
+
+func TestRemoveLabel(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /repos/owner/repo/issues/7/labels/old-label", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	err := c.RemoveLabel(context.Background(), 7, "old-label")
+	if err != nil {
+		t.Fatalf("RemoveLabel: %v", err)
+	}
+}
+
+func TestAssign(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /repos/owner/repo/issues/3/assignees", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.Issue{
+			Number:    gogithub.Ptr(3),
+			Assignees: []*gogithub.User{{Login: gogithub.Ptr("agent-1")}},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	err := c.Assign(context.Background(), 3, "agent-1")
+	if err != nil {
+		t.Fatalf("Assign: %v", err)
+	}
+}
+
+func TestUnassign(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /repos/owner/repo/issues/3/assignees", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.Issue{
+			Number: gogithub.Ptr(3),
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	err := c.Unassign(context.Background(), 3, "agent-1")
+	if err != nil {
+		t.Fatalf("Unassign: %v", err)
+	}
+}
+
+func TestWatch_DetectsNewAndClosedIssues(t *testing.T) {
+	callCount := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/issues", func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+
+		switch callCount {
+		case 1:
+			// Initial load: one issue.
+			writeJSON(t, w, http.StatusOK, []*gogithub.Issue{
+				{
+					Number:    gogithub.Ptr(1),
+					Title:     gogithub.Ptr("Existing"),
+					State:     gogithub.Ptr("open"),
+					CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+					UpdatedAt: &gogithub.Timestamp{Time: time.Now()},
+				},
+			})
+		case 2:
+			// Second poll: new issue #2 appeared, issue #1 gone (closed).
+			writeJSON(t, w, http.StatusOK, []*gogithub.Issue{
+				{
+					Number:    gogithub.Ptr(2),
+					Title:     gogithub.Ptr("New issue"),
+					State:     gogithub.Ptr("open"),
+					CreatedAt: &gogithub.Timestamp{Time: time.Now()},
+					UpdatedAt: &gogithub.Timestamp{Time: time.Now()},
+				},
+			})
+		default:
+			writeJSON(t, w, http.StatusOK, []*gogithub.Issue{})
+		}
+	})
+
+	c, _ := newTestClient(t, mux)
+	c.SetPollInterval(10 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	var events []forge.Event
+	var mu sync.Mutex
+
+	go func() {
+		_ = c.Watch(ctx, func(e forge.Event) {
+			mu.Lock()
+			events = append(events, e)
+			mu.Unlock()
+		})
+	}()
+
+	<-ctx.Done()
+	// Give a moment for the last handler call to complete.
+	time.Sleep(20 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(events) < 2 {
+		t.Fatalf("got %d events, want at least 2 (opened + closed)", len(events))
+	}
+
+	// Should see: issue #2 opened, issue #1 closed (order may vary).
+	var sawOpened, sawClosed bool
+	for _, e := range events {
+		switch {
+		case e.Type == forge.EventIssueOpened && e.IssueNumber == 2:
+			sawOpened = true
+		case e.Type == forge.EventIssueClosed && e.IssueNumber == 1:
+			sawClosed = true
+		}
+	}
+
+	if !sawOpened {
+		t.Error("missing EventIssueOpened for issue #2")
+	}
+	if !sawClosed {
+		t.Error("missing EventIssueClosed for issue #1")
+	}
+}
+
+func TestStringSliceEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"both empty", []string{}, []string{}, true},
+		{"equal", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"different length", []string{"a"}, []string{"a", "b"}, false},
+		{"different content", []string{"a", "b"}, []string{"a", "c"}, false},
+		{"different order", []string{"a", "b"}, []string{"b", "a"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringSliceEqual(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("stringSliceEqual(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Defines the `forge.IssueTracker` interface (12 methods) for platform-agnostic git forge operations
- Implements the GitHub adapter using `google/go-github/v68`
- Adds polling-based `Watch` with change detection (opened, closed, labeled, assigned, edited)
- 14 unit tests using mock HTTP server -- all passing

### Interface Methods

| Category | Methods |
|----------|---------|
| Issues | `CreateIssue`, `GetIssue`, `UpdateIssue`, `ListIssues` |
| Comments | `AddComment`, `ListComments` |
| Labels | `SetLabels`, `AddLabel`, `RemoveLabel` |
| Assignment | `Assign`, `Unassign` |
| Events | `Watch` (polling; webhooks planned in #8) |

### Design Decisions

- Forge types (`internal/forge/`) are separate from protocol types (`pkg/models/`) -- the dispatcher bridges them
- `Watch` uses polling initially (30s default interval) since webhook support needs infra work (#8)
- Interface refined from the original 7-method spec: added `GetIssue`, `ListComments`, `AddLabel`/`RemoveLabel`, `Unassign`

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/forge/...` -- 14 tests passing
- [x] `go vet ./...` clean
- [ ] CI passes

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)