### PR TITLE
feat: implement frontmatter parser for issue bodies

### DIFF
--- a/pkg/models/frontmatter.go
+++ b/pkg/models/frontmatter.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ParseResult holds the parsed frontmatter and remaining body text.
+type ParseResult struct {
+	Frontmatter *IssueFrontmatter
+	Body        string // markdown after the closing ---
+}
+
+const frontmatterDelimiter = "---"
+
+// ParseFrontmatter extracts YAML frontmatter from an issue body.
+// The frontmatter must be delimited by --- on its own line at the start of the body.
+// Returns error if frontmatter is present but malformed.
+// Returns nil Frontmatter (no error) if no frontmatter block exists.
+func ParseFrontmatter(body string) (*ParseResult, error) {
+	trimmed := strings.TrimLeft(body, " \t\r\n")
+
+	if !strings.HasPrefix(trimmed, frontmatterDelimiter+"\n") {
+		return &ParseResult{Frontmatter: nil, Body: body}, nil
+	}
+
+	// Skip past the opening delimiter line.
+	afterOpen := trimmed[len(frontmatterDelimiter)+1:]
+
+	// Handle empty frontmatter (---\n---) and content frontmatter.
+	// Look for closing --- on its own line: either "\n---" or at position 0 (empty block).
+	var closeIdx int
+	if strings.HasPrefix(afterOpen, frontmatterDelimiter+"\n") || afterOpen == frontmatterDelimiter {
+		// Empty frontmatter block: closing --- immediately follows opening.
+		closeIdx = 0
+	} else {
+		idx := strings.Index(afterOpen, "\n"+frontmatterDelimiter)
+		if idx == -1 {
+			return nil, errors.New("frontmatter: missing closing delimiter")
+		}
+		closeIdx = idx + 1 // skip the \n so yamlContent excludes trailing newline
+	}
+
+	yamlContent := afterOpen[:closeIdx]
+
+	var fm IssueFrontmatter
+	if err := yaml.Unmarshal([]byte(yamlContent), &fm); err != nil {
+		return nil, fmt.Errorf("frontmatter: invalid YAML: %w", err)
+	}
+
+	// Determine the body after the closing delimiter.
+	remaining := afterOpen[closeIdx+len(frontmatterDelimiter):]
+	// Strip up to one newline ending the delimiter line, then one optional blank line.
+	remaining = strings.TrimPrefix(remaining, "\n")
+	remaining = strings.TrimPrefix(remaining, "\n")
+
+	return &ParseResult{Frontmatter: &fm, Body: remaining}, nil
+}
+
+// RenderFrontmatter produces an issue body with YAML frontmatter followed by markdown.
+func RenderFrontmatter(fm *IssueFrontmatter, markdown string) string {
+	data, err := yaml.Marshal(fm)
+	if err != nil {
+		// IssueFrontmatter contains only basic types; marshal should never fail.
+		panic(fmt.Sprintf("frontmatter: failed to marshal: %v", err))
+	}
+
+	var b strings.Builder
+	b.WriteString(frontmatterDelimiter)
+	b.WriteByte('\n')
+	b.Write(data)
+	b.WriteString(frontmatterDelimiter)
+	b.WriteByte('\n')
+	if markdown != "" {
+		b.WriteByte('\n')
+		b.WriteString(markdown)
+	}
+	return b.String()
+}

