### PR TITLE
feat: implement dispatcher core routing loop (Phase 1)

### DIFF
--- a/internal/dispatcher/config.go
+++ b/internal/dispatcher/config.go
@@ -1,0 +1,72 @@
+package dispatcher
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds all dispatcher runtime settings.
+type Config struct {
+	HeartbeatInterval          time.Duration `yaml:"heartbeat_interval"`
+	HeartbeatTimeoutMultiplier float64       `yaml:"heartbeat_timeout_multiplier"`
+	MaxConsecutiveFailures     int           `yaml:"max_consecutive_failures"`
+	DependencyRecheckInterval  time.Duration `yaml:"dependency_recheck_interval"`
+	HeartbeatCheckInterval     time.Duration `yaml:"heartbeat_check_interval"`
+}
+
+// configFile is the on-disk YAML representation with friendly duration fields.
+type configFile struct {
+	HeartbeatIntervalMinutes   int     `yaml:"heartbeat_interval_minutes"`
+	HeartbeatTimeoutMultiplier float64 `yaml:"heartbeat_timeout_multiplier"`
+	MaxConsecutiveFailures     int     `yaml:"max_consecutive_failures"`
+	DependencyRecheckSeconds   int     `yaml:"dependency_recheck_seconds"`
+	HeartbeatCheckSeconds      int     `yaml:"heartbeat_check_seconds"`
+}
+
+// DefaultConfig returns production-ready defaults for a self-hosted deployment.
+func DefaultConfig() *Config {
+	return &Config{
+		HeartbeatInterval:          10 * time.Minute,
+		HeartbeatTimeoutMultiplier: 1.5,
+		MaxConsecutiveFailures:     3,
+		DependencyRecheckInterval:  2 * time.Minute,
+		HeartbeatCheckInterval:     60 * time.Second,
+	}
+}
+
+// LoadConfig reads a YAML config file and merges it with defaults.
+// Missing fields keep their default values.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: config path is from trusted CLI/server config
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var cf configFile
+	if err = yaml.Unmarshal(data, &cf); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	cfg := DefaultConfig()
+
+	if cf.HeartbeatIntervalMinutes > 0 {
+		cfg.HeartbeatInterval = time.Duration(cf.HeartbeatIntervalMinutes) * time.Minute
+	}
+	if cf.HeartbeatTimeoutMultiplier > 0 {
+		cfg.HeartbeatTimeoutMultiplier = cf.HeartbeatTimeoutMultiplier
+	}
+	if cf.MaxConsecutiveFailures > 0 {
+		cfg.MaxConsecutiveFailures = cf.MaxConsecutiveFailures
+	}
+	if cf.DependencyRecheckSeconds > 0 {
+		cfg.DependencyRecheckInterval = time.Duration(cf.DependencyRecheckSeconds) * time.Second
+	}
+	if cf.HeartbeatCheckSeconds > 0 {
+		cfg.HeartbeatCheckInterval = time.Duration(cf.HeartbeatCheckSeconds) * time.Second
+	}
+
+	return cfg, nil
+}

