### PR TITLE
docs: reconcile README and CLAUDE.md with Phase 2 completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,15 @@ samverk/
 │   ├── api/                   # REST API handlers for dashboard
 │   ├── mcp/                   # MCP protocol handler (Streamable HTTP)
 │   ├── dispatcher/            # Issue watcher, task router, dependency DAG
+│   ├── digest/                # Check-in digest builder and formatting
 │   ├── forge/                 # IssueTracker interface + GitHub/Gitea impls
 │   ├── agent/                 # Agent runtime, container management
 │   ├── provider/              # AI provider clients (Claude, OpenAI, Ollama)
 │   ├── autonomy/              # Trust tier evaluation engine
 │   ├── profile/               # User profile management
 │   ├── cost/                  # Token tracking, budget, attribution
-│   └── store/                 # SQLite persistence layer
+│   ├── store/                 # SQLite persistence layer
+│   └── version/               # Build version injection (ldflags)
 ├── pkg/models/                # Shared types (Issue, Agent, Action, etc.)
 ├── web/                       # React SPA dashboard (Vite + TypeScript)
 ├── docs/                      # Design docs and ADRs
@@ -44,7 +46,7 @@ samverk/
 │   ├── autonomy-model.md      # Three-tier trust model for agent actions
 │   ├── user-profile.md        # Persistent user preferences across projects
 │   ├── open-questions.md      # Unresolved design and business questions
-│   └── decisions/             # Architecture Decision Records (20 so far)
+│   └── decisions/             # Architecture Decision Records (25 total)
 ├── .samverk/                  # Runtime config (gitignored)
 ├── .github/workflows/         # CI/CD pipelines
 └── Makefile                   # Build and development tasks
@@ -82,7 +84,7 @@ For full details including specific libraries, what NOT to use, and project stru
 
 ## Known Constraints
 
-- Phase 1 implementation complete -- dispatcher, forge, store, autonomy, profile, provider all functional
+- Phase 2 complete -- dispatcher, forge, store, autonomy, profile, provider, MCP handler, digest, cost adapter all functional
 - Async-first architecture (not synchronous tooling)
 - Hybrid local/cloud agent model
 - Target audience: hobbyist devs with limited time, not enterprise teams
@@ -108,6 +110,8 @@ For full details including specific libraries, what NOT to use, and project stru
 - Intent verification protocol ([ADR-021](docs/decisions/ADR-021-intent-verification.md))
 - Full project lifecycle -- idea to delivery ([ADR-022](docs/decisions/ADR-022-full-project-lifecycle.md))
 - Per-project repos with coordination layer ([ADR-023](docs/decisions/ADR-023-per-project-repos.md))
+- Failure recovery strategy ([ADR-027](docs/decisions/ADR-027-failure-recovery.md))
+- Cross-model QA validation ([ADR-030](docs/decisions/ADR-030-cross-model-qa.md))
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ Not targeting: enterprise teams, AI engineers, or full-time developers who can s
 
 ## Status
 
-**Phase 1 complete.** Core components implemented: dispatcher routing, frontmatter parser, profile store, SQLite persistence, GitHub and Gitea forge adapters, Ollama provider, autonomy policy engine. 72 tests passing across 8 packages.
+**Phase 2 complete.** Core infrastructure operational with MCP server, check-in digest, and end-to-end validation (GO decision). 118 tests passing across 11 packages.
 
-Next: Issue #11 (manual check-in prototype), then Phase 2 (MCP server, web dashboard, cloud providers).
+**Phase 1** delivered: dispatcher routing, frontmatter parser, profile store, SQLite persistence, GitHub and Gitea forge adapters, Ollama provider, autonomy policy engine.
+
+**Phase 2** delivered: HTTP server with health endpoint, MCP handler (get_digest + get_cost_summary tools via Streamable HTTP), cost tracking adapter, check-in digest prototype, label taxonomy (47 labels), front-end agent system prompt design.
+
+Next: Phase 3 -- wire remaining forge ops as MCP tools, session recording, Claude Desktop integration, authentication middleware, web dashboard.
 
 ## Related Projects
 


### PR DESCRIPTION
## Summary

- Update README.md status from Phase 1 to Phase 2 complete (118 tests, 11 packages)
- Add missing `internal/digest/` and `internal/version/` to CLAUDE.md project structure
- Update ADR count from 20 to 25, add ADR-027 and ADR-030 to key decisions
- Deleted 14 stale merged branches (2 local, 12 remote)

## Test plan

- [ ] `make ci` passes locally (verified via pre-push hook)
- [ ] All doc links resolve correctly
- [ ] No code changes -- docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)