--- a/pkg/models/frontmatter_test.go
+++ b/pkg/models/frontmatter_test.go
@@ -1,0 +1,170 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestParseFrontmatter(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantFM  *IssueFrontmatter
+		wantErr bool
+		wantBody string
+	}{
+		{
+			name: "valid frontmatter with all fields",
+			body: "---\nschema_version: \"1.0.0\"\ntype: task\nagent_type: code-gen\npriority: normal\nparent_issue: 123\ndepends_on: [121, 122]\nestimated_tokens: 2000\nactual_tokens: 1800\nmodel_used: claude-opus-4\n---\n\n## Summary\n\nOne sentence description.\n",
+			wantFM: &IssueFrontmatter{
+				SchemaVersion:   "1.0.0",
+				Type:            IssueTypeTask,
+				AgentType:       AgentTypeCodeGen,
+				Priority:        PriorityNormal,
+				ParentIssue:     123,
+				DependsOn:       []int{121, 122},
+				EstimatedTokens: 2000,
+				ActualTokens:    1800,
+				ModelUsed:       "claude-opus-4",
+			},
+			wantBody: "## Summary\n\nOne sentence description.\n",
+		},
+		{
+			name: "minimal required fields",
+			body: "---\nschema_version: \"1.0.0\"\ntype: question\nagent_type: human\npriority: high\n---\n\nPlain body text.\n",
+			wantFM: &IssueFrontmatter{
+				SchemaVersion: "1.0.0",
+				Type:          IssueTypeQuestion,
+				AgentType:     AgentTypeHuman,
+				Priority:      PriorityHigh,
+			},
+			wantBody: "Plain body text.\n",
+		},
+		{
+			name:     "no frontmatter returns nil",
+			body:     "## Summary\n\nJust a plain issue body with no frontmatter.\n",
+			wantFM:   nil,
+			wantBody: "## Summary\n\nJust a plain issue body with no frontmatter.\n",
+		},
+		{
+			name:    "malformed YAML returns error",
+			body:    "---\nschema_version: \"1.0.0\"\n  bad indent: [unmatched\n---\n\nbody\n",
+			wantErr: true,
+		},
+		{
+			name:    "missing closing delimiter returns error",
+			body:    "---\nschema_version: \"1.0.0\"\ntype: task\n",
+			wantErr: true,
+		},
+		{
+			name: "empty frontmatter block",
+			body: "---\n---\n\nBody after empty frontmatter.\n",
+			wantFM: &IssueFrontmatter{},
+			wantBody: "Body after empty frontmatter.\n",
+		},
+		{
+			name: "depends_on array parsing",
+			body: "---\nschema_version: \"1.0.0\"\ntype: task\nagent_type: code-gen\npriority: normal\ndepends_on:\n  - 10\n  - 20\n  - 30\n---\n\nTask with dependencies.\n",
+			wantFM: &IssueFrontmatter{
+				SchemaVersion: "1.0.0",
+				Type:          IssueTypeTask,
+				AgentType:     AgentTypeCodeGen,
+				Priority:      PriorityNormal,
+				DependsOn:     []int{10, 20, 30},
+			},
+			wantBody: "Task with dependencies.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseFrontmatter(tt.body)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantFM == nil {
+				if result.Frontmatter != nil {
+					t.Fatalf("expected nil Frontmatter, got %+v", result.Frontmatter)
+				}
+			} else {
+				if result.Frontmatter == nil {
+					t.Fatal("expected non-nil Frontmatter, got nil")
+				}
+				assertFrontmatterEqual(t, tt.wantFM, result.Frontmatter)
+			}
+			if result.Body != tt.wantBody {
+				t.Errorf("Body mismatch:\n  got:  %q\n  want: %q", result.Body, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestRenderFrontmatterRoundTrip(t *testing.T) {
+	original := &IssueFrontmatter{
+		SchemaVersion:   SchemaVersion,
+		Type:            IssueTypeTask,
+		AgentType:       AgentTypeCodeGen,
+		Priority:        PriorityNormal,
+		ParentIssue:     42,
+		DependsOn:       []int{10, 20},
+		EstimatedTokens: 5000,
+	}
+	markdown := "## Summary\n\nRound-trip test body.\n"
+
+	rendered := RenderFrontmatter(original, markdown)
+	result, err := ParseFrontmatter(rendered)
+	if err != nil {
+		t.Fatalf("round-trip parse failed: %v", err)
+	}
+	if result.Frontmatter == nil {
+		t.Fatal("round-trip: expected non-nil Frontmatter")
+	}
+
+	assertFrontmatterEqual(t, original, result.Frontmatter)
+
+	if result.Body != markdown {
+		t.Errorf("round-trip body mismatch:\n  got:  %q\n  want: %q", result.Body, markdown)
+	}
+}
+
+func assertFrontmatterEqual(t *testing.T, want, got *IssueFrontmatter) {
+	t.Helper()
+	if got.SchemaVersion != want.SchemaVersion {
+		t.Errorf("SchemaVersion: got %q, want %q", got.SchemaVersion, want.SchemaVersion)
+	}
+	if got.Type != want.Type {
+		t.Errorf("Type: got %q, want %q", got.Type, want.Type)
+	}
+	if got.AgentType != want.AgentType {
+		t.Errorf("AgentType: got %q, want %q", got.AgentType, want.AgentType)
+	}
+	if got.Priority != want.Priority {
+		t.Errorf("Priority: got %q, want %q", got.Priority, want.Priority)
+	}
+	if got.ParentIssue != want.ParentIssue {
+		t.Errorf("ParentIssue: got %d, want %d", got.ParentIssue, want.ParentIssue)
+	}
+	if len(got.DependsOn) != len(want.DependsOn) {
+		t.Errorf("DependsOn length: got %d, want %d", len(got.DependsOn), len(want.DependsOn))
+	} else {
+		for i := range want.DependsOn {
+			if got.DependsOn[i] != want.DependsOn[i] {
+				t.Errorf("DependsOn[%d]: got %d, want %d", i, got.DependsOn[i], want.DependsOn[i])
+			}
+		}
+	}
+	if got.EstimatedTokens != want.EstimatedTokens {
+		t.Errorf("EstimatedTokens: got %d, want %d", got.EstimatedTokens, want.EstimatedTokens)
+	}
+	if got.ActualTokens != want.ActualTokens {
+		t.Errorf("ActualTokens: got %d, want %d", got.ActualTokens, want.ActualTokens)
+	}
+	if got.ModelUsed != want.ModelUsed {
+		t.Errorf("ModelUsed: got %q, want %q", got.ModelUsed, want.ModelUsed)
+	}
+}


### PR DESCRIPTION
## Summary

- Parse YAML frontmatter from issue bodies into `IssueFrontmatter` struct
- `ParseFrontmatter(body) -> (*ParseResult, error)` handles: no frontmatter, malformed YAML, missing delimiters, empty blocks
- `RenderFrontmatter(fm, markdown) -> string` for round-trip serialization
- 8 table-driven tests covering all parsing scenarios

## Test plan

- [x] `go test ./pkg/models/...` -- 8/8 pass
- [x] `go build ./...` -- compiles
- [x] `GOOS=linux GOARCH=amd64 go build ./...` -- cross-compiles
- [x] `golangci-lint run ./pkg/models/...` -- 0 issues

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)