### PR TITLE
feat: add MCP repo read operations (#113)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/digest"
+	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/internal/forge/github"
 	internalmcp "github.com/herbhall/samverk/internal/mcp"
 	"github.com/herbhall/samverk/internal/server"
@@ -92,7 +93,9 @@ func serveCmd() *cobra.Command {
 				}
 				policy := autonomy.NewPolicy(policyCfg)
 
-				mcpHandler := internalmcp.NewHandler(tracker, costs, st, policy)
+				// The GitHub Client implements both IssueTracker and RepoReader.
+				var repoReader forge.RepoReader = tracker
+				mcpHandler := internalmcp.NewHandler(tracker, costs, st, policy, repoReader)
 				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
 				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
 			} else {

--- a/internal/forge/github/repo.go
+++ b/internal/forge/github/repo.go
@@ -1,0 +1,198 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gogithub "github.com/google/go-github/v68/github"
+
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+// Compile-time interface check.
+var _ forge.RepoReader = (*Client)(nil)
+
+// ListFiles returns the files and directories at the given path and ref.
+// If path is empty, the repository root is listed.
+// If ref is empty, the default branch is used.
+func (c *Client) ListFiles(ctx context.Context, path, ref string) ([]forge.FileEntry, error) {
+	opts := &gogithub.RepositoryContentGetOptions{}
+	if ref != "" {
+		opts.Ref = ref
+	}
+
+	_, dirContents, resp, err := c.gh.Repositories.GetContents(ctx, c.owner, c.repo, path, opts)
+	if err != nil {
+		return nil, fmt.Errorf("github: list files at %q: %w", path, err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	entries := make([]forge.FileEntry, 0, len(dirContents))
+	for i := range dirContents {
+		entries = append(entries, forge.FileEntry{
+			Name: dirContents[i].GetName(),
+			Path: dirContents[i].GetPath(),
+			Type: dirContents[i].GetType(),
+			Size: dirContents[i].GetSize(),
+		})
+	}
+
+	return entries, nil
+}
+
+// ReadFile returns the contents of the file at the given path and ref.
+// If ref is empty, the default branch is used.
+// Uses GetContents which returns base64-encoded content (limited to 1 MB files).
+func (c *Client) ReadFile(ctx context.Context, path, ref string) ([]byte, error) {
+	opts := &gogithub.RepositoryContentGetOptions{}
+	if ref != "" {
+		opts.Ref = ref
+	}
+
+	fileContent, _, resp, err := c.gh.Repositories.GetContents(ctx, c.owner, c.repo, path, opts)
+	if err != nil {
+		return nil, fmt.Errorf("github: read file %q: %w", path, err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	if fileContent == nil {
+		return nil, fmt.Errorf("github: %q is a directory, not a file", path)
+	}
+
+	content, err := fileContent.GetContent()
+	if err != nil {
+		return nil, fmt.Errorf("github: decode file %q content: %w", path, err)
+	}
+
+	return []byte(content), nil
+}
+
+// GetDiff returns the diff between two refs (branches, tags, or commit SHAs).
+func (c *Client) GetDiff(ctx context.Context, base, head string) (string, error) {
+	comparison, resp, err := c.gh.Repositories.CompareCommits(ctx, c.owner, c.repo, base, head, nil)
+	if err != nil {
+		return "", fmt.Errorf("github: compare %s...%s: %w", base, head, err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Comparing %s...%s\n", base, head)
+	fmt.Fprintf(&b, "Status: %s | Ahead by %d | Behind by %d\n",
+		comparison.GetStatus(), comparison.GetAheadBy(), comparison.GetBehindBy())
+	fmt.Fprintf(&b, "Total commits: %d\n\n", comparison.GetTotalCommits())
+
+	for i := range comparison.Files {
+		f := comparison.Files[i]
+		fmt.Fprintf(&b, "--- %s\n", f.GetFilename())
+		fmt.Fprintf(&b, "    Status: %s | Changes: %d (+%d -%d)\n",
+			f.GetStatus(), f.GetChanges(), f.GetAdditions(), f.GetDeletions())
+		if patch := f.GetPatch(); patch != "" {
+			fmt.Fprintf(&b, "%s\n", patch)
+		}
+	}
+
+	return b.String(), nil
+}
+
+// ListBranches returns all branches in the repository.
+func (c *Client) ListBranches(ctx context.Context) ([]forge.Branch, error) {
+	ghBranches, resp, err := c.gh.Repositories.ListBranches(ctx, c.owner, c.repo, &gogithub.BranchListOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("github: list branches: %w", err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	branches := make([]forge.Branch, 0, len(ghBranches))
+	for i := range ghBranches {
+		branch := forge.Branch{
+			Name: ghBranches[i].GetName(),
+		}
+		if commit := ghBranches[i].GetCommit(); commit != nil {
+			branch.LastCommit = commit.GetSHA()
+		}
+		branches = append(branches, branch)
+	}
+
+	return branches, nil
+}
+
+// GetCommitLog returns the most recent commits on a branch.
+// If branch is empty, "main" is used. Limit defaults to 20 if <= 0.
+func (c *Client) GetCommitLog(ctx context.Context, branch string, limit int) ([]forge.Commit, error) {
+	if branch == "" {
+		branch = "main"
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+
+	ghCommits, resp, err := c.gh.Repositories.ListCommits(ctx, c.owner, c.repo, &gogithub.CommitsListOptions{
+		SHA:         branch,
+		ListOptions: gogithub.ListOptions{PerPage: limit},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("github: list commits on %q: %w", branch, err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	commits := make([]forge.Commit, 0, len(ghCommits))
+	for i := range ghCommits {
+		commit := forge.Commit{
+			SHA: ghCommits[i].GetSHA(),
+		}
+		if gc := ghCommits[i].GetCommit(); gc != nil {
+			commit.Message = gc.GetMessage()
+			if author := gc.GetAuthor(); author != nil {
+				commit.Author = author.GetName()
+				commit.Date = author.GetDate().Time
+			}
+		}
+		commits = append(commits, commit)
+	}
+
+	return commits, nil
+}
+
+// SearchCode searches for code matching the query within this repository.
+func (c *Client) SearchCode(ctx context.Context, query string) ([]forge.SearchResult, error) {
+	scopedQuery := fmt.Sprintf("%s repo:%s/%s", query, c.owner, c.repo)
+	searchResult, resp, err := c.gh.Search.Code(ctx, scopedQuery, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github: search code %q: %w", query, err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	results := make([]forge.SearchResult, 0, len(searchResult.CodeResults))
+	for i := range searchResult.CodeResults {
+		cr := searchResult.CodeResults[i]
+		result := forge.SearchResult{
+			Path: cr.GetPath(),
+		}
+		// GitHub code search results include text_matches when requested,
+		// but the basic response includes path and name. We return what's available.
+		for j := range cr.TextMatches {
+			if cr.TextMatches[j] != nil {
+				result.Line = cr.TextMatches[j].GetFragment()
+				break
+			}
+		}
+		results = append(results, result)
+	}
+
+	return results, nil
+}

--- a/internal/forge/github/repo_test.go
+++ b/internal/forge/github/repo_test.go
@@ -1,0 +1,306 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	gogithub "github.com/google/go-github/v68/github"
+)
+
+// base64Encode is a test helper for encoding content as base64.
+func base64Encode(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestListFiles(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/contents/cmd", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, []*gogithub.RepositoryContent{
+			{
+				Name: gogithub.Ptr("main.go"),
+				Path: gogithub.Ptr("cmd/main.go"),
+				Type: gogithub.Ptr("file"),
+				Size: gogithub.Ptr(1024),
+			},
+			{
+				Name: gogithub.Ptr("util"),
+				Path: gogithub.Ptr("cmd/util"),
+				Type: gogithub.Ptr("dir"),
+				Size: gogithub.Ptr(0),
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	entries, err := c.ListFiles(context.Background(), "cmd", "")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2", len(entries))
+	}
+	if entries[0].Name != "main.go" {
+		t.Errorf("entries[0].Name = %q, want %q", entries[0].Name, "main.go")
+	}
+	if entries[0].Type != "file" {
+		t.Errorf("entries[0].Type = %q, want %q", entries[0].Type, "file")
+	}
+	if entries[1].Name != "util" {
+		t.Errorf("entries[1].Name = %q, want %q", entries[1].Name, "util")
+	}
+	if entries[1].Type != "dir" {
+		t.Errorf("entries[1].Type = %q, want %q", entries[1].Type, "dir")
+	}
+}
+
+func TestListFiles_WithRef(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/contents/", func(w http.ResponseWriter, r *http.Request) {
+		ref := r.URL.Query().Get("ref")
+		if ref != "feature-branch" {
+			t.Errorf("ref param = %q, want %q", ref, "feature-branch")
+		}
+		writeJSON(t, w, http.StatusOK, []*gogithub.RepositoryContent{
+			{
+				Name: gogithub.Ptr("README.md"),
+				Path: gogithub.Ptr("README.md"),
+				Type: gogithub.Ptr("file"),
+				Size: gogithub.Ptr(512),
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	entries, err := c.ListFiles(context.Background(), "", "feature-branch")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+}
+
+func TestReadFile(t *testing.T) {
+	fileContent := "package main\n\nfunc main() {}\n"
+	encoded := base64Encode(fileContent)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/contents/main.go", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.RepositoryContent{
+			Name:     gogithub.Ptr("main.go"),
+			Path:     gogithub.Ptr("main.go"),
+			Type:     gogithub.Ptr("file"),
+			Encoding: gogithub.Ptr("base64"),
+			Content:  gogithub.Ptr(encoded),
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	data, err := c.ReadFile(context.Background(), "main.go", "")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != fileContent {
+		t.Errorf("content = %q, want %q", string(data), fileContent)
+	}
+}
+
+func TestGetDiff(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/compare/main...feature", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.CommitsComparison{
+			Status:       gogithub.Ptr("ahead"),
+			AheadBy:      gogithub.Ptr(2),
+			BehindBy:     gogithub.Ptr(0),
+			TotalCommits: gogithub.Ptr(2),
+			Files: []*gogithub.CommitFile{
+				{
+					Filename:  gogithub.Ptr("internal/mcp/handler.go"),
+					Status:    gogithub.Ptr("modified"),
+					Changes:   gogithub.Ptr(10),
+					Additions: gogithub.Ptr(8),
+					Deletions: gogithub.Ptr(2),
+					Patch:     gogithub.Ptr("@@ -1,5 +1,13 @@\n+new code"),
+				},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	diff, err := c.GetDiff(context.Background(), "main", "feature")
+	if err != nil {
+		t.Fatalf("GetDiff: %v", err)
+	}
+	if diff == "" {
+		t.Fatal("expected non-empty diff")
+	}
+	if !strings.Contains(diff, "ahead") {
+		t.Errorf("diff missing status, got %q", diff)
+	}
+	if !strings.Contains(diff, "handler.go") {
+		t.Errorf("diff missing filename, got %q", diff)
+	}
+}
+
+func TestListBranches(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/branches", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, []*gogithub.Branch{
+			{
+				Name: gogithub.Ptr("main"),
+				Commit: &gogithub.RepositoryCommit{
+					SHA: gogithub.Ptr("abc123def456"),
+				},
+			},
+			{
+				Name: gogithub.Ptr("feature/test"),
+				Commit: &gogithub.RepositoryCommit{
+					SHA: gogithub.Ptr("789ghi012jkl"),
+				},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	branches, err := c.ListBranches(context.Background())
+	if err != nil {
+		t.Fatalf("ListBranches: %v", err)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("len(branches) = %d, want 2", len(branches))
+	}
+	if branches[0].Name != "main" {
+		t.Errorf("branches[0].Name = %q, want %q", branches[0].Name, "main")
+	}
+	if branches[0].LastCommit != "abc123def456" {
+		t.Errorf("branches[0].LastCommit = %q, want %q", branches[0].LastCommit, "abc123def456")
+	}
+	if branches[1].Name != "feature/test" {
+		t.Errorf("branches[1].Name = %q, want %q", branches[1].Name, "feature/test")
+	}
+}
+
+func TestGetCommitLog(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/commits", func(w http.ResponseWriter, r *http.Request) {
+		sha := r.URL.Query().Get("sha")
+		if sha != "main" {
+			t.Errorf("sha param = %q, want %q", sha, "main")
+		}
+		perPage := r.URL.Query().Get("per_page")
+		if perPage != "5" {
+			t.Errorf("per_page param = %q, want %q", perPage, "5")
+		}
+
+		commitDate := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+		writeJSON(t, w, http.StatusOK, []*gogithub.RepositoryCommit{
+			{
+				SHA: gogithub.Ptr("abc123"),
+				Commit: &gogithub.Commit{
+					Message: gogithub.Ptr("feat: add feature"),
+					Author: &gogithub.CommitAuthor{
+						Name: gogithub.Ptr("Developer"),
+						Date: &gogithub.Timestamp{Time: commitDate},
+					},
+				},
+			},
+			{
+				SHA: gogithub.Ptr("def456"),
+				Commit: &gogithub.Commit{
+					Message: gogithub.Ptr("fix: bug fix"),
+					Author: &gogithub.CommitAuthor{
+						Name: gogithub.Ptr("Developer"),
+						Date: &gogithub.Timestamp{Time: commitDate.Add(-time.Hour)},
+					},
+				},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	commits, err := c.GetCommitLog(context.Background(), "main", 5)
+	if err != nil {
+		t.Fatalf("GetCommitLog: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("len(commits) = %d, want 2", len(commits))
+	}
+	if commits[0].SHA != "abc123" {
+		t.Errorf("commits[0].SHA = %q, want %q", commits[0].SHA, "abc123")
+	}
+	if commits[0].Message != "feat: add feature" {
+		t.Errorf("commits[0].Message = %q, want %q", commits[0].Message, "feat: add feature")
+	}
+	if commits[0].Author != "Developer" {
+		t.Errorf("commits[0].Author = %q, want %q", commits[0].Author, "Developer")
+	}
+}
+
+func TestGetCommitLog_DefaultBranch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/commits", func(w http.ResponseWriter, r *http.Request) {
+		sha := r.URL.Query().Get("sha")
+		if sha != "main" {
+			t.Errorf("sha param = %q, want %q (default)", sha, "main")
+		}
+		writeJSON(t, w, http.StatusOK, []*gogithub.RepositoryCommit{})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.GetCommitLog(context.Background(), "", 0)
+	if err != nil {
+		t.Fatalf("GetCommitLog: %v", err)
+	}
+}
+
+func TestSearchCode(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /search/code", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if q == "" {
+			t.Error("expected non-empty query")
+		}
+		writeJSON(t, w, http.StatusOK, &gogithub.CodeSearchResult{
+			Total: gogithub.Ptr(1),
+			CodeResults: []*gogithub.CodeResult{
+				{
+					Path: gogithub.Ptr("internal/mcp/handler.go"),
+					TextMatches: []*gogithub.TextMatch{
+						{
+							Fragment: gogithub.Ptr("func NewHandler(tracker forge.IssueTracker)"),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	results, err := c.SearchCode(context.Background(), "NewHandler")
+	if err != nil {
+		t.Fatalf("SearchCode: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Path != "internal/mcp/handler.go" {
+		t.Errorf("results[0].Path = %q, want %q", results[0].Path, "internal/mcp/handler.go")
+	}
+	if results[0].Line == "" {
+		t.Error("expected non-empty line fragment")
+	}
+}
+

--- a/internal/forge/repo.go
+++ b/internal/forge/repo.go
@@ -1,0 +1,46 @@
+package forge
+
+import (
+	"context"
+	"time"
+)
+
+// RepoReader provides read-only access to a git repository's contents.
+type RepoReader interface {
+	ListFiles(ctx context.Context, path, ref string) ([]FileEntry, error)
+	ReadFile(ctx context.Context, path, ref string) ([]byte, error)
+	GetDiff(ctx context.Context, base, head string) (string, error)
+	ListBranches(ctx context.Context) ([]Branch, error)
+	GetCommitLog(ctx context.Context, branch string, limit int) ([]Commit, error)
+	SearchCode(ctx context.Context, query string) ([]SearchResult, error)
+}
+
+// FileEntry represents a single file or directory in the repository tree.
+type FileEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Type string `json:"type"` // "file", "dir", "symlink"
+	Size int    `json:"size"`
+}
+
+// Branch represents a git branch in the repository.
+type Branch struct {
+	Name       string    `json:"name"`
+	LastCommit string    `json:"last_commit"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// Commit represents a single commit in the repository log.
+type Commit struct {
+	SHA     string    `json:"sha"`
+	Message string    `json:"message"`
+	Author  string    `json:"author"`
+	Date    time.Time `json:"date"`
+}
+
+// SearchResult represents a single code search match.
+type SearchResult struct {
+	Path       string `json:"path"`
+	LineNumber int    `json:"line_number"`
+	Line       string `json:"line"`
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -22,11 +22,12 @@ type Handler struct {
 	recorder *sessionRecorder        // derived from store; nil when store is nil
 	policy   autonomy.AutonomyPolicy // may be nil (no enforcement)
 	pending  *pendingActions          // Tier 3 action queue
+	repo     forge.RepoReader        // may be nil (no repo browsing)
 }
 
 // NewHandler creates a new MCP tool handler with its dependencies.
-// The store and policy parameters are optional (may be nil) for graceful degradation.
-func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Store, policy autonomy.AutonomyPolicy) *Handler {
+// The store, policy, and repo parameters are optional (may be nil) for graceful degradation.
+func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Store, policy autonomy.AutonomyPolicy, repo forge.RepoReader) *Handler {
 	var rec *sessionRecorder
 	if s != nil {
 		rec = &sessionRecorder{store: s}
@@ -38,6 +39,7 @@ func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Sto
 		recorder: rec,
 		policy:   policy,
 		pending:  newPendingActions(),
+		repo:     repo,
 	}
 }
 
@@ -77,6 +79,7 @@ func newMCPServer(h *Handler) *gosdk.Server {
 	)
 
 	registerTools(srv, h)
+	registerRepoTools(srv, h)
 	return srv
 }
 

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -196,7 +196,7 @@ type callToolResult struct {
 // newTestMCPServer sets up an httptest.Server serving the MCP handler.
 func newTestMCPServer(t *testing.T, tracker forge.IssueTracker, costs digest.CostSource) *httptest.Server {
 	t.Helper()
-	h := internalmcp.NewHandler(tracker, costs, nil, nil)
+	h := internalmcp.NewHandler(tracker, costs, nil, nil, nil)
 	handler := internalmcp.NewHTTPHandler(h)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
@@ -270,14 +270,16 @@ func TestToolsListDiscovery(t *testing.T) {
 		"list_issues", "get_issue", "update_issue",
 		"close_issue", "reopen_issue", "set_labels", "list_comments",
 		"approve_action", "reject_action",
+		"list_files", "read_file", "get_diff", "list_branches",
+		"get_commit_log", "search_code",
 	}
 	for _, name := range expectedTools {
 		if !toolNames[name] {
 			t.Errorf("%s tool not found in tools/list", name)
 		}
 	}
-	if len(result.Tools) != 15 {
-		t.Errorf("expected 15 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 21 {
+		t.Errorf("expected 21 tools, got %d", len(result.Tools))
 	}
 }
 
@@ -1572,7 +1574,7 @@ func TestListCommentsToolValidation(t *testing.T) {
 // newTestMCPServerWithPolicy sets up an httptest.Server with a specific autonomy policy.
 func newTestMCPServerWithPolicy(t *testing.T, tracker forge.IssueTracker, costs digest.CostSource, policy autonomy.AutonomyPolicy) *httptest.Server {
 	t.Helper()
-	h := internalmcp.NewHandler(tracker, costs, nil, policy)
+	h := internalmcp.NewHandler(tracker, costs, nil, policy, nil)
 	handler := internalmcp.NewHTTPHandler(h)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)

--- a/internal/mcp/session_test.go
+++ b/internal/mcp/session_test.go
@@ -16,7 +16,7 @@ import (
 // newTestMCPServerWithStore sets up an httptest.Server with a real SQLite store.
 func newTestMCPServerWithStore(t *testing.T, tracker *mockTracker, costs digest.CostSource, s store.Store) *httptest.Server {
 	t.Helper()
-	h := internalmcp.NewHandler(tracker, costs, s, nil)
+	h := internalmcp.NewHandler(tracker, costs, s, nil, nil)
 	handler := internalmcp.NewHTTPHandler(h)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)

--- a/internal/mcp/tools_repo.go
+++ b/internal/mcp/tools_repo.go
@@ -1,0 +1,302 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// listFilesInput is the typed input for the list_files tool.
+type listFilesInput struct {
+	Path string `json:"path,omitempty" jsonschema:"repository path to list (default: root)"`
+	Ref  string `json:"ref,omitempty" jsonschema:"git ref: branch, tag, or commit SHA (default: HEAD)"`
+}
+
+// readFileInput is the typed input for the read_file tool.
+type readFileInput struct {
+	Path      string `json:"path" jsonschema:"required,file path to read"`
+	Ref       string `json:"ref,omitempty" jsonschema:"git ref: branch, tag, or commit SHA (default: HEAD)"`
+	StartLine int    `json:"start_line,omitempty" jsonschema:"first line to return (1-based, inclusive)"`
+	EndLine   int    `json:"end_line,omitempty" jsonschema:"last line to return (1-based, inclusive)"`
+}
+
+// getDiffInput is the typed input for the get_diff tool.
+type getDiffInput struct {
+	Base string `json:"base" jsonschema:"required,base ref (branch, tag, or commit SHA)"`
+	Head string `json:"head" jsonschema:"required,head ref (branch, tag, or commit SHA)"`
+}
+
+// listBranchesInput is the typed input for the list_branches tool.
+type listBranchesInput struct{}
+
+// getCommitLogInput is the typed input for the get_commit_log tool.
+type getCommitLogInput struct {
+	Branch string `json:"branch,omitempty" jsonschema:"branch name (default: main)"`
+	Limit  int    `json:"limit,omitempty" jsonschema:"max number of commits to return (default: 20)"`
+}
+
+// searchCodeInput is the typed input for the search_code tool.
+type searchCodeInput struct {
+	Query string `json:"query" jsonschema:"required,code search query"`
+}
+
+// registerRepoTools adds read-only repository browsing tools to the MCP server.
+func registerRepoTools(srv *gosdk.Server, h *Handler) {
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "list_files",
+		Description: "List files and directories at a path in the repository",
+	}, h.handleListFiles)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "read_file",
+		Description: "Read the contents of a file from the repository",
+	}, h.handleReadFile)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "get_diff",
+		Description: "Get the diff between two refs (branches, tags, or commits)",
+	}, h.handleGetDiff)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "list_branches",
+		Description: "List all branches in the repository",
+	}, h.handleListBranches)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "get_commit_log",
+		Description: "Get recent commits on a branch",
+	}, h.handleGetCommitLog)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "search_code",
+		Description: "Search for code in the repository",
+	}, h.handleSearchCode)
+}
+
+// handleListFiles lists files at a given path in the repository.
+func (h *Handler) handleListFiles(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	input listFilesInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.repo == nil {
+		return &gosdk.CallToolResult{
+			Content: []gosdk.Content{
+				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
+			},
+		}, nil, nil
+	}
+
+	entries, err := h.repo.ListFiles(ctx, input.Path, input.Ref)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing files: %w", err)
+	}
+
+	result, err := json.Marshal(entries)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshalling file entries: %w", err)
+	}
+
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: string(result)},
+		},
+	}, nil, nil
+}
+
+// handleReadFile reads a file from the repository with optional line range.
+func (h *Handler) handleReadFile(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	input readFileInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.repo == nil {
+		return &gosdk.CallToolResult{
+			Content: []gosdk.Content{
+				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
+			},
+		}, nil, nil
+	}
+
+	if input.Path == "" {
+		return nil, nil, fmt.Errorf("path must not be empty")
+	}
+
+	data, err := h.repo.ReadFile(ctx, input.Path, input.Ref)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	content := string(data)
+
+	// Apply line range if specified.
+	if input.StartLine > 0 || input.EndLine > 0 {
+		lines := strings.Split(content, "\n")
+		start := input.StartLine
+		end := input.EndLine
+
+		if start <= 0 {
+			start = 1
+		}
+		if end <= 0 || end > len(lines) {
+			end = len(lines)
+		}
+		if start > len(lines) {
+			start = len(lines)
+		}
+		if start > end {
+			start = end
+		}
+
+		// Convert to 0-based indexing.
+		content = strings.Join(lines[start-1:end], "\n")
+	}
+
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: content},
+		},
+	}, nil, nil
+}
+
+// handleGetDiff returns the diff between two refs.
+func (h *Handler) handleGetDiff(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	input getDiffInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.repo == nil {
+		return &gosdk.CallToolResult{
+			Content: []gosdk.Content{
+				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
+			},
+		}, nil, nil
+	}
+
+	if input.Base == "" {
+		return nil, nil, fmt.Errorf("base must not be empty")
+	}
+	if input.Head == "" {
+		return nil, nil, fmt.Errorf("head must not be empty")
+	}
+
+	diff, err := h.repo.GetDiff(ctx, input.Base, input.Head)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting diff: %w", err)
+	}
+
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: diff},
+		},
+	}, nil, nil
+}
+
+// handleListBranches lists all branches in the repository.
+func (h *Handler) handleListBranches(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	_ listBranchesInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.repo == nil {
+		return &gosdk.CallToolResult{
+			Content: []gosdk.Content{
+				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
+			},
+		}, nil, nil
+	}
+
+	branches, err := h.repo.ListBranches(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing branches: %w", err)
+	}
+
+	result, err := json.Marshal(branches)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshalling branches: %w", err)
+	}
+
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: string(result)},
+		},
+	}, nil, nil
+}
+
+// handleGetCommitLog returns recent commits on a branch.
+func (h *Handler) handleGetCommitLog(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	input getCommitLogInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.repo == nil {
+		return &gosdk.CallToolResult{
+			Content: []gosdk.Content{
+				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
+			},
+		}, nil, nil
+	}
+
+	branch := input.Branch
+	if branch == "" {
+		branch = "main"
+	}
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	commits, err := h.repo.GetCommitLog(ctx, branch, limit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting commit log: %w", err)
+	}
+
+	result, err := json.Marshal(commits)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshalling commits: %w", err)
+	}
+
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: string(result)},
+		},
+	}, nil, nil
+}
+
+// handleSearchCode searches for code in the repository.
+func (h *Handler) handleSearchCode(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	input searchCodeInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.repo == nil {
+		return &gosdk.CallToolResult{
+			Content: []gosdk.Content{
+				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
+			},
+		}, nil, nil
+	}
+
+	if input.Query == "" {
+		return nil, nil, fmt.Errorf("query must not be empty")
+	}
+
+	results, err := h.repo.SearchCode(ctx, input.Query)
+	if err != nil {
+		return nil, nil, fmt.Errorf("searching code: %w", err)
+	}
+
+	result, err := json.Marshal(results)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshalling search results: %w", err)
+	}
+
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: string(result)},
+		},
+	}, nil, nil
+}

--- a/internal/mcp/tools_repo_test.go
+++ b/internal/mcp/tools_repo_test.go
@@ -1,0 +1,500 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/herbhall/samverk/internal/forge"
+	internalmcp "github.com/herbhall/samverk/internal/mcp"
+)
+
+// mockRepoReader implements forge.RepoReader for testing.
+type mockRepoReader struct {
+	files    []forge.FileEntry
+	fileData []byte
+	diff     string
+	branches []forge.Branch
+	commits  []forge.Commit
+	search   []forge.SearchResult
+}
+
+func (m *mockRepoReader) ListFiles(_ context.Context, _, _ string) ([]forge.FileEntry, error) {
+	return m.files, nil
+}
+
+func (m *mockRepoReader) ReadFile(_ context.Context, _, _ string) ([]byte, error) {
+	return m.fileData, nil
+}
+
+func (m *mockRepoReader) GetDiff(_ context.Context, _, _ string) (string, error) {
+	return m.diff, nil
+}
+
+func (m *mockRepoReader) ListBranches(_ context.Context) ([]forge.Branch, error) {
+	return m.branches, nil
+}
+
+func (m *mockRepoReader) GetCommitLog(_ context.Context, _ string, _ int) ([]forge.Commit, error) {
+	return m.commits, nil
+}
+
+func (m *mockRepoReader) SearchCode(_ context.Context, _ string) ([]forge.SearchResult, error) {
+	return m.search, nil
+}
+
+// newTestMCPServerWithRepo sets up an httptest.Server with a RepoReader.
+func newTestMCPServerWithRepo(t *testing.T, tracker *mockTracker, repo forge.RepoReader) *httptest.Server {
+	t.Helper()
+	h := internalmcp.NewHandler(tracker, nil, nil, nil, repo)
+	handler := internalmcp.NewHTTPHandler(h)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestListFiles(t *testing.T) {
+	repo := &mockRepoReader{
+		files: []forge.FileEntry{
+			{Name: "main.go", Path: "cmd/main.go", Type: "file", Size: 1024},
+			{Name: "internal", Path: "internal", Type: "dir", Size: 0},
+		},
+	}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "list_files",
+			"arguments": map[string]any{
+				"path": "",
+				"ref":  "main",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "main.go") {
+		t.Errorf("response missing main.go, got %q", result.Content[0].Text)
+	}
+	if !strings.Contains(result.Content[0].Text, "internal") {
+		t.Errorf("response missing internal dir, got %q", result.Content[0].Text)
+	}
+}
+
+func TestReadFile(t *testing.T) {
+	repo := &mockRepoReader{
+		fileData: []byte("package main\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n"),
+	}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "read_file",
+			"arguments": map[string]any{
+				"path": "main.go",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "package main") {
+		t.Errorf("response missing file content, got %q", result.Content[0].Text)
+	}
+}
+
+func TestReadFile_LineRange(t *testing.T) {
+	repo := &mockRepoReader{
+		fileData: []byte("line1\nline2\nline3\nline4\nline5\n"),
+	}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      3,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "read_file",
+			"arguments": map[string]any{
+				"path":       "test.txt",
+				"start_line": 2,
+				"end_line":   4,
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "line2") || !strings.Contains(text, "line4") {
+		t.Errorf("expected lines 2-4, got %q", text)
+	}
+	if strings.Contains(text, "line1") || strings.Contains(text, "line5") {
+		t.Errorf("expected only lines 2-4, but got extra content: %q", text)
+	}
+}
+
+func TestReadFile_EmptyPath(t *testing.T) {
+	repo := &mockRepoReader{}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      4,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "read_file",
+			"arguments": map[string]any{
+				"path": "",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	// Either protocol-level error or isError=true in result.
+	if resp.Error != nil {
+		return
+	}
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true for empty path")
+	}
+}
+
+func TestGetDiff(t *testing.T) {
+	repo := &mockRepoReader{
+		diff: "Comparing main...feature\nStatus: ahead | Ahead by 3 | Behind by 0\n",
+	}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      5,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "get_diff",
+			"arguments": map[string]any{
+				"base": "main",
+				"head": "feature",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "feature") {
+		t.Errorf("response missing diff content, got %q", result.Content[0].Text)
+	}
+}
+
+func TestGetDiff_EmptyBase(t *testing.T) {
+	repo := &mockRepoReader{}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      6,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "get_diff",
+			"arguments": map[string]any{
+				"base": "",
+				"head": "feature",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	// Either protocol-level error or isError=true in result.
+	if resp.Error != nil {
+		return
+	}
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true for empty base")
+	}
+}
+
+func TestListBranches(t *testing.T) {
+	repo := &mockRepoReader{
+		branches: []forge.Branch{
+			{Name: "main", LastCommit: "abc123", UpdatedAt: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)},
+			{Name: "feature/test", LastCommit: "def456", UpdatedAt: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      7,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name":      "list_branches",
+			"arguments": map[string]any{},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "main") {
+		t.Errorf("response missing main branch, got %q", result.Content[0].Text)
+	}
+	if !strings.Contains(result.Content[0].Text, "feature/test") {
+		t.Errorf("response missing feature branch, got %q", result.Content[0].Text)
+	}
+}
+
+func TestGetCommitLog(t *testing.T) {
+	repo := &mockRepoReader{
+		commits: []forge.Commit{
+			{SHA: "abc123", Message: "feat: add widget", Author: "dev", Date: time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)},
+			{SHA: "def456", Message: "fix: typo", Author: "dev", Date: time.Date(2026, 3, 1, 11, 0, 0, 0, time.UTC)},
+		},
+	}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      8,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "get_commit_log",
+			"arguments": map[string]any{
+				"branch": "main",
+				"limit":  10,
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "abc123") {
+		t.Errorf("response missing commit SHA, got %q", result.Content[0].Text)
+	}
+	if !strings.Contains(result.Content[0].Text, "feat: add widget") {
+		t.Errorf("response missing commit message, got %q", result.Content[0].Text)
+	}
+}
+
+func TestSearchCode(t *testing.T) {
+	repo := &mockRepoReader{
+		search: []forge.SearchResult{
+			{Path: "internal/server/server.go", LineNumber: 42, Line: "func NewServer(cfg Config) *Server {"},
+		},
+	}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      9,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "search_code",
+			"arguments": map[string]any{
+				"query": "NewServer",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "server.go") {
+		t.Errorf("response missing file path, got %q", result.Content[0].Text)
+	}
+}
+
+func TestSearchCode_EmptyQuery(t *testing.T) {
+	repo := &mockRepoReader{}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      10,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "search_code",
+			"arguments": map[string]any{
+				"query": "",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	// Either protocol-level error or isError=true in result.
+	if resp.Error != nil {
+		return
+	}
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true for empty query")
+	}
+}
+
+func TestRepoToolsNilRepo(t *testing.T) {
+	// All 6 repo tools should return "not available" when repo is nil.
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, nil)
+
+	tools := []struct {
+		name string
+		args map[string]any
+	}{
+		{"list_files", map[string]any{}},
+		{"read_file", map[string]any{"path": "test.go"}},
+		{"get_diff", map[string]any{"base": "main", "head": "feature"}},
+		{"list_branches", map[string]any{}},
+		{"get_commit_log", map[string]any{}},
+		{"search_code", map[string]any{"query": "test"}},
+	}
+
+	for _, tool := range tools {
+		t.Run(tool.name, func(t *testing.T) {
+			respBody := postJSON(t, ts.URL, jsonRPCRequest{
+				JSONRPC: "2.0",
+				ID:      20,
+				Method:  "tools/call",
+				Params: map[string]any{
+					"name":      tool.name,
+					"arguments": tool.args,
+				},
+			})
+
+			var resp jsonRPCResponse
+			if err := json.Unmarshal(respBody, &resp); err != nil {
+				t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+			}
+			if resp.Error != nil {
+				t.Fatalf("unexpected error: %s", resp.Error)
+			}
+
+			var result callToolResult
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				t.Fatalf("unmarshal result: %v", err)
+			}
+			if len(result.Content) == 0 {
+				t.Fatal("expected content in response")
+			}
+			if !strings.Contains(result.Content[0].Text, "not available") {
+				t.Errorf("expected 'not available' message, got %q", result.Content[0].Text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `RepoReader` interface in `internal/forge/repo.go` with 6 methods and domain types
- GitHub implementation using go-github APIs (Contents, Branches, Commits, Search)
- 6 new MCP tools: `list_files`, `read_file`, `get_diff`, `list_branches`, `get_commit_log`, `search_code`
- All tools gracefully handle nil RepoReader (returns "not available" message)
- Wire RepoReader from GitHub tracker in main.go, update NewHandler to 5 params

Closes #113

## Test plan

- [x] 8 GitHub adapter tests with httptest mock
- [x] 11 MCP tool tests (line range slicing, validation, nil-repo degradation)
- [x] Total 21 MCP tools in discovery test
- [x] Cross-compile Linux amd64
- [x] golangci-lint 0 issues

Generated with [Claude Code](https://claude.com/claude-code)