### PR TITLE
feat: add Tier 3 approve/reject with autonomy enforcement (#112)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge/github"
 	internalmcp "github.com/herbhall/samverk/internal/mcp"
@@ -82,7 +83,16 @@ func serveCmd() *cobra.Command {
 				ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 				httpClient := oauth2.NewClient(ctx, ts)
 				tracker := github.New(owner, repo, httpClient)
-				mcpHandler := internalmcp.NewHandler(tracker, costs, st)
+
+				// Load autonomy policy for tier enforcement.
+				policyCfg, policyErr := autonomy.LoadOrDefault(".")
+				if policyErr != nil {
+					slog.Warn("could not load autonomy config, using defaults", "error", policyErr)
+					policyCfg = autonomy.DefaultConfig()
+				}
+				policy := autonomy.NewPolicy(policyCfg)
+
+				mcpHandler := internalmcp.NewHandler(tracker, costs, st, policy)
 				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
 				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
 			} else {

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -1,10 +1,13 @@
 package mcp
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/internal/store"
@@ -14,14 +17,16 @@ import (
 // Handler holds dependencies for MCP tool handlers.
 type Handler struct {
 	tracker  forge.IssueTracker
-	costs    digest.CostSource // may be nil
-	store    store.Store       // may be nil
-	recorder *sessionRecorder  // derived from store; nil when store is nil
+	costs    digest.CostSource      // may be nil
+	store    store.Store             // may be nil
+	recorder *sessionRecorder        // derived from store; nil when store is nil
+	policy   autonomy.AutonomyPolicy // may be nil (no enforcement)
+	pending  *pendingActions          // Tier 3 action queue
 }
 
 // NewHandler creates a new MCP tool handler with its dependencies.
-// The store parameter is optional (may be nil) for graceful degradation.
-func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Store) *Handler {
+// The store and policy parameters are optional (may be nil) for graceful degradation.
+func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Store, policy autonomy.AutonomyPolicy) *Handler {
 	var rec *sessionRecorder
 	if s != nil {
 		rec = &sessionRecorder{store: s}
@@ -31,6 +36,33 @@ func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Sto
 		costs:    costs,
 		store:    s,
 		recorder: rec,
+		policy:   policy,
+		pending:  newPendingActions(),
+	}
+}
+
+// checkTier evaluates the autonomy tier for an action. Returns nil if the action
+// should proceed, or a CallToolResult with confirmation_required if Tier 3.
+func (h *Handler) checkTier(actionType autonomy.ActionType, toolName string, execute func() (*gosdk.CallToolResult, error)) *gosdk.CallToolResult {
+	if h.policy == nil {
+		return nil // no policy = no enforcement
+	}
+	tier := h.policy.TierFor(actionType)
+	if tier < autonomy.Tier3 {
+		return nil // Tier 1/2: proceed
+	}
+	// Tier 3: queue for confirmation.
+	actionID := h.pending.add(toolName, execute)
+	result := map[string]any{
+		"status":    "confirmation_required",
+		"action":    toolName,
+		"tier":      3,
+		"action_id": actionID,
+		"reason":    fmt.Sprintf("%s requires user confirmation (Tier 3)", toolName),
+	}
+	resultJSON, _ := json.Marshal(result)
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{&gosdk.TextContent{Text: string(resultJSON)}},
 	}
 }
 

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge"
 	internalmcp "github.com/herbhall/samverk/internal/mcp"
@@ -195,7 +196,7 @@ type callToolResult struct {
 // newTestMCPServer sets up an httptest.Server serving the MCP handler.
 func newTestMCPServer(t *testing.T, tracker forge.IssueTracker, costs digest.CostSource) *httptest.Server {
 	t.Helper()
-	h := internalmcp.NewHandler(tracker, costs, nil)
+	h := internalmcp.NewHandler(tracker, costs, nil, nil)
 	handler := internalmcp.NewHTTPHandler(h)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
@@ -268,14 +269,15 @@ func TestToolsListDiscovery(t *testing.T) {
 		"add_label", "remove_label", "add_comment", "create_issue",
 		"list_issues", "get_issue", "update_issue",
 		"close_issue", "reopen_issue", "set_labels", "list_comments",
+		"approve_action", "reject_action",
 	}
 	for _, name := range expectedTools {
 		if !toolNames[name] {
 			t.Errorf("%s tool not found in tools/list", name)
 		}
 	}
-	if len(result.Tools) != 13 {
-		t.Errorf("expected 13 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 15 {
+		t.Errorf("expected 15 tools, got %d", len(result.Tools))
 	}
 }
 
@@ -1564,5 +1566,414 @@ func TestListCommentsToolValidation(t *testing.T) {
 				t.Error("expected isError=true for invalid input")
 			}
 		})
+	}
+}
+
+// newTestMCPServerWithPolicy sets up an httptest.Server with a specific autonomy policy.
+func newTestMCPServerWithPolicy(t *testing.T, tracker forge.IssueTracker, costs digest.CostSource, policy autonomy.AutonomyPolicy) *httptest.Server {
+	t.Helper()
+	h := internalmcp.NewHandler(tracker, costs, nil, policy)
+	handler := internalmcp.NewHTTPHandler(h)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// tier3Policy is a test policy that makes all actions Tier 3 (require confirmation).
+type tier3Policy struct{}
+
+func (p *tier3Policy) TierFor(_ autonomy.ActionType) autonomy.Tier    { return autonomy.Tier3 }
+func (p *tier3Policy) RequiresConfirmation(_ autonomy.ActionType) bool { return true }
+func (p *tier3Policy) CostThreshold() float64                         { return 5.0 }
+
+// tier1Policy is a test policy that makes all actions Tier 1 (always autonomous).
+type tier1Policy struct{}
+
+func (p *tier1Policy) TierFor(_ autonomy.ActionType) autonomy.Tier    { return autonomy.Tier1 }
+func (p *tier1Policy) RequiresConfirmation(_ autonomy.ActionType) bool { return false }
+func (p *tier1Policy) CostThreshold() float64                         { return 5.0 }
+
+func TestTierEnforcement_Tier3BlocksCloseIssue(t *testing.T) {
+	tracker := &mockTracker{
+		issues: []*forge.Issue{
+			{Number: 10, Title: "Test issue", State: forge.StateOpen},
+		},
+	}
+	ts := newTestMCPServerWithPolicy(t, tracker, nil, &tier3Policy{})
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      100,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "close_issue",
+			"arguments": map[string]any{
+				"issue_number": 10,
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+
+	// Parse the confirmation_required JSON response.
+	var confirmation map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &confirmation); err != nil {
+		t.Fatalf("expected JSON confirmation response, got %q: %v", result.Content[0].Text, err)
+	}
+
+	if confirmation["status"] != "confirmation_required" {
+		t.Errorf("status = %v, want confirmation_required", confirmation["status"])
+	}
+	if confirmation["action"] != "close_issue" {
+		t.Errorf("action = %v, want close_issue", confirmation["action"])
+	}
+	if confirmation["tier"] != float64(3) {
+		t.Errorf("tier = %v, want 3", confirmation["tier"])
+	}
+	actionID, ok := confirmation["action_id"].(string)
+	if !ok || actionID == "" {
+		t.Error("action_id should be a non-empty string")
+	}
+
+	// Verify the tracker was NOT called (action was blocked).
+	if len(tracker.updateIssueCalls) != 0 {
+		t.Errorf("expected 0 UpdateIssue calls, got %d", len(tracker.updateIssueCalls))
+	}
+}
+
+func TestTierEnforcement_NilPolicyAllowsAll(t *testing.T) {
+	tracker := &mockTracker{
+		issues: []*forge.Issue{
+			{Number: 10, Title: "Test issue", State: forge.StateOpen},
+		},
+	}
+	// nil policy = no enforcement, all actions proceed.
+	ts := newTestMCPServer(t, tracker, nil)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      101,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "close_issue",
+			"arguments": map[string]any{
+				"issue_number": 10,
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+
+	text := result.Content[0].Text
+	if !strings.Contains(text, "Closed issue #10") {
+		t.Errorf("expected 'Closed issue #10', got %q", text)
+	}
+
+	// Verify the tracker was called (action proceeded).
+	if len(tracker.updateIssueCalls) != 1 {
+		t.Errorf("expected 1 UpdateIssue call, got %d", len(tracker.updateIssueCalls))
+	}
+}
+
+func TestTierEnforcement_Tier1AllowsAll(t *testing.T) {
+	tracker := &mockTracker{
+		issues: []*forge.Issue{
+			{Number: 10, Title: "Test issue", State: forge.StateOpen},
+		},
+	}
+	ts := newTestMCPServerWithPolicy(t, tracker, nil, &tier1Policy{})
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      102,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "close_issue",
+			"arguments": map[string]any{
+				"issue_number": 10,
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+
+	text := result.Content[0].Text
+	if !strings.Contains(text, "Closed issue #10") {
+		t.Errorf("expected 'Closed issue #10', got %q", text)
+	}
+}
+
+func TestApproveAction_ExecutesPending(t *testing.T) {
+	tracker := &mockTracker{
+		issues: []*forge.Issue{
+			{Number: 10, Title: "Test issue", State: forge.StateOpen},
+		},
+	}
+	ts := newTestMCPServerWithPolicy(t, tracker, nil, &tier3Policy{})
+
+	// Step 1: Call close_issue -- should be queued.
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      110,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "close_issue",
+			"arguments": map[string]any{
+				"issue_number": 10,
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var queueResult callToolResult
+	if err := json.Unmarshal(resp.Result, &queueResult); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	var confirmation map[string]any
+	if err := json.Unmarshal([]byte(queueResult.Content[0].Text), &confirmation); err != nil {
+		t.Fatalf("unmarshal confirmation: %v", err)
+	}
+
+	actionID := confirmation["action_id"].(string)
+
+	// Step 2: Approve the action.
+	respBody = postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      111,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "approve_action",
+			"arguments": map[string]any{
+				"action_id": actionID,
+			},
+		},
+	})
+
+	var approveResp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &approveResp); err != nil {
+		t.Fatalf("unmarshal approve response: %v\nbody: %s", err, respBody)
+	}
+	if approveResp.Error != nil {
+		t.Fatalf("unexpected error on approve: %s", approveResp.Error)
+	}
+
+	var approveResult callToolResult
+	if err := json.Unmarshal(approveResp.Result, &approveResult); err != nil {
+		t.Fatalf("unmarshal approve result: %v", err)
+	}
+
+	if len(approveResult.Content) == 0 {
+		t.Fatal("expected content in approve response")
+	}
+
+	text := approveResult.Content[0].Text
+	if !strings.Contains(text, "Closed issue #10") {
+		t.Errorf("expected 'Closed issue #10' after approval, got %q", text)
+	}
+
+	// Verify the tracker was called.
+	if len(tracker.updateIssueCalls) != 1 {
+		t.Errorf("expected 1 UpdateIssue call after approval, got %d", len(tracker.updateIssueCalls))
+	}
+}
+
+func TestApproveAction_UnknownIDReturnsError(t *testing.T) {
+	tracker := &mockTracker{}
+	ts := newTestMCPServerWithPolicy(t, tracker, nil, &tier3Policy{})
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      120,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "approve_action",
+			"arguments": map[string]any{
+				"action_id": "nonexistent-id",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+
+	// Either protocol-level error or isError=true in result.
+	if resp.Error != nil {
+		return
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true for unknown action ID")
+	}
+}
+
+func TestRejectAction_RemovesPending(t *testing.T) {
+	tracker := &mockTracker{
+		issues: []*forge.Issue{
+			{Number: 10, Title: "Test issue", State: forge.StateOpen},
+		},
+	}
+	ts := newTestMCPServerWithPolicy(t, tracker, nil, &tier3Policy{})
+
+	// Step 1: Call close_issue -- should be queued.
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      130,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "close_issue",
+			"arguments": map[string]any{
+				"issue_number": 10,
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+
+	var queueResult callToolResult
+	if err := json.Unmarshal(resp.Result, &queueResult); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	var confirmation map[string]any
+	if err := json.Unmarshal([]byte(queueResult.Content[0].Text), &confirmation); err != nil {
+		t.Fatalf("unmarshal confirmation: %v", err)
+	}
+
+	actionID := confirmation["action_id"].(string)
+
+	// Step 2: Reject the action.
+	respBody = postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      131,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "reject_action",
+			"arguments": map[string]any{
+				"action_id": actionID,
+				"reason":    "not needed",
+			},
+		},
+	})
+
+	var rejectResp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &rejectResp); err != nil {
+		t.Fatalf("unmarshal reject response: %v\nbody: %s", err, respBody)
+	}
+	if rejectResp.Error != nil {
+		t.Fatalf("unexpected error on reject: %s", rejectResp.Error)
+	}
+
+	var rejectResult callToolResult
+	if err := json.Unmarshal(rejectResp.Result, &rejectResult); err != nil {
+		t.Fatalf("unmarshal reject result: %v", err)
+	}
+
+	if len(rejectResult.Content) == 0 {
+		t.Fatal("expected content in reject response")
+	}
+
+	text := rejectResult.Content[0].Text
+	if !strings.Contains(text, "rejected") {
+		t.Errorf("expected 'rejected' in response, got %q", text)
+	}
+	if !strings.Contains(text, "not needed") {
+		t.Errorf("expected rejection reason 'not needed' in response, got %q", text)
+	}
+
+	// Verify the tracker was NOT called.
+	if len(tracker.updateIssueCalls) != 0 {
+		t.Errorf("expected 0 UpdateIssue calls after rejection, got %d", len(tracker.updateIssueCalls))
+	}
+
+	// Step 3: Try to approve the same action -- should fail (already removed).
+	respBody = postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      132,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "approve_action",
+			"arguments": map[string]any{
+				"action_id": actionID,
+			},
+		},
+	})
+
+	var approveResp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &approveResp); err != nil {
+		t.Fatalf("unmarshal approve response: %v\nbody: %s", err, respBody)
+	}
+
+	if approveResp.Error != nil {
+		return // protocol-level error is acceptable
+	}
+
+	var approveResult callToolResult
+	if err := json.Unmarshal(approveResp.Result, &approveResult); err != nil {
+		t.Fatalf("unmarshal approve result: %v", err)
+	}
+	if !approveResult.IsError {
+		t.Error("expected isError=true for already-rejected action")
 	}
 }

