### PR TITLE
feat: add session recording for MCP tool cost tracking

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -37,7 +37,8 @@ func main() {
 }
 
 func serveCmd() *cobra.Command {
-	var addr, owner, repo string
+	var addr, owner, repo, dbPath string
+	var budget float64
 
 	cmd := &cobra.Command{
 		Use:   "serve",
@@ -54,6 +55,21 @@ func serveCmd() *cobra.Command {
 				slog.Info("MCP authentication enabled")
 			}
 
+			// Open SQLite store for session/cost recording.
+			var costs digest.CostSource
+			var st store.Store
+			if dbPath != "" {
+				s, err := store.New(dbPath)
+				if err != nil {
+					slog.Warn("could not open database", "path", dbPath, "error", err)
+				} else {
+					st = s
+					costs = digest.NewStoreCostSource(s, budget)
+					defer func() { _ = s.Close() }()
+					slog.Info("database opened", "path", dbPath)
+				}
+			}
+
 			// Wire MCP handler if GitHub credentials are available.
 			token := os.Getenv("GITHUB_TOKEN")
 			if owner == "" {
@@ -66,7 +82,7 @@ func serveCmd() *cobra.Command {
 				ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 				httpClient := oauth2.NewClient(ctx, ts)
 				tracker := github.New(owner, repo, httpClient)
-				mcpHandler := internalmcp.NewHandler(tracker, nil)
+				mcpHandler := internalmcp.NewHandler(tracker, costs, st)
 				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
 				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
 			} else {
@@ -86,6 +102,8 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&addr, "addr", ":8080", "HTTP listen address")
 	cmd.Flags().StringVar(&owner, "owner", "", "GitHub repository owner")
 	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository name")
+	cmd.Flags().StringVar(&dbPath, "db", ".samverk/samverk.db", "Path to SQLite database for session/cost tracking")
+	cmd.Flags().Float64Var(&budget, "budget", 0, "Daily budget in USD (0 = unlimited)")
 	return cmd
 }
 

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -7,20 +7,30 @@ import (
 
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/internal/store"
 	"github.com/herbhall/samverk/internal/version"
 )
 
 // Handler holds dependencies for MCP tool handlers.
 type Handler struct {
-	tracker forge.IssueTracker
-	costs   digest.CostSource // may be nil
+	tracker  forge.IssueTracker
+	costs    digest.CostSource // may be nil
+	store    store.Store       // may be nil
+	recorder *sessionRecorder  // derived from store; nil when store is nil
 }
 
 // NewHandler creates a new MCP tool handler with its dependencies.
-func NewHandler(tracker forge.IssueTracker, costs digest.CostSource) *Handler {
+// The store parameter is optional (may be nil) for graceful degradation.
+func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Store) *Handler {
+	var rec *sessionRecorder
+	if s != nil {
+		rec = &sessionRecorder{store: s}
+	}
 	return &Handler{
-		tracker: tracker,
-		costs:   costs,
+		tracker:  tracker,
+		costs:    costs,
+		store:    s,
+		recorder: rec,
 	}
 }
 

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -161,7 +161,7 @@ type callToolResult struct {
 // newTestMCPServer sets up an httptest.Server serving the MCP handler.
 func newTestMCPServer(t *testing.T, tracker forge.IssueTracker, costs digest.CostSource) *httptest.Server {
 	t.Helper()
-	h := internalmcp.NewHandler(tracker, costs)
+	h := internalmcp.NewHandler(tracker, costs, nil)
 	handler := internalmcp.NewHTTPHandler(h)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)

--- a/internal/mcp/session.go
+++ b/internal/mcp/session.go
@@ -1,0 +1,54 @@
+package mcp
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/herbhall/samverk/internal/store"
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// sessionRecorder wraps tool calls with session/cost recording.
+type sessionRecorder struct {
+	store store.Store
+}
+
+// recordToolCall creates a session and cost record for an MCP tool invocation.
+// provider and model default to "mcp" and the tool name since the MCP server
+// doesn't know the client's model -- real token data comes from provider clients.
+func (r *sessionRecorder) recordToolCall(ctx context.Context, toolName string, issueNumber int) {
+	if r == nil || r.store == nil {
+		return
+	}
+
+	now := time.Now().UTC()
+	finished := now
+	sess := &models.Session{
+		IssueNumber: issueNumber,
+		AgentType:   "mcp-tool",
+		Provider:    "mcp",
+		Model:       toolName,
+		Status:      models.SessionStatusCompleted,
+		StartedAt:   now,
+		FinishedAt:  &finished,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := r.store.CreateSession(ctx, sess); err != nil {
+		slog.Warn("session recorder: failed to create session", "tool", toolName, "error", err)
+		return
+	}
+
+	// Record a cost entry (tokens will be 0 for MCP-side calls;
+	// real token data comes from provider clients in future).
+	cost := &models.CostRecord{
+		SessionID: sess.ID,
+		Provider:  "mcp",
+		Model:     toolName,
+	}
+	if err := r.store.RecordCost(ctx, cost); err != nil {
+		slog.Warn("session recorder: failed to record cost", "tool", toolName, "error", err)
+	}
+}

--- a/internal/mcp/session_test.go
+++ b/internal/mcp/session_test.go
@@ -1,0 +1,236 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/herbhall/samverk/internal/digest"
+	internalmcp "github.com/herbhall/samverk/internal/mcp"
+	"github.com/herbhall/samverk/internal/store"
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// newTestMCPServerWithStore sets up an httptest.Server with a real SQLite store.
+func newTestMCPServerWithStore(t *testing.T, tracker *mockTracker, costs digest.CostSource, s store.Store) *httptest.Server {
+	t.Helper()
+	h := internalmcp.NewHandler(tracker, costs, s)
+	handler := internalmcp.NewHTTPHandler(h)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestSessionRecordingNilStore(t *testing.T) {
+	// NewHandler with nil store should not panic when tools are called.
+	tracker := &mockTracker{}
+	ts := newTestMCPServerWithStore(t, tracker, nil, nil)
+
+	// Call add_label -- should succeed without recording (no panic).
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      100,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "add_label",
+			"arguments": map[string]any{
+				"issue_number": 1,
+				"label":        "test",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "test") {
+		t.Errorf("response missing label name, got %q", result.Content[0].Text)
+	}
+}
+
+func TestSessionRecordingWithStore(t *testing.T) {
+	// Create in-memory SQLite store.
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	tracker := &mockTracker{}
+	costs := digest.NewStoreCostSource(s, 0)
+	ts := newTestMCPServerWithStore(t, tracker, costs, s)
+
+	// Call add_label -- should record a session and cost entry.
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      101,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "add_label",
+			"arguments": map[string]any{
+				"issue_number": 42,
+				"label":        "enhancement",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	// Verify a session was created.
+	sessions, err := s.ListSessions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+
+	sess := sessions[0]
+	if sess.AgentType != "mcp-tool" {
+		t.Errorf("agent_type = %q, want %q", sess.AgentType, "mcp-tool")
+	}
+	if sess.Provider != "mcp" {
+		t.Errorf("provider = %q, want %q", sess.Provider, "mcp")
+	}
+	if sess.Model != "add_label" {
+		t.Errorf("model = %q, want %q", sess.Model, "add_label")
+	}
+	if sess.IssueNumber != 42 {
+		t.Errorf("issue_number = %d, want %d", sess.IssueNumber, 42)
+	}
+	if sess.Status != models.SessionStatusCompleted {
+		t.Errorf("status = %q, want %q", sess.Status, models.SessionStatusCompleted)
+	}
+	if sess.FinishedAt == nil {
+		t.Error("finished_at should not be nil")
+	}
+}
+
+func TestSessionRecordingCreateIssue(t *testing.T) {
+	// Verify create_issue uses the returned issue number for recording.
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	tracker := &mockTracker{}
+	ts := newTestMCPServerWithStore(t, tracker, nil, s)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      102,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "create_issue",
+			"arguments": map[string]any{
+				"title": "Test issue",
+				"body":  "Test body",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	// Verify the session was recorded with issue number 99 (from mock).
+	sessions, err := s.ListSessions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].IssueNumber != 99 {
+		t.Errorf("issue_number = %d, want 99 (returned by mock)", sessions[0].IssueNumber)
+	}
+	if sessions[0].Model != "create_issue" {
+		t.Errorf("model = %q, want %q", sessions[0].Model, "create_issue")
+	}
+}
+
+func TestSessionRecordingMultipleTools(t *testing.T) {
+	// Verify multiple tool calls each create their own session.
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	tracker := &mockTracker{}
+	ts := newTestMCPServerWithStore(t, tracker, nil, s)
+
+	tools := []struct {
+		name string
+		args map[string]any
+	}{
+		{"add_label", map[string]any{"issue_number": 1, "label": "bug"}},
+		{"remove_label", map[string]any{"issue_number": 2, "label": "wontfix"}},
+		{"add_comment", map[string]any{"issue_number": 3, "body": "hello"}},
+	}
+
+	for _, tool := range tools {
+		respBody := postJSON(t, ts.URL, jsonRPCRequest{
+			JSONRPC: "2.0",
+			ID:      200,
+			Method:  "tools/call",
+			Params: map[string]any{
+				"name":      tool.name,
+				"arguments": tool.args,
+			},
+		})
+
+		var resp jsonRPCResponse
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			t.Fatalf("unmarshal response for %s: %v\nbody: %s", tool.name, err, respBody)
+		}
+		if resp.Error != nil {
+			t.Fatalf("unexpected error for %s: %s", tool.name, resp.Error)
+		}
+	}
+
+	// Verify 3 sessions were created.
+	sessions, err := s.ListSessions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Fatalf("expected 3 sessions, got %d", len(sessions))
+	}
+
+	// Verify each session has the correct tool name.
+	toolNames := make(map[string]bool, len(sessions))
+	for _, sess := range sessions {
+		toolNames[sess.Model] = true
+	}
+	for _, tool := range tools {
+		if !toolNames[tool.name] {
+			t.Errorf("no session found for tool %q", tool.name)
+		}
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -124,6 +124,8 @@ func (h *Handler) handleAddLabel(
 		return nil, nil, fmt.Errorf("adding label: %w", err)
 	}
 
+	h.recorder.recordToolCall(ctx, "add_label", input.IssueNumber)
+
 	text := fmt.Sprintf("Added label %q to issue #%d", input.Label, input.IssueNumber)
 	return &gosdk.CallToolResult{
 		Content: []gosdk.Content{
@@ -148,6 +150,8 @@ func (h *Handler) handleRemoveLabel(
 	if err := h.tracker.RemoveLabel(ctx, input.IssueNumber, input.Label); err != nil {
 		return nil, nil, fmt.Errorf("removing label: %w", err)
 	}
+
+	h.recorder.recordToolCall(ctx, "remove_label", input.IssueNumber)
 
 	text := fmt.Sprintf("Removed label %q from issue #%d", input.Label, input.IssueNumber)
 	return &gosdk.CallToolResult{
@@ -174,6 +178,8 @@ func (h *Handler) handleAddComment(
 	if err != nil {
 		return nil, nil, fmt.Errorf("adding comment: %w", err)
 	}
+
+	h.recorder.recordToolCall(ctx, "add_comment", input.IssueNumber)
 
 	result, err := json.Marshal(map[string]any{
 		"comment_id":   comment.ID,
@@ -209,6 +215,8 @@ func (h *Handler) handleCreateIssue(
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating issue: %w", err)
 	}
+
+	h.recorder.recordToolCall(ctx, "create_issue", issue.Number)
 
 	result, err := json.Marshal(map[string]any{
 		"issue_number": issue.Number,


### PR DESCRIPTION
## Summary

- Wire SQLite store into MCP handler to record session and cost data for each mutating tool invocation
- Add `--db` and `--budget` flags to `samverk serve` for cost tracking configuration
- `get_cost_summary` now returns real data when store is configured
- Graceful degradation: store is optional (nil-safe throughout)

Closes #102

## Changes

- `internal/mcp/handler.go` -- add `store.Store` + `sessionRecorder` fields to Handler
- `internal/mcp/session.go` -- new nil-safe session recorder (creates session + cost record per tool call)
- `internal/mcp/session_test.go` -- 4 tests covering nil store, real store, create_issue issue number, multi-tool recording
- `internal/mcp/tools.go` -- add recording calls after successful mutating operations
- `cmd/samverk/main.go` -- add `--db`/`--budget` flags, wire store into MCP handler

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (18 packages)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [x] `golangci-lint` -- 0 issues
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)