### PR TITLE
feat: implement CostSource adapter for SQLite store (#84)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge/github"
 	"github.com/herbhall/samverk/internal/server"
+	"github.com/herbhall/samverk/internal/store"
 	"github.com/herbhall/samverk/internal/version"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
@@ -69,7 +70,8 @@ func dispatchCmd() *cobra.Command {
 }
 
 func digestCmd() *cobra.Command {
-	var owner, repo, since string
+	var owner, repo, since, dbPath string
+	var budget float64
 
 	cmd := &cobra.Command{
 		Use:   "digest",
@@ -102,7 +104,19 @@ func digestCmd() *cobra.Command {
 			tracker := github.New(owner, repo, httpClient)
 			ctx := context.Background()
 
-			d, err := digest.BuildDigest(ctx, tracker, nil, lastCheckIn)
+			// Wire cost source from SQLite store if the database exists.
+			var costs digest.CostSource
+			if dbPath != "" {
+				s, storeErr := store.New(dbPath)
+				if storeErr != nil {
+					slog.Warn("could not open cost database, continuing without cost data", "path", dbPath, "error", storeErr)
+				} else {
+					defer func() { _ = s.Close() }()
+					costs = digest.NewStoreCostSource(s, budget)
+				}
+			}
+
+			d, err := digest.BuildDigest(ctx, tracker, costs, lastCheckIn)
 			if err != nil {
 				return fmt.Errorf("building digest: %w", err)
 			}
@@ -115,6 +129,8 @@ func digestCmd() *cobra.Command {
 	cmd.Flags().StringVar(&owner, "owner", "", "GitHub repository owner")
 	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository name")
 	cmd.Flags().StringVar(&since, "since", "24h", "Time window for digest (e.g., 24h, 720h)")
+	cmd.Flags().StringVar(&dbPath, "db", ".samverk/samverk.db", "Path to SQLite database for cost tracking")
+	cmd.Flags().Float64Var(&budget, "budget", 0, "Daily budget in USD (0 = unlimited)")
 
 	return cmd
 }

--- a/internal/digest/cost_adapter.go
+++ b/internal/digest/cost_adapter.go
@@ -1,0 +1,47 @@
+package digest
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/herbhall/samverk/internal/store"
+)
+
+// StoreCostSource adapts store.Store to the CostSource interface.
+type StoreCostSource struct {
+	store       store.Store
+	dailyBudget float64 // daily budget in USD, 0 means unlimited
+}
+
+// NewStoreCostSource creates a CostSource backed by the SQLite store.
+func NewStoreCostSource(s store.Store, dailyBudget float64) *StoreCostSource {
+	return &StoreCostSource{
+		store:       s,
+		dailyBudget: dailyBudget,
+	}
+}
+
+// ComputeCostSince implements CostSource by querying the store and mapping
+// models.CostSummary fields to digest.CostSummary fields.
+func (s *StoreCostSource) ComputeCostSince(ctx context.Context, since time.Time) CostSummary {
+	summary, err := s.store.ComputeCostSince(ctx, since)
+	if err != nil {
+		slog.Error("cost adapter: failed to compute cost", "error", err)
+		return CostSummary{}
+	}
+
+	result := CostSummary{
+		TokensUsed:       summary.TotalInputTokens + summary.TotalOutputTokens,
+		EstimatedCostUSD: summary.TotalCostUSD,
+	}
+
+	if s.dailyBudget > 0 {
+		result.BudgetRemainingUSD = s.dailyBudget - summary.TotalCostUSD
+		if result.BudgetRemainingUSD < 0 {
+			result.BudgetRemainingUSD = 0
+		}
+	}
+
+	return result
+}

--- a/internal/digest/cost_adapter_test.go
+++ b/internal/digest/cost_adapter_test.go
@@ -1,0 +1,178 @@
+package digest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/herbhall/samverk/internal/store"
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// newTestStoreWithSession creates an in-memory SQLite store and inserts a
+// minimal session so that cost records can satisfy the foreign key constraint.
+func newTestStoreWithSession(t *testing.T) (s *store.SQLiteStore, sessionID string) {
+	t.Helper()
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	sess := &models.Session{
+		IssueNumber: 1,
+		AgentType:   "code-gen",
+		Provider:    "claude",
+		Model:       "opus-4",
+		Status:      models.SessionStatusActive,
+		StartedAt:   time.Now().UTC(),
+	}
+	if err := s.CreateSession(context.Background(), sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return s, sess.ID
+}
+
+func TestStoreCostSource_ComputeCostSince(t *testing.T) {
+	s, sessionID := newTestStoreWithSession(t)
+	ctx := context.Background()
+
+	baseTime := time.Now().UTC().Truncate(time.Second)
+
+	// Insert two cost records.
+	records := []*models.CostRecord{
+		{
+			SessionID:    sessionID,
+			Provider:     "claude",
+			Model:        "opus-4",
+			InputTokens:  2000,
+			OutputTokens: 800,
+			CostUSD:      0.05,
+			CreatedAt:    baseTime.Add(-30 * time.Minute),
+		},
+		{
+			SessionID:    sessionID,
+			Provider:     "ollama",
+			Model:        "qwen2.5-coder:7b",
+			InputTokens:  1000,
+			OutputTokens: 200,
+			CostUSD:      0,
+			CreatedAt:    baseTime.Add(-10 * time.Minute),
+		},
+	}
+	for _, r := range records {
+		if err := s.RecordCost(ctx, r); err != nil {
+			t.Fatalf("record cost: %v", err)
+		}
+	}
+
+	src := NewStoreCostSource(s, 0)
+	since := baseTime.Add(-1 * time.Hour)
+	result := src.ComputeCostSince(ctx, since)
+
+	wantTokens := (2000 + 800) + (1000 + 200) // 4000 total
+	if result.TokensUsed != wantTokens {
+		t.Errorf("TokensUsed = %d, want %d", result.TokensUsed, wantTokens)
+	}
+	if result.EstimatedCostUSD != 0.05 {
+		t.Errorf("EstimatedCostUSD = %f, want 0.05", result.EstimatedCostUSD)
+	}
+	if result.BudgetRemainingUSD != 0 {
+		t.Errorf("BudgetRemainingUSD = %f, want 0 (unlimited budget)", result.BudgetRemainingUSD)
+	}
+}
+
+func TestStoreCostSource_WithBudget(t *testing.T) {
+	s, sessionID := newTestStoreWithSession(t)
+	ctx := context.Background()
+
+	r := &models.CostRecord{
+		SessionID:    sessionID,
+		Provider:     "claude",
+		Model:        "sonnet-4",
+		InputTokens:  5000,
+		OutputTokens: 2000,
+		CostUSD:      0.30,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := s.RecordCost(ctx, r); err != nil {
+		t.Fatalf("record cost: %v", err)
+	}
+
+	src := NewStoreCostSource(s, 1.00) // $1.00 daily budget
+	result := src.ComputeCostSince(ctx, time.Now().UTC().Add(-1*time.Hour))
+
+	if result.TokensUsed != 7000 {
+		t.Errorf("TokensUsed = %d, want 7000", result.TokensUsed)
+	}
+	if result.EstimatedCostUSD != 0.30 {
+		t.Errorf("EstimatedCostUSD = %f, want 0.30", result.EstimatedCostUSD)
+	}
+	wantRemaining := 0.70
+	if result.BudgetRemainingUSD != wantRemaining {
+		t.Errorf("BudgetRemainingUSD = %f, want %f", result.BudgetRemainingUSD, wantRemaining)
+	}
+}
+
+func TestStoreCostSource_BudgetExceeded(t *testing.T) {
+	s, sessionID := newTestStoreWithSession(t)
+	ctx := context.Background()
+
+	r := &models.CostRecord{
+		SessionID:    sessionID,
+		Provider:     "claude",
+		Model:        "opus-4",
+		InputTokens:  50000,
+		OutputTokens: 20000,
+		CostUSD:      2.50,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := s.RecordCost(ctx, r); err != nil {
+		t.Fatalf("record cost: %v", err)
+	}
+
+	src := NewStoreCostSource(s, 1.00) // $1.00 budget, $2.50 spent
+	result := src.ComputeCostSince(ctx, time.Now().UTC().Add(-1*time.Hour))
+
+	if result.BudgetRemainingUSD != 0 {
+		t.Errorf("BudgetRemainingUSD = %f, want 0 (floored at zero)", result.BudgetRemainingUSD)
+	}
+}
+
+func TestStoreCostSource_EmptyStore(t *testing.T) {
+	s, _ := newTestStoreWithSession(t)
+	ctx := context.Background()
+
+	src := NewStoreCostSource(s, 5.00)
+	result := src.ComputeCostSince(ctx, time.Now().UTC().Add(-24*time.Hour))
+
+	if result.TokensUsed != 0 {
+		t.Errorf("TokensUsed = %d, want 0", result.TokensUsed)
+	}
+	if result.EstimatedCostUSD != 0 {
+		t.Errorf("EstimatedCostUSD = %f, want 0", result.EstimatedCostUSD)
+	}
+	// With a budget but no spend, remaining should be 0 (unlimited behavior is dailyBudget=0)
+	// Wait -- with dailyBudget=5.00 and no spend, remaining = 5.00 - 0 = 5.00
+	if result.BudgetRemainingUSD != 5.00 {
+		t.Errorf("BudgetRemainingUSD = %f, want 5.00", result.BudgetRemainingUSD)
+	}
+}
+
+func TestStoreCostSource_EmptyStoreUnlimited(t *testing.T) {
+	s, _ := newTestStoreWithSession(t)
+	ctx := context.Background()
+
+	src := NewStoreCostSource(s, 0) // unlimited
+	result := src.ComputeCostSince(ctx, time.Now().UTC().Add(-24*time.Hour))
+
+	if result.TokensUsed != 0 {
+		t.Errorf("TokensUsed = %d, want 0", result.TokensUsed)
+	}
+	if result.EstimatedCostUSD != 0 {
+		t.Errorf("EstimatedCostUSD = %f, want 0", result.EstimatedCostUSD)
+	}
+	if result.BudgetRemainingUSD != 0 {
+		t.Errorf("BudgetRemainingUSD = %f, want 0 (unlimited)", result.BudgetRemainingUSD)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `StoreCostSource` adapter in `internal/digest/` that bridges `store.Store` to `digest.CostSource` interface
- Wires `--db` and `--budget` CLI flags into the `samverk digest` command for real cost data
- 5 new tests using real in-memory SQLite (token summation, budget tracking, empty store, unlimited budget)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/digest/...` -- 12 tests (7 existing + 5 new)
- [x] `golangci-lint` -- 0 issues
- [x] Pre-push hook passes (build + test + lint + markdownlint)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)