--- a/internal/mcp/pending.go
+++ b/internal/mcp/pending.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// PendingAction represents an MCP tool call queued for user confirmation (Tier 3).
+type PendingAction struct {
+	ID        string
+	ToolName  string
+	Execute   func() (*gosdk.CallToolResult, error) // closure captures handler + input
+	CreatedAt time.Time
+}
+
+// pendingActions is a thread-safe queue for Tier 3 actions awaiting confirmation.
+type pendingActions struct {
+	mu      sync.Mutex
+	actions map[string]*PendingAction
+	ttl     time.Duration
+}
+
+// newPendingActions creates a pendingActions queue with a 1-hour default TTL.
+func newPendingActions() *pendingActions {
+	return &pendingActions{
+		actions: make(map[string]*PendingAction),
+		ttl:     time.Hour,
+	}
+}
+
+// add queues a tool call for user confirmation and returns the action ID.
+func (p *pendingActions) add(toolName string, execute func() (*gosdk.CallToolResult, error)) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	id := generateActionID()
+	p.actions[id] = &PendingAction{
+		ID:        id,
+		ToolName:  toolName,
+		Execute:   execute,
+		CreatedAt: time.Now(),
+	}
+	return id
+}
+
+// get retrieves a pending action by ID. Returns nil, false if not found or expired.
+func (p *pendingActions) get(id string) (*PendingAction, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	action, ok := p.actions[id]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(action.CreatedAt) > p.ttl {
+		delete(p.actions, id)
+		return nil, false
+	}
+	return action, true
+}
+
+// remove deletes a pending action by ID.
+func (p *pendingActions) remove(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	delete(p.actions, id)
+}
+
+// generateActionID creates a random hex ID for pending actions.
+func generateActionID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/mcp/session_test.go
+++ b/internal/mcp/session_test.go
@@ -16,7 +16,7 @@ import (
 // newTestMCPServerWithStore sets up an httptest.Server with a real SQLite store.
 func newTestMCPServerWithStore(t *testing.T, tracker *mockTracker, costs digest.CostSource, s store.Store) *httptest.Server {
 	t.Helper()
-	h := internalmcp.NewHandler(tracker, costs, s)
+	h := internalmcp.NewHandler(tracker, costs, s, nil)
 	handler := internalmcp.NewHTTPHandler(h)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 
 	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge"
 )
@@ -91,6 +92,17 @@ type listCommentsInput struct {
 	IssueNumber int `json:"issue_number" jsonschema:"required,the issue number to list comments for"`
 }
 
+// approveActionInput is the typed input for the approve_action tool.
+type approveActionInput struct {
+	ActionID string `json:"action_id" jsonschema:"required,the pending action ID to approve"`
+}
+
+// rejectActionInput is the typed input for the reject_action tool.
+type rejectActionInput struct {
+	ActionID string `json:"action_id" jsonschema:"required,the pending action ID to reject"`
+	Reason   string `json:"reason,omitempty" jsonschema:"optional reason for rejection"`
+}
+
 // registerTools adds all MCP tools to the server.
 func registerTools(srv *gosdk.Server, h *Handler) {
 	gosdk.AddTool(srv, &gosdk.Tool{
@@ -157,6 +169,16 @@ func registerTools(srv *gosdk.Server, h *Handler) {
 		Name:        "list_comments",
 		Description: "List all comments on an issue",
 	}, h.handleListComments)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "approve_action",
+		Description: "Approve a pending Tier 3 action for execution",
+	}, h.handleApproveAction)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "reject_action",
+		Description: "Reject a pending Tier 3 action",
+	}, h.handleRejectAction)
 }
 
 // handleGetDigest builds and formats a check-in digest.
