### PR TITLE
chore: sync docs and metadata with Phase 1 implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,13 @@ Async background development engine -- keeps your project building while you liv
 ## Quick Start
 
 ```bash
-# No build steps yet -- concept phase
-# Future:
-make install   # Install dependencies
-make build     # Build the project
-make test      # Run tests
-make lint      # Run linters
-make run       # Start the system
+make build     # Build binary to bin/samverk
+make test      # Run all tests
+make lint      # Run golangci-lint
+make lint-md   # Run markdownlint
+make ci        # Run build + test + lint (full CI locally)
+make hooks     # Install pre-push git hook
+make run       # Build and start samverk serve
 ```
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ Not targeting: enterprise teams, AI engineers, or full-time developers who can s
 
 - [Concept and Problem Space](docs/concept.md)
 - [Architecture](docs/architecture.md)
+- [Tech Stack](docs/tech-stack.md)
 - [Communication Protocol](docs/communication-protocol.md)
+- [Dispatcher Design](docs/dispatcher-design.md)
+- [Autonomy Model](docs/autonomy-model.md)
+- [User Profile](docs/user-profile.md)
+- [System Requirements](docs/system-requirements.md)
 - [Competitive Landscape](docs/competitive.md)
 - [Cost Model](docs/cost-model.md)
 - [User Interface](docs/user-interface.md)
@@ -68,7 +73,9 @@ Not targeting: enterprise teams, AI engineers, or full-time developers who can s
 
 ## Status
 
-Early concept / research phase. Active development has not yet begun.
+**Phase 1 complete.** Core components implemented: dispatcher routing, frontmatter parser, profile store, SQLite persistence, GitHub and Gitea forge adapters, Ollama provider, autonomy policy engine. 72 tests passing across 8 packages.
+
+Next: Issue #11 (manual check-in prototype), then Phase 2 (MCP server, web dashboard, cloud providers).
 
 ## Related Projects
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -2,6 +2,8 @@
 
 The MCP server is the bridge between the front-end agent (Claude on any device) and the Samverk back-end (Gitea + dispatcher + agents). It exposes project state and issue operations as MCP tools that Claude can call during check-in conversations.
 