--- a/internal/dispatcher/deps.go
+++ b/internal/dispatcher/deps.go
@@ -1,0 +1,180 @@
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// checkDependencies verifies all depends_on issues are done.
+// Returns blocked=true with the list of unsatisfied dependency issue numbers.
+func (d *Dispatcher) checkDependencies(ctx context.Context, fm *models.IssueFrontmatter) (blocked bool, blockers []int, err error) {
+	if fm == nil || len(fm.DependsOn) == 0 {
+		return false, nil, nil
+	}
+
+	blockers = make([]int, 0, len(fm.DependsOn))
+	for _, dep := range fm.DependsOn {
+		issue, getErr := d.tracker.GetIssue(ctx, dep)
+		if getErr != nil {
+			return false, nil, fmt.Errorf("get dependency #%d: %w", dep, getErr)
+		}
+		if !isDone(issue) {
+			blockers = append(blockers, dep)
+		}
+	}
+
+	return len(blockers) > 0, blockers, nil
+}
+
+// isDone returns true if the issue is closed and has the status:done label.
+func isDone(issue *forge.Issue) bool {
+	if issue.State != forge.StateClosed {
+		return false
+	}
+	for _, label := range issue.Labels {
+		if label == "status:done" {
+			return true
+		}
+	}
+	return false
+}
+
+// detectCycle runs DFS from startIssue to find dependency cycles.
+// Returns the cycle path if found, nil if no cycle exists.
+func (d *Dispatcher) detectCycle(ctx context.Context, startIssue int) ([]int, error) {
+	// Build the dependency graph from all open issues.
+	graph, err := d.buildDependencyGraph(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// DFS with visited set and current path tracking.
+	visited := make(map[int]bool)
+	inPath := make(map[int]bool)
+	var path []int
+
+	var dfs func(node int) []int
+	dfs = func(node int) []int {
+		if inPath[node] {
+			// Found a cycle. Extract the cycle from path.
+			cycleStart := -1
+			for i, n := range path {
+				if n == node {
+					cycleStart = i
+					break
+				}
+			}
+			if cycleStart >= 0 {
+				cycle := make([]int, len(path)-cycleStart)
+				copy(cycle, path[cycleStart:])
+				return append(cycle, node)
+			}
+			return []int{node}
+		}
+		if visited[node] {
+			return nil
+		}
+
+		visited[node] = true
+		inPath[node] = true
+		path = append(path, node)
+
+		for _, dep := range graph[node] {
+			if cycle := dfs(dep); cycle != nil {
+				return cycle
+			}
+		}
+
+		inPath[node] = false
+		path = path[:len(path)-1]
+		return nil
+	}
+
+	return dfs(startIssue), nil
+}
+
+// buildDependencyGraph lists open issues and builds an adjacency list
+// from each issue number to its depends_on list.
+func (d *Dispatcher) buildDependencyGraph(ctx context.Context) (graph map[int][]int, err error) {
+	issues, listErr := d.tracker.ListIssues(ctx, &forge.ListOptions{State: forge.StateOpen})
+	if listErr != nil {
+		return nil, fmt.Errorf("list open issues: %w", listErr)
+	}
+
+	graph = make(map[int][]int, len(issues))
+	for _, issue := range issues {
+		result, parseErr := models.ParseFrontmatter(issue.Body)
+		if parseErr != nil || result.Frontmatter == nil {
+			continue
+		}
+		if len(result.Frontmatter.DependsOn) > 0 {
+			graph[issue.Number] = result.Frontmatter.DependsOn
+		}
+	}
+	return graph, nil
+}
+
+// unblockDependents scans blocked issues and transitions any whose
+// dependencies are all satisfied after closedIssueNumber was closed.
+func (d *Dispatcher) unblockDependents(ctx context.Context, closedIssueNumber int) error {
+	blockedIssues, err := d.tracker.ListIssues(ctx, &forge.ListOptions{
+		State:  forge.StateOpen,
+		Labels: []string{"status:blocked"},
+	})
+	if err != nil {
+		return fmt.Errorf("list blocked issues: %w", err)
+	}
+
+	for _, issue := range blockedIssues {
+		result, parseErr := models.ParseFrontmatter(issue.Body)
+		if parseErr != nil || result.Frontmatter == nil {
+			continue
+		}
+
+		// Only check issues that depend on the one that just closed.
+		dependsOnClosed := false
+		for _, dep := range result.Frontmatter.DependsOn {
+			if dep == closedIssueNumber {
+				dependsOnClosed = true
+				break
+			}
+		}
+		if !dependsOnClosed {
+			continue
+		}
+
+		// Check if ALL dependencies are now satisfied.
+		blocked, _, depErr := d.checkDependencies(ctx, result.Frontmatter)
+		if depErr != nil {
+			d.logger.Printf("check deps for #%d: %v", issue.Number, depErr)
+			continue
+		}
+		if blocked {
+			continue
+		}
+
+		// Unblock: transition from blocked to queued.
+		if removeErr := d.tracker.RemoveLabel(ctx, issue.Number, "status:blocked"); removeErr != nil {
+			d.logger.Printf("remove blocked from #%d: %v", issue.Number, removeErr)
+		}
+		if addErr := d.tracker.AddLabel(ctx, issue.Number, "status:queued"); addErr != nil {
+			d.logger.Printf("add queued to #%d: %v", issue.Number, addErr)
+		}
+
+		comment := fmt.Sprintf(
+			"UNBLOCKED [dispatcher] [%s]\nDependency #%d completed. All dependencies satisfied.\nTransitioning to status:queued for routing.",
+			time.Now().UTC().Format(time.RFC3339), closedIssueNumber,
+		)
+		if _, commentErr := d.tracker.AddComment(ctx, issue.Number, comment); commentErr != nil {
+			d.logger.Printf("add unblock comment to #%d: %v", issue.Number, commentErr)
+		}
+
+		d.logger.Printf("unblocked issue #%d after #%d closed", issue.Number, closedIssueNumber)
+	}
+
+	return nil
+}

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -1,0 +1,248 @@
+// Package dispatcher watches the issue tracker, routes tasks to agents, and manages dependencies.
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/internal/store"
+)
+
+// claimedIssue tracks in-memory heartbeat state for a single routed issue.
+type claimedIssue struct {
+	AgentID       string
+	ClaimedAt     time.Time
+	LastHeartbeat time.Time
+	FailureCount  int
+}
+
+// Dispatcher is the core routing engine. It watches the issue tracker for
+// changes, classifies incoming work, resolves dependencies, and assigns
+// tasks to agent pools.
+type Dispatcher struct {
+	tracker forge.IssueTracker
+	policy  autonomy.AutonomyPolicy
+	store   store.Store
+	config  *Config
+	claimed map[int]*claimedIssue
+	mu      sync.Mutex
+	logger  *log.Logger
+	stop    context.CancelFunc
+}
+
+// New creates a Dispatcher with the given dependencies.
+func New(tracker forge.IssueTracker, policy autonomy.AutonomyPolicy, st store.Store, cfg *Config) *Dispatcher {
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+	return &Dispatcher{
+		tracker: tracker,
+		policy:  policy,
+		store:   st,
+		config:  cfg,
+		claimed: make(map[int]*claimedIssue),
+		logger:  log.Default(),
+	}
+}
+
+// Run starts the watch loop and heartbeat ticker. It blocks until ctx is
+// cancelled or an unrecoverable error occurs.
+func (d *Dispatcher) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	d.stop = cancel
+
+	errCh := make(chan error, 1)
+
+	// Start the event watcher in a goroutine.
+	go func() {
+		errCh <- d.tracker.Watch(ctx, func(ev forge.Event) {
+			d.handleEvent(ctx, ev)
+		})
+	}()
+
+	ticker := time.NewTicker(d.config.HeartbeatCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-errCh:
+			return fmt.Errorf("watch stopped: %w", err)
+		case <-ticker.C:
+			if err := d.checkTimeouts(ctx); err != nil {
+				d.logger.Printf("heartbeat check error: %v", err)
+			}
+		}
+	}
+}
+
+// Stop cancels the dispatcher's context, terminating Run.
+func (d *Dispatcher) Stop() {
+	if d.stop != nil {
+		d.stop()
+	}
+}
+
+// handleEvent dispatches a forge event to the correct handler.
+func (d *Dispatcher) handleEvent(ctx context.Context, ev forge.Event) {
+	var err error
+	switch ev.Type {
+	case forge.EventIssueOpened:
+		err = d.handleOpened(ctx, ev)
+	case forge.EventIssueClosed:
+		err = d.handleClosed(ctx, ev)
+	case forge.EventIssueLabeled:
+		err = d.handleLabeled(ctx, ev)
+	case forge.EventIssueCommented:
+		err = d.handleCommented(ctx, ev)
+	case forge.EventIssueEdited:
+		err = d.handleEdited(ctx, ev)
+	default:
+		d.logger.Printf("unknown event type: %s", ev.Type)
+		return
+	}
+	if err != nil {
+		d.logger.Printf("error handling %s for issue #%d: %v", ev.Type, ev.IssueNumber, err)
+	}
+}
+
+// handleOpened processes a newly created issue: classify, check deps, route or block.
+func (d *Dispatcher) handleOpened(ctx context.Context, ev forge.Event) error {
+	issue := ev.Issue
+	if issue == nil {
+		var err error
+		issue, err = d.tracker.GetIssue(ctx, ev.IssueNumber)
+		if err != nil {
+			return fmt.Errorf("get issue #%d: %w", ev.IssueNumber, err)
+		}
+	}
+
+	agentType, err := d.classify(ctx, issue)
+	if err != nil {
+		return d.escalate(ctx, issue.Number, "invalid_frontmatter", err.Error())
+	}
+
+	// Check dependencies before routing.
+	fm, fmErr := d.parseFrontmatter(issue)
+	if fmErr != nil {
+		return d.escalate(ctx, issue.Number, "frontmatter_parse_error", fmErr.Error())
+	}
+
+	if fm != nil && len(fm.DependsOn) > 0 {
+		// Check for cycles first.
+		cycle, cycleErr := d.detectCycle(ctx, issue.Number)
+		if cycleErr != nil {
+			return fmt.Errorf("cycle detection for #%d: %w", issue.Number, cycleErr)
+		}
+		if len(cycle) > 0 {
+			return d.escalateCycle(ctx, cycle)
+		}
+
+		blocked, blockers, depErr := d.checkDependencies(ctx, fm)
+		if depErr != nil {
+			return fmt.Errorf("check deps for #%d: %w", issue.Number, depErr)
+		}
+		if blocked {
+			return d.blockIssue(ctx, issue.Number, blockers)
+		}
+	}
+
+	return d.route(ctx, issue, agentType)
+}
+
+// handleClosed processes a closed issue by unblocking dependents.
+func (d *Dispatcher) handleClosed(ctx context.Context, ev forge.Event) error {
+	// Remove from claimed map if tracked.
+	d.mu.Lock()
+	delete(d.claimed, ev.IssueNumber)
+	d.mu.Unlock()
+
+	return d.unblockDependents(ctx, ev.IssueNumber)
+}
+
+// handleLabeled re-evaluates routing when a status label changes.
+func (d *Dispatcher) handleLabeled(_ context.Context, _ forge.Event) error {
+	// Phase 1: no re-evaluation on label changes beyond what handleOpened covers.
+	return nil
+}
+
+// handleCommented checks for heartbeat comments from agents.
+func (d *Dispatcher) handleCommented(_ context.Context, ev forge.Event) error {
+	if ev.Comment == nil {
+		return nil
+	}
+	hb := parseHeartbeat(ev.Comment.Body)
+	if hb == nil {
+		return nil
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	claimed, ok := d.claimed[ev.IssueNumber]
+	if !ok {
+		return nil
+	}
+	claimed.LastHeartbeat = hb.Timestamp
+	return nil
+}
+
+// handleEdited re-parses frontmatter when an issue body changes.
+func (d *Dispatcher) handleEdited(_ context.Context, _ forge.Event) error {
+	// Phase 1: no re-parsing on edits.
+	return nil
+}
+
+// escalate labels an issue as needs-human and posts a comment.
+func (d *Dispatcher) escalate(ctx context.Context, issueNumber int, trigger, details string) error {
+	comment := fmt.Sprintf(
+		"ESCALATE [dispatcher] [%s]\ntrigger: %s\ndetails: %s\naction_needed: Manual review required.",
+		time.Now().UTC().Format(time.RFC3339), trigger, details,
+	)
+	if err := d.tracker.AddLabel(ctx, issueNumber, "status:needs-human"); err != nil {
+		return fmt.Errorf("add needs-human label: %w", err)
+	}
+	if _, err := d.tracker.AddComment(ctx, issueNumber, comment); err != nil {
+		return fmt.Errorf("add escalation comment: %w", err)
+	}
+	return nil
+}
+
+// escalateCycle labels all issues in a dependency cycle as needs-human.
+func (d *Dispatcher) escalateCycle(ctx context.Context, cycle []int) error {
+	cyclePath := fmt.Sprintf("%v", cycle)
+	for _, num := range cycle {
+		comment := fmt.Sprintf(
+			"ESCALATE [dispatcher] [%s]\ntrigger: dependency_cycle\ndetails: Cycle detected: %s\naction_needed: Break the dependency cycle.",
+			time.Now().UTC().Format(time.RFC3339), cyclePath,
+		)
+		if err := d.tracker.AddLabel(ctx, num, "status:needs-human"); err != nil {
+			d.logger.Printf("add needs-human to #%d: %v", num, err)
+		}
+		if _, err := d.tracker.AddComment(ctx, num, comment); err != nil {
+			d.logger.Printf("add cycle comment to #%d: %v", num, err)
+		}
+	}
+	return nil
+}
+
+// blockIssue transitions an issue to status:blocked with a comment listing blockers.
+func (d *Dispatcher) blockIssue(ctx context.Context, issueNumber int, blockers []int) error {
+	comment := fmt.Sprintf(
+		"BLOCKED [dispatcher] [%s]\nWaiting on: %v\nWill auto-unblock when all dependencies reach status:done.",
+		time.Now().UTC().Format(time.RFC3339), blockers,
+	)
+	if err := d.tracker.AddLabel(ctx, issueNumber, "status:blocked"); err != nil {
+		return fmt.Errorf("add blocked label: %w", err)
+	}
+	if _, err := d.tracker.AddComment(ctx, issueNumber, comment); err != nil {
+		return fmt.Errorf("add block comment: %w", err)
+	}
+	return nil
+}

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -1,0 +1,692 @@
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+// mockTracker implements forge.IssueTracker for testing.
+type mockTracker struct {
+	mu       sync.Mutex
+	issues   map[int]*forge.Issue
+	comments map[int][]*forge.Comment
+	calls    []string
+}
+
+func newMockTracker() *mockTracker {
+	return &mockTracker{
+		issues:   make(map[int]*forge.Issue),
+		comments: make(map[int][]*forge.Comment),
+	}
+}
+
+func (m *mockTracker) record(method string) {
+	m.mu.Lock()
+	m.calls = append(m.calls, method)
+	m.mu.Unlock()
+}
+
+func (m *mockTracker) CreateIssue(_ context.Context, req *forge.CreateIssueRequest) (*forge.Issue, error) {
+	m.record("CreateIssue")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	num := len(m.issues) + 1
+	issue := &forge.Issue{
+		Number:    num,
+		Title:     req.Title,
+		Body:      req.Body,
+		State:     forge.StateOpen,
+		Labels:    req.Labels,
+		Assignees: req.Assignees,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	m.issues[num] = issue
+	return issue, nil
+}
+
+func (m *mockTracker) GetIssue(_ context.Context, number int) (*forge.Issue, error) {
+	m.record("GetIssue")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	issue, ok := m.issues[number]
+	if !ok {
+		return nil, fmt.Errorf("issue #%d not found", number)
+	}
+	return issue, nil
+}
+
+func (m *mockTracker) UpdateIssue(_ context.Context, number int, req *forge.UpdateIssueRequest) (*forge.Issue, error) {
+	m.record("UpdateIssue")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	issue, ok := m.issues[number]
+	if !ok {
+		return nil, fmt.Errorf("issue #%d not found", number)
+	}
+	if req.Title != nil {
+		issue.Title = *req.Title
+	}
+	if req.Body != nil {
+		issue.Body = *req.Body
+	}
+	if req.State != nil {
+		issue.State = *req.State
+	}
+	issue.UpdatedAt = time.Now()
+	return issue, nil
+}
+
+func (m *mockTracker) ListIssues(_ context.Context, opts *forge.ListOptions) ([]*forge.Issue, error) {
+	m.record("ListIssues")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]*forge.Issue, 0)
+	for _, issue := range m.issues {
+		if opts != nil {
+			if opts.State != "" && issue.State != opts.State {
+				continue
+			}
+			if len(opts.Labels) > 0 && !hasAllLabels(issue.Labels, opts.Labels) {
+				continue
+			}
+		}
+		result = append(result, issue)
+	}
+	return result, nil
+}
+
+func hasAllLabels(issueLabels, required []string) bool {
+	set := make(map[string]bool, len(issueLabels))
+	for _, l := range issueLabels {
+		set[l] = true
+	}
+	for _, r := range required {
+		if !set[r] {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *mockTracker) AddComment(_ context.Context, number int, body string) (*forge.Comment, error) {
+	m.record("AddComment")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c := &forge.Comment{
+		ID:        int64(len(m.comments[number]) + 1),
+		Body:      body,
+		Author:    "dispatcher",
+		CreatedAt: time.Now(),
+	}
+	m.comments[number] = append(m.comments[number], c)
+	return c, nil
+}
+
+func (m *mockTracker) ListComments(_ context.Context, number int) ([]*forge.Comment, error) {
+	m.record("ListComments")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.comments[number], nil
+}
+
+func (m *mockTracker) SetLabels(_ context.Context, number int, labels []string) error {
+	m.record("SetLabels")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if issue, ok := m.issues[number]; ok {
+		issue.Labels = labels
+	}
+	return nil
+}
+
+func (m *mockTracker) AddLabel(_ context.Context, number int, label string) error {
+	m.record("AddLabel")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if issue, ok := m.issues[number]; ok {
+		for _, l := range issue.Labels {
+			if l == label {
+				return nil
+			}
+		}
+		issue.Labels = append(issue.Labels, label)
+	}
+	return nil
+}
+
+func (m *mockTracker) RemoveLabel(_ context.Context, number int, label string) error {
+	m.record("RemoveLabel")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if issue, ok := m.issues[number]; ok {
+		filtered := make([]string, 0, len(issue.Labels))
+		for _, l := range issue.Labels {
+			if l != label {
+				filtered = append(filtered, l)
+			}
+		}
+		issue.Labels = filtered
+	}
+	return nil
+}
+
+func (m *mockTracker) Assign(_ context.Context, number int, assignee string) error {
+	m.record("Assign")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if issue, ok := m.issues[number]; ok {
+		issue.Assignees = append(issue.Assignees, assignee)
+	}
+	return nil
+}
+
+func (m *mockTracker) Unassign(_ context.Context, number int, assignee string) error {
+	m.record("Unassign")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if issue, ok := m.issues[number]; ok {
+		filtered := make([]string, 0, len(issue.Assignees))
+		for _, a := range issue.Assignees {
+			if a != assignee {
+				filtered = append(filtered, a)
+			}
+		}
+		issue.Assignees = filtered
+	}
+	return nil
+}
+
+func (m *mockTracker) Watch(ctx context.Context, handler func(forge.Event)) error {
+	// The Watch method does nothing by default; tests send events directly.
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// --- Mock autonomy policy ---
+
+type mockPolicy struct {
+	costThreshold float64
+}
+
+func (p *mockPolicy) TierFor(_ autonomy.ActionType) autonomy.Tier {
+	return autonomy.Tier1
+}
+
+func (p *mockPolicy) RequiresConfirmation(_ autonomy.ActionType) bool {
+	return false
+}
+
+func (p *mockPolicy) CostThreshold() float64 {
+	return p.costThreshold
+}
+
+// --- Helper to build issue body with frontmatter ---
+
+func issueBody(agentType string, dependsOn []int) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("schema_version: \"1.0.0\"\n")
+	b.WriteString("type: task\n")
+	if agentType != "" {
+		fmt.Fprintf(&b, "agent_type: %s\n", agentType)
+	}
+	b.WriteString("priority: normal\n")
+	if len(dependsOn) > 0 {
+		b.WriteString("depends_on:\n")
+		for _, dep := range dependsOn {
+			fmt.Fprintf(&b, "  - %d\n", dep)
+		}
+	}
+	b.WriteString("---\n\n## Summary\n\nTest issue.\n")
+	return b.String()
+}
+
+func newTestDispatcher(tracker *mockTracker) *Dispatcher {
+	cfg := DefaultConfig()
+	// Use short intervals for tests.
+	cfg.HeartbeatInterval = 100 * time.Millisecond
+	cfg.HeartbeatCheckInterval = 50 * time.Millisecond
+	return New(tracker, &mockPolicy{costThreshold: 5.0}, nil, cfg)
+}
+
+// --- Tests ---
+
+func TestNewDispatcher(t *testing.T) {
+	tracker := newMockTracker()
+	d := New(tracker, &mockPolicy{costThreshold: 5.0}, nil, nil)
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	if d.config == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if d.config.MaxConsecutiveFailures != 3 {
+		t.Errorf("MaxConsecutiveFailures: got %d, want 3", d.config.MaxConsecutiveFailures)
+	}
+	if d.claimed == nil {
+		t.Fatal("expected non-nil claimed map")
+	}
+}
+
+func TestHandleOpened_ValidFrontmatter(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	issue := &forge.Issue{
+		Number: 1,
+		Title:  "Add widget",
+		Body:   issueBody("code-gen", nil),
+		State:  forge.StateOpen,
+		Labels: []string{"status:queued"},
+	}
+	tracker.issues[1] = issue
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 1,
+		Issue:       issue,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Issue should be claimed and assigned.
+	if !hasLabel(issue.Labels, "status:claimed") {
+		t.Error("expected status:claimed label")
+	}
+	if hasLabel(issue.Labels, "status:queued") {
+		t.Error("did not expect status:queued label after routing")
+	}
+	if len(issue.Assignees) == 0 || issue.Assignees[0] != "code-gen" {
+		t.Errorf("expected assignee code-gen, got %v", issue.Assignees)
+	}
+}
+
+func TestHandleOpened_InvalidAgentType(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	issue := &forge.Issue{
+		Number: 1,
+		Title:  "Bad type",
+		Body:   issueBody("nonexistent-type", nil),
+		State:  forge.StateOpen,
+	}
+	tracker.issues[1] = issue
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 1,
+		Issue:       issue,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !hasLabel(issue.Labels, "status:needs-human") {
+		t.Error("expected status:needs-human label for invalid agent type")
+	}
+}
+
+func TestHandleOpened_NoFrontmatter(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	issue := &forge.Issue{
+		Number: 1,
+		Title:  "Plain issue",
+		Body:   "No frontmatter here, just a plain issue body.",
+		State:  forge.StateOpen,
+	}
+	tracker.issues[1] = issue
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 1,
+		Issue:       issue,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !hasLabel(issue.Labels, "status:needs-human") {
+		t.Error("expected status:needs-human label for missing frontmatter")
+	}
+}
+
+func TestHandleOpened_WithDependencies_AllDone(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Create a closed dependency with status:done.
+	closedAt := time.Now()
+	tracker.issues[10] = &forge.Issue{
+		Number:   10,
+		State:    forge.StateClosed,
+		Labels:   []string{"status:done"},
+		ClosedAt: &closedAt,
+	}
+
+	issue := &forge.Issue{
+		Number: 1,
+		Title:  "Depends on #10",
+		Body:   issueBody("code-gen", []int{10}),
+		State:  forge.StateOpen,
+		Labels: []string{"status:queued"},
+	}
+	tracker.issues[1] = issue
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 1,
+		Issue:       issue,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be routed, not blocked.
+	if hasLabel(issue.Labels, "status:blocked") {
+		t.Error("did not expect status:blocked -- dependency is done")
+	}
+	if !hasLabel(issue.Labels, "status:claimed") {
+		t.Error("expected status:claimed after routing")
+	}
+}
+
+func TestHandleOpened_WithDependencies_Blocked(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Dependency is open (not done).
+	tracker.issues[10] = &forge.Issue{
+		Number: 10,
+		State:  forge.StateOpen,
+		Labels: []string{"status:in-progress"},
+		Body:   issueBody("code-gen", nil),
+	}
+
+	issue := &forge.Issue{
+		Number: 1,
+		Title:  "Depends on #10",
+		Body:   issueBody("code-gen", []int{10}),
+		State:  forge.StateOpen,
+		Labels: []string{"status:queued"},
+	}
+	tracker.issues[1] = issue
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 1,
+		Issue:       issue,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !hasLabel(issue.Labels, "status:blocked") {
+		t.Error("expected status:blocked for unsatisfied dependency")
+	}
+}
+
+func TestHandleClosed_UnblocksDependents(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Dependency issue that will be closed.
+	closedAt := time.Now()
+	tracker.issues[10] = &forge.Issue{
+		Number:   10,
+		State:    forge.StateClosed,
+		Labels:   []string{"status:done"},
+		ClosedAt: &closedAt,
+	}
+
+	// Blocked issue waiting on #10.
+	tracker.issues[1] = &forge.Issue{
+		Number: 1,
+		Title:  "Blocked on #10",
+		Body:   issueBody("code-gen", []int{10}),
+		State:  forge.StateOpen,
+		Labels: []string{"status:blocked"},
+	}
+
+	err := d.handleClosed(context.Background(), forge.Event{
+		Type:        forge.EventIssueClosed,
+		IssueNumber: 10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Issue #1 should be unblocked.
+	issue := tracker.issues[1]
+	if hasLabel(issue.Labels, "status:blocked") {
+		t.Error("expected status:blocked to be removed")
+	}
+	if !hasLabel(issue.Labels, "status:queued") {
+		t.Error("expected status:queued after unblock")
+	}
+}
+
+func TestDetectCycle_NoCycle(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Linear chain: 1 -> 2 -> 3 (no cycle).
+	tracker.issues[1] = &forge.Issue{Number: 1, State: forge.StateOpen, Body: issueBody("code-gen", []int{2})}
+	tracker.issues[2] = &forge.Issue{Number: 2, State: forge.StateOpen, Body: issueBody("code-gen", []int{3})}
+	tracker.issues[3] = &forge.Issue{Number: 3, State: forge.StateOpen, Body: issueBody("code-gen", nil)}
+
+	cycle, err := d.detectCycle(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cycle != nil {
+		t.Errorf("expected no cycle, got %v", cycle)
+	}
+}
+
+func TestDetectCycle_WithCycle(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Cycle: 1 -> 2 -> 3 -> 1.
+	tracker.issues[1] = &forge.Issue{Number: 1, State: forge.StateOpen, Body: issueBody("code-gen", []int{2})}
+	tracker.issues[2] = &forge.Issue{Number: 2, State: forge.StateOpen, Body: issueBody("code-gen", []int{3})}
+	tracker.issues[3] = &forge.Issue{Number: 3, State: forge.StateOpen, Body: issueBody("code-gen", []int{1})}
+
+	cycle, err := d.detectCycle(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cycle == nil {
+		t.Fatal("expected cycle, got nil")
+	}
+	// Cycle should contain all three nodes.
+	if len(cycle) < 3 {
+		t.Errorf("expected cycle of length >= 3, got %v", cycle)
+	}
+}
+
+func TestParseHeartbeat_Valid(t *testing.T) {
+	body := "HEARTBEAT [agent-codegen-1] [2026-02-28T10:30:00Z]\nprogress: 45%\nstatus: Running test suite"
+	hb := parseHeartbeat(body)
+	if hb == nil {
+		t.Fatal("expected non-nil heartbeat")
+	}
+	if hb.AgentID != "agent-codegen-1" {
+		t.Errorf("AgentID: got %q, want %q", hb.AgentID, "agent-codegen-1")
+	}
+	if hb.Progress != 45 {
+		t.Errorf("Progress: got %d, want 45", hb.Progress)
+	}
+	if hb.Status != "Running test suite" {
+		t.Errorf("Status: got %q, want %q", hb.Status, "Running test suite")
+	}
+	expectedTS, _ := time.Parse(time.RFC3339, "2026-02-28T10:30:00Z")
+	if !hb.Timestamp.Equal(expectedTS) {
+		t.Errorf("Timestamp: got %v, want %v", hb.Timestamp, expectedTS)
+	}
+}
+
+func TestParseHeartbeat_Invalid(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "plain comment", body: "This is just a regular comment."},
+		{name: "partial match", body: "HEARTBEAT without brackets"},
+		{name: "bad timestamp", body: "HEARTBEAT [agent-1] [not-a-timestamp]\nprogress: 50%\nstatus: working"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hb := parseHeartbeat(tt.body)
+			if hb != nil {
+				t.Errorf("expected nil heartbeat for %q, got %+v", tt.body, hb)
+			}
+		})
+	}
+}
+
+func TestCheckTimeouts_NoTimeout(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Claim an issue with a recent heartbeat.
+	d.mu.Lock()
+	d.claimed[1] = &claimedIssue{
+		AgentID:       "code-gen",
+		ClaimedAt:     time.Now(),
+		LastHeartbeat: time.Now(),
+	}
+	d.mu.Unlock()
+
+	tracker.issues[1] = &forge.Issue{
+		Number: 1,
+		State:  forge.StateOpen,
+		Labels: []string{"status:claimed"},
+	}
+
+	err := d.checkTimeouts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Issue should still be claimed.
+	d.mu.Lock()
+	_, stillClaimed := d.claimed[1]
+	d.mu.Unlock()
+	if !stillClaimed {
+		t.Error("expected issue to remain claimed (no timeout)")
+	}
+}
+
+func TestCheckTimeouts_TimedOut(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Claim an issue with an old heartbeat.
+	d.mu.Lock()
+	d.claimed[1] = &claimedIssue{
+		AgentID:       "code-gen",
+		ClaimedAt:     time.Now().Add(-time.Hour),
+		LastHeartbeat: time.Now().Add(-time.Hour),
+	}
+	d.mu.Unlock()
+
+	tracker.issues[1] = &forge.Issue{
+		Number:    1,
+		State:     forge.StateOpen,
+		Labels:    []string{"status:claimed"},
+		Assignees: []string{"code-gen"},
+	}
+
+	err := d.checkTimeouts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Issue should be released.
+	d.mu.Lock()
+	_, stillClaimed := d.claimed[1]
+	d.mu.Unlock()
+	if stillClaimed {
+		t.Error("expected issue to be released after timeout")
+	}
+
+	issue := tracker.issues[1]
+	if !hasLabel(issue.Labels, "status:queued") {
+		t.Error("expected status:queued after timeout release")
+	}
+}
+
+func TestCheckTimeouts_ThreeFailures(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Issue with 2 prior failures -- next timeout will be the 3rd.
+	d.mu.Lock()
+	d.claimed[1] = &claimedIssue{
+		AgentID:       "code-gen",
+		ClaimedAt:     time.Now().Add(-time.Hour),
+		LastHeartbeat: time.Now().Add(-time.Hour),
+		FailureCount:  2,
+	}
+	d.mu.Unlock()
+
+	tracker.issues[1] = &forge.Issue{
+		Number:    1,
+		State:     forge.StateOpen,
+		Labels:    []string{"status:claimed"},
+		Assignees: []string{"code-gen"},
+	}
+
+	err := d.checkTimeouts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	issue := tracker.issues[1]
+	if !hasLabel(issue.Labels, "status:needs-human") {
+		t.Error("expected status:needs-human after 3 consecutive failures")
+	}
+}
+
+func TestLoadConfig_Defaults(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.HeartbeatInterval != 10*time.Minute {
+		t.Errorf("HeartbeatInterval: got %v, want 10m", cfg.HeartbeatInterval)
+	}
+	if cfg.HeartbeatTimeoutMultiplier != 1.5 {
+		t.Errorf("HeartbeatTimeoutMultiplier: got %v, want 1.5", cfg.HeartbeatTimeoutMultiplier)
+	}
+	if cfg.MaxConsecutiveFailures != 3 {
+		t.Errorf("MaxConsecutiveFailures: got %d, want 3", cfg.MaxConsecutiveFailures)
+	}
+	if cfg.DependencyRecheckInterval != 2*time.Minute {
+		t.Errorf("DependencyRecheckInterval: got %v, want 2m", cfg.DependencyRecheckInterval)
+	}
+	if cfg.HeartbeatCheckInterval != 60*time.Second {
+		t.Errorf("HeartbeatCheckInterval: got %v, want 60s", cfg.HeartbeatCheckInterval)
+	}
+}
+
+// --- Helpers ---
+
+func hasLabel(labels []string, target string) bool {
+	for _, l := range labels {
+		if l == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dispatcher/doc.go
+++ b/internal/dispatcher/doc.go
@@ -1,2 +1,0 @@
-// Package dispatcher watches the issue tracker, routes tasks to agents, and manages dependencies.
-package dispatcher

--- a/internal/dispatcher/heartbeat.go
+++ b/internal/dispatcher/heartbeat.go
@@ -1,0 +1,134 @@
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// Heartbeat represents a parsed heartbeat comment from an agent.
+type Heartbeat struct {
+	AgentID   string
+	Timestamp time.Time
+	Progress  int
+	Status    string
+}
+
+// heartbeatHeaderRe matches the first line: HEARTBEAT [agent-id] [iso-timestamp]
+var heartbeatHeaderRe = regexp.MustCompile(
+	`HEARTBEAT\s+\[([^\]]+)\]\s+\[([^\]]+)\]`,
+)
+
+// heartbeatProgressRe matches "progress: N%"
+var heartbeatProgressRe = regexp.MustCompile(`(?m)^progress:\s*(\d+)%`)
+
+// heartbeatStatusRe matches "status: <text>"
+var heartbeatStatusRe = regexp.MustCompile(`(?m)^status:\s*(.+)`)
+
+// parseHeartbeat extracts heartbeat data from a comment body.
+// Returns nil if the comment is not a heartbeat.
+func parseHeartbeat(body string) *Heartbeat {
+	headerMatch := heartbeatHeaderRe.FindStringSubmatch(body)
+	if headerMatch == nil {
+		return nil
+	}
+
+	ts, err := time.Parse(time.RFC3339, headerMatch[2])
+	if err != nil {
+		return nil
+	}
+
+	hb := &Heartbeat{
+		AgentID:   headerMatch[1],
+		Timestamp: ts,
+	}
+
+	if progressMatch := heartbeatProgressRe.FindStringSubmatch(body); progressMatch != nil {
+		hb.Progress, _ = strconv.Atoi(progressMatch[1])
+	}
+
+	if statusMatch := heartbeatStatusRe.FindStringSubmatch(body); statusMatch != nil {
+		hb.Status = statusMatch[1]
+	}
+
+	return hb
+}
+
+// checkTimeouts iterates claimed issues and releases any that have timed out.
+func (d *Dispatcher) checkTimeouts(ctx context.Context) error {
+	d.mu.Lock()
+	// Snapshot the claimed map to avoid holding the lock during tracker calls.
+	timedOut := make([]int, 0)
+	now := time.Now()
+	timeout := time.Duration(float64(d.config.HeartbeatInterval) * d.config.HeartbeatTimeoutMultiplier)
+
+	for num, claimed := range d.claimed {
+		if now.Sub(claimed.LastHeartbeat) > timeout {
+			timedOut = append(timedOut, num)
+		}
+	}
+	d.mu.Unlock()
+
+	for _, num := range timedOut {
+		if err := d.releaseTimedOut(ctx, num); err != nil {
+			d.logger.Printf("release timed out #%d: %v", num, err)
+		}
+	}
+	return nil
+}
+
+// releaseTimedOut unclaims a single timed-out issue and re-queues it.
+func (d *Dispatcher) releaseTimedOut(ctx context.Context, issueNumber int) error {
+	d.mu.Lock()
+	claimed, ok := d.claimed[issueNumber]
+	if !ok {
+		d.mu.Unlock()
+		return nil
+	}
+	claimed.FailureCount++
+	failureCount := claimed.FailureCount
+	agentID := claimed.AgentID
+	lastHB := claimed.LastHeartbeat
+	delete(d.claimed, issueNumber)
+	d.mu.Unlock()
+
+	comment := fmt.Sprintf(
+		"RELEASE [dispatcher] [%s] timeout\nAgent %s missed heartbeat. Last seen: %s.\nUnclaiming issue for re-queue.",
+		time.Now().UTC().Format(time.RFC3339), agentID, lastHB.UTC().Format(time.RFC3339),
+	)
+	if _, err := d.tracker.AddComment(ctx, issueNumber, comment); err != nil {
+		d.logger.Printf("add release comment to #%d: %v", issueNumber, err)
+	}
+
+	// Remove in-progress or claimed label.
+	_ = d.tracker.RemoveLabel(ctx, issueNumber, "status:in-progress")
+	_ = d.tracker.RemoveLabel(ctx, issueNumber, "status:claimed")
+
+	if err := d.tracker.AddLabel(ctx, issueNumber, "status:queued"); err != nil {
+		d.logger.Printf("add queued to #%d: %v", issueNumber, err)
+	}
+	if err := d.tracker.Unassign(ctx, issueNumber, agentID); err != nil {
+		d.logger.Printf("unassign #%d: %v", issueNumber, err)
+	}
+
+	d.logger.Printf("released timed out issue #%d (agent=%s, failures=%d)", issueNumber, agentID, failureCount)
+
+	// Escalate after max consecutive failures.
+	if failureCount >= d.config.MaxConsecutiveFailures {
+		escalateComment := fmt.Sprintf(
+			"ESCALATE [dispatcher] [%s]\ntrigger: %d_consecutive_failures\nseverity: high\nissue: #%d\ndetails: Agent %s failed %d times on this issue.\naction_needed: Review issue complexity and acceptance criteria.",
+			time.Now().UTC().Format(time.RFC3339),
+			failureCount, issueNumber, agentID, failureCount,
+		)
+		if err := d.tracker.AddLabel(ctx, issueNumber, "status:needs-human"); err != nil {
+			d.logger.Printf("add needs-human to #%d: %v", issueNumber, err)
+		}
+		if _, err := d.tracker.AddComment(ctx, issueNumber, escalateComment); err != nil {
+			d.logger.Printf("add escalation comment to #%d: %v", issueNumber, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -1,0 +1,77 @@
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// knownAgentTypes is the set of valid agent types for routing validation.
+var knownAgentTypes = map[models.AgentType]bool{
+	models.AgentTypeOrchestrator: true,
+	models.AgentTypeDispatcher:   true,
+	models.AgentTypeCodeGen:      true,
+	models.AgentTypeTest:         true,
+	models.AgentTypeDocs:         true,
+	models.AgentTypeResearch:     true,
+	models.AgentTypeQC:           true,
+	models.AgentTypeHuman:        true,
+}
+
+// classify parses frontmatter from the issue body and validates the agent_type.
+// Returns an error if frontmatter is missing or agent_type is invalid.
+func (d *Dispatcher) classify(_ context.Context, issue *forge.Issue) (models.AgentType, error) {
+	fm, err := d.parseFrontmatter(issue)
+	if err != nil {
+		return "", fmt.Errorf("classify issue #%d: %w", issue.Number, err)
+	}
+	if fm == nil {
+		return "", fmt.Errorf("classify issue #%d: no frontmatter found", issue.Number)
+	}
+	if fm.AgentType == "" {
+		return "", fmt.Errorf("classify issue #%d: agent_type is empty", issue.Number)
+	}
+	if !knownAgentTypes[fm.AgentType] {
+		return "", fmt.Errorf("classify issue #%d: unknown agent_type %q", issue.Number, fm.AgentType)
+	}
+	return fm.AgentType, nil
+}
+
+// route assigns the issue to the agent pool matching agentType.
+// It transitions the issue from queued to claimed and records it in memory.
+func (d *Dispatcher) route(ctx context.Context, issue *forge.Issue, agentType models.AgentType) error {
+	if err := d.tracker.RemoveLabel(ctx, issue.Number, "status:queued"); err != nil {
+		d.logger.Printf("remove queued label from #%d: %v", issue.Number, err)
+	}
+	if err := d.tracker.AddLabel(ctx, issue.Number, "status:claimed"); err != nil {
+		return fmt.Errorf("add claimed label to #%d: %w", issue.Number, err)
+	}
+	if err := d.tracker.Assign(ctx, issue.Number, string(agentType)); err != nil {
+		return fmt.Errorf("assign #%d to %s: %w", issue.Number, agentType, err)
+	}
+
+	now := time.Now()
+	d.mu.Lock()
+	d.claimed[issue.Number] = &claimedIssue{
+		AgentID:       string(agentType),
+		ClaimedAt:     now,
+		LastHeartbeat: now,
+	}
+	d.mu.Unlock()
+
+	d.logger.Printf("routed issue #%d to %s", issue.Number, agentType)
+	return nil
+}
+
+// parseFrontmatter extracts the IssueFrontmatter from an issue's body.
+// Returns (nil, nil) if no frontmatter block exists.
+func (d *Dispatcher) parseFrontmatter(issue *forge.Issue) (*models.IssueFrontmatter, error) {
+	result, err := models.ParseFrontmatter(issue.Body)
+	if err != nil {
+		return nil, err
+	}
+	return result.Frontmatter, nil
+}


### PR DESCRIPTION
## Summary

- Phase 1 MVP dispatcher: poll-based watch via `IssueTracker.Watch()`, validate-then-trust routing
- Frontmatter-based classification with `models.ParseFrontmatter()` (from PR #60)
- Strict dependency blocking with DFS cycle detection
- Heartbeat monitoring with timeout, re-queue, and 3-failure escalation
- In-memory `claimedIssues` map with mutex protection
- 5 source files: config, dispatcher, router, deps, heartbeat
- 15 tests with mock `IssueTracker` and `AutonomyPolicy`

## Test plan

- [x] `go test ./internal/dispatcher/...` -- 15/15 pass
- [x] `go build ./...` -- compiles
- [x] `GOOS=linux GOARCH=amd64 go build ./...` -- cross-compiles
- [x] `golangci-lint run ./internal/dispatcher/...` -- 0 issues

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)