@@ -198,8 +220,19 @@ func (h *Handler) handleAddLabel(
 		return nil, nil, fmt.Errorf("label must not be empty")
 	}
 
+	if result := h.checkTier(autonomy.ActionLabelIssue, "add_label", func() (*gosdk.CallToolResult, error) {
+		return h.executeAddLabel(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeAddLabel(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeAddLabel(ctx context.Context, input addLabelInput) (*gosdk.CallToolResult, error) {
 	if err := h.tracker.AddLabel(ctx, input.IssueNumber, input.Label); err != nil {
-		return nil, nil, fmt.Errorf("adding label: %w", err)
+		return nil, fmt.Errorf("adding label: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "add_label", input.IssueNumber)
@@ -209,7 +242,7 @@ func (h *Handler) handleAddLabel(
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: text},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleRemoveLabel removes a label from an issue.
@@ -225,8 +258,19 @@ func (h *Handler) handleRemoveLabel(
 		return nil, nil, fmt.Errorf("label must not be empty")
 	}
 
+	if result := h.checkTier(autonomy.ActionLabelIssue, "remove_label", func() (*gosdk.CallToolResult, error) {
+		return h.executeRemoveLabel(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeRemoveLabel(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeRemoveLabel(ctx context.Context, input removeLabelInput) (*gosdk.CallToolResult, error) {
 	if err := h.tracker.RemoveLabel(ctx, input.IssueNumber, input.Label); err != nil {
-		return nil, nil, fmt.Errorf("removing label: %w", err)
+		return nil, fmt.Errorf("removing label: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "remove_label", input.IssueNumber)
@@ -236,7 +280,7 @@ func (h *Handler) handleRemoveLabel(
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: text},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleAddComment adds a comment to an issue.
@@ -252,9 +296,20 @@ func (h *Handler) handleAddComment(
 		return nil, nil, fmt.Errorf("body must not be empty")
 	}
 
+	if result := h.checkTier(autonomy.ActionCommentIssue, "add_comment", func() (*gosdk.CallToolResult, error) {
+		return h.executeAddComment(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeAddComment(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeAddComment(ctx context.Context, input addCommentInput) (*gosdk.CallToolResult, error) {
 	comment, err := h.tracker.AddComment(ctx, input.IssueNumber, input.Body)
 	if err != nil {
-		return nil, nil, fmt.Errorf("adding comment: %w", err)
+		return nil, fmt.Errorf("adding comment: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "add_comment", input.IssueNumber)
@@ -264,14 +319,14 @@ func (h *Handler) handleAddComment(
 		"issue_number": input.IssueNumber,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("marshalling comment result: %w", err)
+		return nil, fmt.Errorf("marshalling comment result: %w", err)
 	}
 
 	return &gosdk.CallToolResult{
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: string(result)},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleCreateIssue creates a new issue on the forge.
@@ -284,6 +339,17 @@ func (h *Handler) handleCreateIssue(
 		return nil, nil, fmt.Errorf("title must not be empty")
 	}
 
+	if result := h.checkTier(autonomy.ActionOpenIssue, "create_issue", func() (*gosdk.CallToolResult, error) {
+		return h.executeCreateIssue(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeCreateIssue(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeCreateIssue(ctx context.Context, input createIssueInput) (*gosdk.CallToolResult, error) {
 	issue, err := h.tracker.CreateIssue(ctx, &forge.CreateIssueRequest{
 		Title:     input.Title,
 		Body:      input.Body,
@@ -291,7 +357,7 @@ func (h *Handler) handleCreateIssue(
 		Assignees: input.Assignees,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating issue: %w", err)
+		return nil, fmt.Errorf("creating issue: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "create_issue", issue.Number)
@@ -301,14 +367,14 @@ func (h *Handler) handleCreateIssue(
 		"title":        issue.Title,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("marshalling issue result: %w", err)
+		return nil, fmt.Errorf("marshalling issue result: %w", err)
 	}
 
 	return &gosdk.CallToolResult{
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: string(result)},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleListIssues lists issues with optional filters.
@@ -379,6 +445,17 @@ func (h *Handler) handleUpdateIssue(
 		return nil, nil, fmt.Errorf("issue_number must be greater than 0")
 	}
 
+	if result := h.checkTier(autonomy.ActionEditFile, "update_issue", func() (*gosdk.CallToolResult, error) {
+		return h.executeUpdateIssue(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeUpdateIssue(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeUpdateIssue(ctx context.Context, input updateIssueInput) (*gosdk.CallToolResult, error) {
 	req := &forge.UpdateIssueRequest{
 		Title: input.Title,
 		Body:  input.Body,
@@ -390,21 +467,21 @@ func (h *Handler) handleUpdateIssue(
 
 	issue, err := h.tracker.UpdateIssue(ctx, input.IssueNumber, req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("updating issue: %w", err)
+		return nil, fmt.Errorf("updating issue: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "update_issue", input.IssueNumber)
 
 	result, err := json.Marshal(issue)
 	if err != nil {
-		return nil, nil, fmt.Errorf("marshalling updated issue: %w", err)
+		return nil, fmt.Errorf("marshalling updated issue: %w", err)
 	}
 
 	return &gosdk.CallToolResult{
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: string(result)},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleCloseIssue is a convenience wrapper that closes an issue.
@@ -417,12 +494,23 @@ func (h *Handler) handleCloseIssue(
 		return nil, nil, fmt.Errorf("issue_number must be greater than 0")
 	}
 
+	if result := h.checkTier(autonomy.ActionCloseIssue, "close_issue", func() (*gosdk.CallToolResult, error) {
+		return h.executeCloseIssue(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeCloseIssue(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeCloseIssue(ctx context.Context, input closeIssueInput) (*gosdk.CallToolResult, error) {
 	closedState := forge.StateClosed
 	_, err := h.tracker.UpdateIssue(ctx, input.IssueNumber, &forge.UpdateIssueRequest{
 		State: &closedState,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("closing issue: %w", err)
+		return nil, fmt.Errorf("closing issue: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "close_issue", input.IssueNumber)
@@ -432,7 +520,7 @@ func (h *Handler) handleCloseIssue(
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: text},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleReopenIssue is a convenience wrapper that reopens a closed issue.
@@ -445,12 +533,23 @@ func (h *Handler) handleReopenIssue(
 		return nil, nil, fmt.Errorf("issue_number must be greater than 0")
 	}
 
+	if result := h.checkTier(autonomy.ActionCloseIssue, "reopen_issue", func() (*gosdk.CallToolResult, error) {
+		return h.executeReopenIssue(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeReopenIssue(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeReopenIssue(ctx context.Context, input reopenIssueInput) (*gosdk.CallToolResult, error) {
 	openState := forge.StateOpen
 	_, err := h.tracker.UpdateIssue(ctx, input.IssueNumber, &forge.UpdateIssueRequest{
 		State: &openState,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("reopening issue: %w", err)
+		return nil, fmt.Errorf("reopening issue: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "reopen_issue", input.IssueNumber)
@@ -460,7 +559,7 @@ func (h *Handler) handleReopenIssue(
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: text},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleSetLabels replaces all labels on an issue with the given set.
@@ -476,8 +575,19 @@ func (h *Handler) handleSetLabels(
 		return nil, nil, fmt.Errorf("labels must not be empty")
 	}
 
+	if result := h.checkTier(autonomy.ActionLabelIssue, "set_labels", func() (*gosdk.CallToolResult, error) {
+		return h.executeSetLabels(ctx, input)
+	}); result != nil {
+		return result, nil, nil
+	}
+
+	r, err := h.executeSetLabels(ctx, input)
+	return r, nil, err
+}
+
+func (h *Handler) executeSetLabels(ctx context.Context, input setLabelsInput) (*gosdk.CallToolResult, error) {
 	if err := h.tracker.SetLabels(ctx, input.IssueNumber, input.Labels); err != nil {
-		return nil, nil, fmt.Errorf("setting labels: %w", err)
+		return nil, fmt.Errorf("setting labels: %w", err)
 	}
 
 	h.recorder.recordToolCall(ctx, "set_labels", input.IssueNumber)
@@ -487,7 +597,7 @@ func (h *Handler) handleSetLabels(
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: text},
 		},
-	}, nil, nil
+	}, nil
 }
 
 // handleListComments lists all comments on an issue.
@@ -549,6 +659,60 @@ func (h *Handler) handleGetCostSummary(
 		summary.BudgetRemainingUSD,
 	)
 
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: text},
+		},
+	}, nil, nil
+}
+
+// handleApproveAction executes a pending Tier 3 action after user confirmation.
+func (h *Handler) handleApproveAction(
+	_ context.Context,
+	_ *gosdk.CallToolRequest,
+	input approveActionInput,
+) (*gosdk.CallToolResult, any, error) {
+	if input.ActionID == "" {
+		return nil, nil, fmt.Errorf("action_id must not be empty")
+	}
+
+	action, ok := h.pending.get(input.ActionID)
+	if !ok {
+		return nil, nil, fmt.Errorf("pending action %q not found or expired", input.ActionID)
+	}
+
+	h.pending.remove(input.ActionID)
+
+	result, err := action.Execute()
+	if err != nil {
+		return nil, nil, err
+	}
+	return result, nil, nil
+}
+
+// handleRejectAction removes a pending Tier 3 action without executing it.
+func (h *Handler) handleRejectAction(
+	_ context.Context,
+	_ *gosdk.CallToolRequest,
+	input rejectActionInput,
+) (*gosdk.CallToolResult, any, error) {
+	if input.ActionID == "" {
+		return nil, nil, fmt.Errorf("action_id must not be empty")
+	}
+
+	_, ok := h.pending.get(input.ActionID)
+	if !ok {
+		return nil, nil, fmt.Errorf("pending action %q not found or expired", input.ActionID)
+	}
+
+	h.pending.remove(input.ActionID)
+
+	reason := input.Reason
+	if reason == "" {
+		reason = "rejected by user"
+	}
+
+	text := fmt.Sprintf("Action %s rejected: %s", input.ActionID, reason)
 	return &gosdk.CallToolResult{
 		Content: []gosdk.Content{
 			&gosdk.TextContent{Text: text},


### PR DESCRIPTION
## Summary

- Add `approve_action` and `reject_action` MCP tools for Tier 3 confirmation workflow
- All 8 mutating handlers now check autonomy policy before execution (Tier 1/2 proceed, Tier 3 queues)
- Thread-safe pending actions queue with closure-based deferred execution and 1-hour TTL
- Wire autonomy policy loading from `.samverk/autonomy.yaml` (or defaults) in `serveCmd`

Closes #112

## Test plan

- [x] 6 new tier enforcement tests (policy mock, approve/reject flow)
- [x] All 38 MCP tests pass
- [x] Cross-compile Linux amd64
- [x] golangci-lint 0 issues

Generated with [Claude Code](https://claude.com/claude-code)