+> **Implementation status:** Phase 2. This document serves as the specification. The `internal/mcp/` package currently contains only a placeholder. Implementation begins after the dispatcher is stable and the manual check-in prototype (Issue #11) validates the workflow.
+
 ## Architecture Position
 
 ```text

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -7,21 +7,21 @@ Problems that must be resolved before or during development.
 - **Hierarchy depth calibration.** How does the orchestration layer determine appropriate depth for a given task? A bug fix doesn't need all layers. A new feature might. What's the decision logic?
 - **State persistence across sessions.** If the system is down for 8 hours, how does it resume without losing context? How is agent state serialized and restored?
 - **Production/QC deadlock arbitration.** When Production and QC agents disagree and neither will yield, what's the arbitration mechanism before escalating to the user?
-- **Task dependency management.** Agent B may depend on Agent A's output. How does the system manage the DAG of dependencies? What happens when a dependency fails?
+- ~~**Task dependency management.**~~ Resolved: Dispatcher implements full DAG with cycle detection, blocking, and automatic unblocking when dependencies complete. See [Dispatcher Design](dispatcher-design.md) and `internal/dispatcher/`.
 
 ## Cost and Resources
 
 - **Token budget granularity.** How are token budgets expressed? Per task? Per session? Per day? User-defined? Some combination?
 - **Model tier selection.** How does the system decide which model tier to use for a given task? What signals determine "this needs cloud" vs. "local is fine"?
 - **Cost reporting UX.** How is cost reported to the user in a way that's meaningful without being anxiety-inducing?
-- **Minimum hardware spec.** What's the minimum viable hardware spec for a useful local agent setup?
+- ~~**Minimum hardware spec.**~~ Resolved: Three tiers defined (minimum, recommended, optimal) with VRAM budgets. See [System Requirements](system-requirements.md).
 
 ## User Interface
 
 - ~~**Primary interface.**~~ Resolved: Chat (Claude + MCP) is the primary interface ([ADR-011](decisions/ADR-011-chat-as-interface.md)). Web dashboard handles operations ([ADR-020](decisions/ADR-020-web-dashboard.md)). See [Tech Stack](tech-stack.md).
 - **Mobile experience.** Native app, PWA, or mobile web?
 - **Developer tool integration.** How does Samverk integrate with VS Code, GitHub, etc.?
-- **Check-in digest design.** What does the check-in digest look like? How is blocked work prioritized for display?
+- ~~**Check-in digest design.**~~ Resolved: Digest format, data schema, and Go types defined. See [Check-in Digest Design](check-in-digest-design.md) and [Digest Data Schema](digest-data-schema.md).
 - **Direction input method.** How does the user provide direction asynchronously -- chat, structured forms, voice?
 
 ## Multi-Model and Providers
@@ -50,7 +50,7 @@ Problems that must be resolved before or during development.
 - **Maximum issue size.** What is the maximum useful issue size before context becomes unwieldy for agents?
 - **Code artifact handling.** How are file attachments / code artifacts handled in issues? Links to repo paths? Inline code blocks?
 - **Issue spike handling.** How does the dispatcher handle a sudden spike of 50 new issues? Priority queue design?
-- **Polling interval.** What's the right polling interval for agents watching the issue tracker? Too fast = API rate limit risk. Too slow = latency on task pickup.
+- ~~**Polling interval.**~~ Resolved: 1-minute default, configurable per forge adapter. See [Dispatcher Design](dispatcher-design.md).
 - **Webhook failure recovery.** How are webhook delivery failures handled? What's the polling fallback strategy?
 - **Forge outage handling.** How does the system handle a git forge being unreachable (self-hosted Gitea down)?
 - **Sub-task structure.** Should sub-tasks be child issues or checklist items within a parent issue? Child issues are trackable individually; checklists are simpler.
@@ -67,7 +67,7 @@ Problems that must be resolved before or during development.
 ## Autonomy and Trust
 
 - **Tier 3 block communication.** How does the system communicate a Tier 3 block to the user without creating anxiety? (The project is not broken -- one action is waiting.)
-- **Trust tier override scoping.** How are trust tier overrides scoped -- per project, per agent type, per action?
+- ~~**Trust tier override scoping.**~~ Resolved: Per-agent and per-branch overrides with full precedence chain (branch > agent > global > system default). See `internal/autonomy/` and [Autonomy Model](autonomy-model.md).
 - **Temporary tier promotion.** Can trust tiers be promoted temporarily? ("Auto-approve merges for the next 2 hours")
 - ~~**Unanticipated action classification.**~~ Partially resolved: Intent Verification Protocol (ADR-021) defines concern flagging for discovered conflicts during execution, and tier classification heuristics default to rounding UP when signals are ambiguous. Remaining question: should unclassifiable actions hard-block or default to Tier 3? See [Intent Verification Protocol](intent-verification.md).
 - **Audit log format.** What is the audit log format for Tier 1 and Tier 2 actions reviewed at check-in?
@@ -123,6 +123,6 @@ Problems that must be resolved before or during development.
 
 - ~~**V1 scope.**~~ Resolved in [ADR-018](decisions/ADR-018-release-versioning.md). Three-phase: v0.0.1 alpha, v0.1 beta, v1.0 public.
 - ~~**Hosting model.**~~ Resolved in [ADR-019](decisions/ADR-019-self-hosted-first.md). Self-hosted-first, cloud as fallback.
-- **Server platform.** Unraid vs Proxmox vs Windows for the dedicated project server. RTX 3090 Ti available. Needs research spike.
+- ~~**Server platform.**~~ Resolved: Proxmox VE selected, running at 192.168.1.203 with GPU passthrough (RTX 3090 Ti). See [Ollama VM Setup](ollama-vm-setup.md) and [Gitea Setup](gitea-setup.md).
 - **Dogfooding.** How does Samverk itself get built -- can Subnetree serve as the dogfood project?
 - **Licensing model.** What fits the target user -- subscription, usage-based, open core?

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -29,13 +29,13 @@ Can be split into separate binaries later if deployment topology demands it. Sin
 | CLI framework | `spf13/cobra` | Standard Go CLI framework, subcommand pattern |
 | GitHub API | `google/go-github/v68` | Mature, well-maintained, covers full Issues/PRs API |
 | Gitea API | `code.gitea.io/sdk/gitea` | Official SDK, mirrors GitHub API patterns |
-| Claude API | `anthropics/anthropic-sdk-go` | Official Go SDK |
-| OpenAI/GPT-4 | `sashabaranov/go-openai` | Most popular Go client, supports all endpoints |
-| Ollama (local) | Raw `net/http` | Ollama's REST API is trivial (3 endpoints). No SDK needed. |
-| Docker mgmt | `docker/docker/client` | Manage local agent containers programmatically |
-| Config (YAML) | `gopkg.in/yaml.v3` | Direct YAML parsing for `.samverk/*.yaml`. Viper is overkill -- no env var layering needed since config is file-based. |
-| Logging | `uber-go/zap` | Structured logging, fast, consistent with SubNetree |
-| SQLite | `modernc.org/sqlite` | Pure Go (no CGO required), for local state persistence |
+| Claude API | `anthropics/anthropic-sdk-go` | Official Go SDK *(Phase 2 -- not yet in go.mod)* |
+| OpenAI/GPT-4 | `sashabaranov/go-openai` | Most popular Go client, supports all endpoints *(Phase 2 -- not yet in go.mod)* |
+| Ollama (local) | Raw `net/http` | Ollama's REST API is trivial (3 endpoints). No SDK needed. **Implemented.** |
+| Docker mgmt | `docker/docker/client` | Manage local agent containers programmatically *(Phase 2 -- not yet in go.mod)* |
+| Config (YAML) | `gopkg.in/yaml.v3` | Direct YAML parsing for `.samverk/*.yaml`. Viper is overkill -- no env var layering needed since config is file-based. **Implemented.** |
+| Logging | `uber-go/zap` | Structured logging, fast, consistent with SubNetree *(Phase 2 -- not yet in go.mod)* |
+| SQLite | `modernc.org/sqlite` | Pure Go (no CGO required), for local state persistence. **Implemented.** |
 
 ### What NOT to Use
 
@@ -69,6 +69,8 @@ The chat (Claude + MCP) is the primary interface for project progress and decisi
 The React SPA is embedded in the Go binary via `embed.FS`. Single binary deployment stays intact -- no separate web server process, no CORS, no reverse proxy.
 
 ### Dashboard Scope
+
+> **Note:** Dashboard implementation is Phase 2. The sections below describe the target design; implementation starts after dispatcher and MCP server are stable.
 
 | Section | Purpose |
 |---------|---------|


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Replace "concept phase" placeholder with actual `make` commands
- **README.md**: Update status from "early concept" to "Phase 1 complete", add 5 missing doc links
- **open-questions.md**: Strikethrough 6 resolved items (task deps, hardware spec, digest design, polling interval, autonomy overrides, server platform)
- **tech-stack.md**: Add "Phase 2" callouts to unimplemented dependencies, dashboard scope note
- **mcp-server.md**: Add Phase 2 implementation status note

Also completed (outside this PR):
- Deleted 15 stale remote branches from merged/closed PRs
- Deleted 3 stale local branches
- Labeled issues #51, #52, #53 with `feat`, `type:task`, epic, priority
- Assigned issues #51-53, #57-59 to Phase 0: Foundation milestone
- Deleted 5 unused GitHub default labels (documentation, enhancement, invalid, wontfix, duplicate)

## Test plan

- [x] `make lint-md` passes (0 markdownlint errors)
- [x] Pre-push hook passes (build, test, lint, markdownlint)
- [ ] CI passes on this PR
- [ ] Verify `git branch -r` shows only `main` and this PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)