### PR TITLE
feat: implement profile store with SQLite persistence

### DIFF
--- a/internal/profile/doc.go
+++ b/internal/profile/doc.go
@@ -1,2 +1,0 @@
-// Package profile manages the persistent user profile for preferences and conventions.
-package profile

--- a/internal/profile/loader.go
+++ b/internal/profile/loader.go
@@ -1,0 +1,22 @@
+package profile
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadFromFile reads a YAML profile from disk and returns it.
+func LoadFromFile(path string) (p *Profile, err error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is user-provided profile file location
+	if err != nil {
+		return nil, fmt.Errorf("read profile file: %w", err)
+	}
+
+	p = &Profile{}
+	if err = yaml.Unmarshal(data, p); err != nil {
+		return nil, fmt.Errorf("unmarshal YAML profile: %w", err)
+	}
+	return p, nil
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,163 @@
+package profile
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/herbhall/samverk/internal/store"
+)
+
+// ProfileStore defines the read API for user profiles.
+type ProfileStore interface {
+	// Get returns the latest profile version.
+	Get(ctx context.Context) (*Profile, error)
+	// GetField extracts a single field by dot-separated path (e.g., "git.branch_pattern").
+	GetField(ctx context.Context, path string) (any, error)
+	// Version returns the current profile version number.
+	Version(ctx context.Context) (int, error)
+	// Import stores a new profile version (append-only).
+	Import(ctx context.Context, p *Profile) error
+	// Close releases resources.
+	Close() error
+}
+
+// SQLiteProfileStore implements ProfileStore using SQLite.
+type SQLiteProfileStore struct {
+	db *sql.DB
+}
+
+// Compile-time interface check.
+var _ ProfileStore = (*SQLiteProfileStore)(nil)
+
+// New creates a ProfileStore using the given database connection.
+// It runs migrations to ensure the profiles table exists.
+func New(db *sql.DB) (ps *SQLiteProfileStore, err error) {
+	ps = &SQLiteProfileStore{db: db}
+	if err = ps.migrate(); err != nil {
+		return nil, fmt.Errorf("profile migrate: %w", err)
+	}
+	return ps, nil
+}
+
+// Close is a no-op because the db connection is shared and owned by the caller.
+func (s *SQLiteProfileStore) Close() error {
+	return nil
+}
+
+// migrate creates the profiles table and index if they do not exist.
+func (s *SQLiteProfileStore) migrate() error {
+	const ddl = `
+CREATE TABLE IF NOT EXISTS profiles (
+	id         INTEGER PRIMARY KEY AUTOINCREMENT,
+	version    INTEGER NOT NULL,
+	data       TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_profiles_version ON profiles(version);
+`
+	_, err := s.db.ExecContext(context.Background(), ddl)
+	return err
+}
+
+// Get returns the latest profile version.
+func (s *SQLiteProfileStore) Get(ctx context.Context) (p *Profile, err error) {
+	var data string
+	err = s.db.QueryRowContext(ctx,
+		"SELECT data FROM profiles ORDER BY version DESC LIMIT 1",
+	).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query latest profile: %w", err)
+	}
+
+	p = &Profile{}
+	if err = json.Unmarshal([]byte(data), p); err != nil {
+		return nil, fmt.Errorf("unmarshal profile: %w", err)
+	}
+	return p, nil
+}
+
+// GetField extracts a single field by dot-separated path.
+// It navigates the JSON representation of the profile using the path segments.
+func (s *SQLiteProfileStore) GetField(ctx context.Context, path string) (val any, err error) {
+	p, err := s.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Round-trip through JSON to get a generic map for path navigation.
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal profile for field lookup: %w", err)
+	}
+
+	var m map[string]any
+	if err = json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("unmarshal profile to map: %w", err)
+	}
+
+	parts := strings.Split(path, ".")
+	var current any = m
+	for _, part := range parts {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("field %q: %w", path, store.ErrNotFound)
+		}
+		val, ok = obj[part]
+		if !ok {
+			return nil, fmt.Errorf("field %q: %w", path, store.ErrNotFound)
+		}
+		current = val
+	}
+	return current, nil
+}
+
+// Version returns the current profile version number.
+// Returns 0 if no profiles exist.
+func (s *SQLiteProfileStore) Version(ctx context.Context) (v int, err error) {
+	var version sql.NullInt64
+	err = s.db.QueryRowContext(ctx,
+		"SELECT MAX(version) FROM profiles",
+	).Scan(&version)
+	if err != nil {
+		return 0, fmt.Errorf("query max version: %w", err)
+	}
+	if !version.Valid {
+		return 0, nil
+	}
+	return int(version.Int64), nil
+}
+
+// Import stores a new profile version (append-only).
+func (s *SQLiteProfileStore) Import(ctx context.Context, p *Profile) error {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("marshal profile: %w", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Get next version number.
+	currentVersion, err := s.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("get current version: %w", err)
+	}
+	nextVersion := currentVersion + 1
+
+	_, err = s.db.ExecContext(ctx,
+		"INSERT INTO profiles (version, data, created_at, updated_at) VALUES (?, ?, ?, ?)",
+		nextVersion, string(data), now, now,
+	)
+	if err != nil {
+		return fmt.Errorf("insert profile: %w", err)
+	}
+	return nil
+}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,294 @@
+package profile
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/herbhall/samverk/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func newTestStore(t *testing.T) *SQLiteProfileStore {
+	t.Helper()
+	db := newTestDB(t)
+	ps, err := New(db)
+	if err != nil {
+		t.Fatalf("new profile store: %v", err)
+	}
+	return ps
+}
+
+func testProfile(overrides ...func(*Profile)) *Profile {
+	p := &Profile{
+		ProjectConventions: ProjectConventions{
+			DirectoryStructure: map[string]string{
+				"standard": "cmd/ internal/ pkg/",
+			},
+			FileNaming: map[string]string{
+				"go": "snake_case",
+			},
+			Git: GitConfig{
+				BranchPattern: "feature/issue-{number}-{description}",
+				CommitFormat:  "conventional",
+				MergeStrategy: "squash",
+			},
+		},
+		TechnicalPreferences: TechnicalPreferences{
+			Languages: map[string]any{
+				"primary": "go",
+			},
+		},
+		AIAgentConfig: AIAgentConfig{
+			ModelRouting: map[string]any{
+				"implementation": "sonnet",
+			},
+			Communication: map[string]any{
+				"style": "concise",
+			},
+		},
+		QualityStandards: QualityStandards{
+			ErrorPolicy:  "fix-forward",
+			ReviewPolicy: "independent-reviewer",
+			CIRequirements: map[string]any{
+				"lint": true,
+			},
+		},
+	}
+	for _, fn := range overrides {
+		fn(p)
+	}
+	return p
+}
+
+func TestNew(t *testing.T) {
+	db := newTestDB(t)
+	ps, err := New(db)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	// Verify the profiles table exists.
+	var name string
+	err = db.QueryRowContext(context.Background(),
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='profiles'",
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("query table: %v", err)
+	}
+	if name != "profiles" {
+		t.Errorf("table name = %q, want %q", name, "profiles")
+	}
+	_ = ps
+}
+
+func TestImport_Single(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	if err := ps.Import(ctx, p); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	v, err := ps.Version(ctx)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if v != 1 {
+		t.Errorf("version = %d, want 1", v)
+	}
+}
+
+func TestImport_Multiple(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	for i := range 3 {
+		p := testProfile(func(p *Profile) {
+			p.QualityStandards.ErrorPolicy = "policy-" + string(rune('a'+i))
+		})
+		if err := ps.Import(ctx, p); err != nil {
+			t.Fatalf("import %d: %v", i, err)
+		}
+	}
+
+	v, err := ps.Version(ctx)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if v != 3 {
+		t.Errorf("version = %d, want 3", v)
+	}
+}
+
+func TestGet_Empty(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := ps.Get(ctx)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGet_ReturnsLatest(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	p1 := testProfile(func(p *Profile) {
+		p.QualityStandards.ErrorPolicy = "first"
+	})
+	p2 := testProfile(func(p *Profile) {
+		p.QualityStandards.ErrorPolicy = "second"
+	})
+
+	if err := ps.Import(ctx, p1); err != nil {
+		t.Fatalf("import first: %v", err)
+	}
+	if err := ps.Import(ctx, p2); err != nil {
+		t.Fatalf("import second: %v", err)
+	}
+
+	got, err := ps.Get(ctx)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.QualityStandards.ErrorPolicy != "second" {
+		t.Errorf("error_policy = %q, want %q", got.QualityStandards.ErrorPolicy, "second")
+	}
+}
+
+func TestGetField_TopLevel(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	if err := ps.Import(ctx, p); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	val, err := ps.GetField(ctx, "quality_standards.error_policy")
+	if err != nil {
+		t.Fatalf("get field: %v", err)
+	}
+
+	s, ok := val.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", val)
+	}
+	if s != "fix-forward" {
+		t.Errorf("value = %q, want %q", s, "fix-forward")
+	}
+}
+
+func TestGetField_Nested(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	if err := ps.Import(ctx, p); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	val, err := ps.GetField(ctx, "project_conventions.git.branch_pattern")
+	if err != nil {
+		t.Fatalf("get field: %v", err)
+	}
+
+	s, ok := val.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", val)
+	}
+	if s != "feature/issue-{number}-{description}" {
+		t.Errorf("value = %q, want %q", s, "feature/issue-{number}-{description}")
+	}
+}
+
+func TestGetField_NotFound(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	if err := ps.Import(ctx, p); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	_, err := ps.GetField(ctx, "nonexistent.field")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVersion_Empty(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+
+	v, err := ps.Version(ctx)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if v != 0 {
+		t.Errorf("version = %d, want 0", v)
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+
+	content := `
+project_conventions:
+  git:
+    branch_pattern: "feature/{number}"
+    commit_format: "conventional"
+    merge_strategy: "squash"
+  file_naming:
+    go: "snake_case"
+technical_preferences:
+  languages:
+    primary: "go"
+quality_standards:
+  error_policy: "fix-forward"
+  review_policy: "independent-reviewer"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	p, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if p.ProjectConventions.Git.BranchPattern != "feature/{number}" {
+		t.Errorf("branch_pattern = %q, want %q", p.ProjectConventions.Git.BranchPattern, "feature/{number}")
+	}
+	if p.ProjectConventions.Git.CommitFormat != "conventional" {
+		t.Errorf("commit_format = %q, want %q", p.ProjectConventions.Git.CommitFormat, "conventional")
+	}
+	if p.QualityStandards.ErrorPolicy != "fix-forward" {
+		t.Errorf("error_policy = %q, want %q", p.QualityStandards.ErrorPolicy, "fix-forward")
+	}
+	lang, ok := p.TechnicalPreferences.Languages["primary"]
+	if !ok {
+		t.Fatal("expected languages.primary to exist")
+	}
+	if lang != "go" {
+		t.Errorf("languages.primary = %v, want %q", lang, "go")
+	}
+}

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -1,0 +1,46 @@
+package profile
+
+// Profile represents the full user profile with 4 sections.
+type Profile struct {
+	ProjectConventions   ProjectConventions   `yaml:"project_conventions" json:"project_conventions"`
+	TechnicalPreferences TechnicalPreferences `yaml:"technical_preferences" json:"technical_preferences"`
+	AIAgentConfig        AIAgentConfig        `yaml:"ai_agent_configuration" json:"ai_agent_configuration"`
+	QualityStandards     QualityStandards     `yaml:"quality_standards" json:"quality_standards"`
+}
+
+// ProjectConventions defines how projects are structured, named, and governed.
+type ProjectConventions struct {
+	DirectoryStructure map[string]string `yaml:"directory_structure,omitempty" json:"directory_structure,omitempty"`
+	FileNaming         map[string]string `yaml:"file_naming,omitempty" json:"file_naming,omitempty"`
+	Git                GitConfig         `yaml:"git,omitempty" json:"git,omitempty"`
+}
+
+// GitConfig holds git workflow preferences.
+type GitConfig struct {
+	BranchPattern string `yaml:"branch_pattern,omitempty" json:"branch_pattern,omitempty"`
+	CommitFormat  string `yaml:"commit_format,omitempty" json:"commit_format,omitempty"`
+	MergeStrategy string `yaml:"merge_strategy,omitempty" json:"merge_strategy,omitempty"`
+}
+
+// TechnicalPreferences captures language, framework, testing, and build preferences.
+type TechnicalPreferences struct {
+	Languages  map[string]any `yaml:"languages,omitempty" json:"languages,omitempty"`
+	Frameworks map[string]any `yaml:"frameworks,omitempty" json:"frameworks,omitempty"`
+	Testing    map[string]any `yaml:"testing,omitempty" json:"testing,omitempty"`
+	Build      map[string]any `yaml:"build,omitempty" json:"build,omitempty"`
+	Linting    map[string]any `yaml:"linting,omitempty" json:"linting,omitempty"`
+}
+
+// AIAgentConfig defines how agents behave, what tools they have, and what knowledge they carry.
+type AIAgentConfig struct {
+	TrustTiers    map[string]any `yaml:"trust_tiers,omitempty" json:"trust_tiers,omitempty"`
+	ModelRouting  map[string]any `yaml:"model_routing,omitempty" json:"model_routing,omitempty"`
+	Communication map[string]any `yaml:"communication,omitempty" json:"communication,omitempty"`
+}
+
+// QualityStandards defines error handling, review, and CI policies.
+type QualityStandards struct {
+	ErrorPolicy    string         `yaml:"error_policy,omitempty" json:"error_policy,omitempty"`
+	ReviewPolicy   string         `yaml:"review_policy,omitempty" json:"review_policy,omitempty"`
+	CIRequirements map[string]any `yaml:"ci_requirements,omitempty" json:"ci_requirements,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Read-only `ProfileStore` interface: `Get`, `GetField` (dot-path navigation), `Version`, `Import`, `Close`
- SQLite-backed implementation with append-only versioning (JSON document in versioned rows)
- 4-section profile schema: `ProjectConventions`, `TechnicalPreferences`, `AIAgentConfig`, `QualityStandards`
- YAML file loader for `samverk profile import` command (future)
- 10 tests covering import, get, field navigation, versioning, file loading

## Test plan

- [x] `go test ./internal/profile/...` -- 10/10 pass
- [x] `go build ./...` -- compiles
- [x] `GOOS=linux GOARCH=amd64 go build ./...` -- cross-compiles
- [x] `golangci-lint run ./internal/profile/...` -- 0 issues

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)