### PR TITLE
chore: fix .editorconfig inheritance from DevSpace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
-root = true
+# Inherit from D:\DevSpace\.editorconfig (DevKit standard)
+root = false
 
 [*]
 charset = utf-8


### PR DESCRIPTION
## Summary
- Change `root = true` to `root = false` in `.editorconfig`
- Enables inheritance from `D:\DevSpace\.editorconfig` (DevKit standard)
- Project-specific overrides (Go tabs, Makefile tabs, markdown trailing whitespace) preserved

## Context
DevKit compliance audit identified this as blocking DevSpace-level editor config inheritance. All other projects already use `root = false`.

Co-Authored-By: Claude <noreply@anthropic.com>