### PR TITLE
feat: add REST API for web dashboard (#116)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/herbhall/samverk/internal/api"
 	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge"
@@ -72,7 +73,8 @@ func serveCmd() *cobra.Command {
 				}
 			}
 
-			// Wire MCP handler if GitHub credentials are available.
+			// Wire GitHub forge if credentials are available.
+			var tracker forge.IssueTracker
 			token := os.Getenv("GITHUB_TOKEN")
 			if owner == "" {
 				owner = os.Getenv("SAMVERK_GITHUB_OWNER")
@@ -83,7 +85,8 @@ func serveCmd() *cobra.Command {
 			if token != "" && owner != "" && repo != "" {
 				ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 				httpClient := oauth2.NewClient(ctx, ts)
-				tracker := github.New(owner, repo, httpClient)
+				ghClient := github.New(owner, repo, httpClient)
+				tracker = ghClient
 
 				// Load autonomy policy for tier enforcement.
 				policyCfg, policyErr := autonomy.LoadOrDefault(".")
@@ -94,13 +97,17 @@ func serveCmd() *cobra.Command {
 				policy := autonomy.NewPolicy(policyCfg)
 
 				// The GitHub Client implements both IssueTracker and RepoReader.
-				var repoReader forge.RepoReader = tracker
+				var repoReader forge.RepoReader = ghClient
 				mcpHandler := internalmcp.NewHandler(tracker, costs, st, policy, repoReader)
 				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
 				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
 			} else {
 				slog.Info("MCP handler disabled (set GITHUB_TOKEN, owner, and repo to enable)")
 			}
+
+			// Wire REST API handler for dashboard.
+			cfg.APIHandler = api.New(tracker, st, costs)
+			slog.Info("REST API enabled")
 
 			s := server.New(cfg)
 			slog.Info("starting samverk server", "addr", addr)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/herbhall/samverk/internal/digest"
+	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/internal/store"
+)
+
+// API provides REST endpoints for the web dashboard.
+type API struct {
+	tracker forge.IssueTracker // may be nil if no forge credentials
+	store   store.Store        // may be nil if no database
+	costs   digest.CostSource  // may be nil if no cost tracking
+}
+
+// New creates an API handler with the given dependencies.
+// Any dependency may be nil; endpoints that require a nil dependency
+// return 503 Service Unavailable.
+func New(tracker forge.IssueTracker, s store.Store, costs digest.CostSource) *API {
+	return &API{
+		tracker: tracker,
+		store:   s,
+		costs:   costs,
+	}
+}
+
+// RegisterRoutes registers all API endpoints on the given mux.
+// Routes use Go 1.22+ method+path patterns.
+func (a *API) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/issues", a.handleListIssues)
+	mux.HandleFunc("GET /api/v1/issues/{number}", a.handleGetIssue)
+	mux.HandleFunc("GET /api/v1/sessions", a.handleListSessions)
+	mux.HandleFunc("GET /api/v1/costs", a.handleGetCosts)
+	mux.HandleFunc("GET /api/v1/status", a.handleStatus)
+}
+
+// errorResponse is the JSON body returned for error responses.
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// writeJSON encodes v as JSON and writes it with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("api: failed to encode JSON response", "err", err)
+	}
+}
+
+// writeError writes a JSON error response with the given status code.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, errorResponse{Error: msg})
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,569 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/herbhall/samverk/internal/api"
+	"github.com/herbhall/samverk/internal/digest"
+	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/internal/store"
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// mockTracker implements forge.IssueTracker for testing.
+type mockTracker struct {
+	issues   []*forge.Issue
+	issueMap map[int]*forge.Issue
+	listErr  error
+	getErr   error
+}
+
+func newMockTracker(issues ...*forge.Issue) *mockTracker {
+	m := &mockTracker{
+		issues:   issues,
+		issueMap: make(map[int]*forge.Issue),
+	}
+	for _, iss := range issues {
+		m.issueMap[iss.Number] = iss
+	}
+	return m
+}
+
+func (m *mockTracker) ListIssues(_ context.Context, _ *forge.ListOptions) ([]*forge.Issue, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.issues, nil
+}
+
+func (m *mockTracker) GetIssue(_ context.Context, number int) (*forge.Issue, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	iss, ok := m.issueMap[number]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return iss, nil
+}
+
+func (m *mockTracker) CreateIssue(_ context.Context, _ *forge.CreateIssueRequest) (*forge.Issue, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockTracker) UpdateIssue(_ context.Context, _ int, _ *forge.UpdateIssueRequest) (*forge.Issue, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockTracker) AddComment(_ context.Context, _ int, _ string) (*forge.Comment, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockTracker) ListComments(_ context.Context, _ int) ([]*forge.Comment, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockTracker) SetLabels(_ context.Context, _ int, _ []string) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockTracker) AddLabel(_ context.Context, _ int, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockTracker) RemoveLabel(_ context.Context, _ int, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockTracker) Assign(_ context.Context, _ int, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockTracker) Unassign(_ context.Context, _ int, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockTracker) Watch(_ context.Context, _ func(forge.Event)) error {
+	return errors.New("not implemented")
+}
+
+// mockStore implements store.Store for testing.
+type mockStore struct {
+	sessions []*models.Session
+	listErr  error
+}
+
+func (m *mockStore) CreateSession(_ context.Context, _ *models.Session) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockStore) GetSession(_ context.Context, _ string) (*models.Session, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) UpdateSession(_ context.Context, _ *models.Session) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockStore) ListSessions(_ context.Context, _ models.SessionStatus) ([]*models.Session, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.sessions, nil
+}
+
+func (m *mockStore) RecordCost(_ context.Context, _ *models.CostRecord) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockStore) ComputeCostSince(_ context.Context, _ time.Time) (*models.CostSummary, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) GetBudgetStatus(_ context.Context, _ float64) (spent, remaining float64, err error) {
+	return 0, 0, errors.New("not implemented")
+}
+
+func (m *mockStore) Close() error { return nil }
+
+// Compile-time check: mockStore implements store.Store.
+var _ store.Store = (*mockStore)(nil)
+
+// mockCosts implements digest.CostSource for testing.
+type mockCosts struct {
+	summary digest.CostSummary
+}
+
+func (m *mockCosts) ComputeCostSince(_ context.Context, _ time.Time) digest.CostSummary {
+	return m.summary
+}
+
+// newTestAPI creates an API with all mocks wired and returns an httptest.Server.
+func newTestAPI(t *testing.T, tracker forge.IssueTracker, s store.Store, costs digest.CostSource) *httptest.Server {
+	t.Helper()
+	a := api.New(tracker, s, costs)
+	mux := http.NewServeMux()
+	a.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// doGet performs a GET request with context and returns the response.
+func doGet(t *testing.T, url string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("new GET request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	return resp
+}
+
+// decodeJSON decodes the response body into the given target.
+func decodeJSON(t *testing.T, resp *http.Response, target any) {
+	t.Helper()
+	defer func() { _ = resp.Body.Close() }()
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+}
+
+func TestListIssues(t *testing.T) {
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	tracker := newMockTracker(
+		&forge.Issue{Number: 1, Title: "First issue", State: forge.StateOpen, CreatedAt: now, UpdatedAt: now},
+		&forge.Issue{Number: 2, Title: "Second issue", State: forge.StateOpen, Labels: []string{"bug"}, CreatedAt: now, UpdatedAt: now},
+	)
+
+	tests := []struct {
+		name       string
+		tracker    forge.IssueTracker
+		path       string
+		wantStatus int
+		wantLen    int
+		wantError  string
+	}{
+		{
+			name:       "success with issues",
+			tracker:    tracker,
+			path:       "/api/v1/issues",
+			wantStatus: http.StatusOK,
+			wantLen:    2,
+		},
+		{
+			name:       "with query params",
+			tracker:    tracker,
+			path:       "/api/v1/issues?state=open&labels=bug&page=1&per_page=10",
+			wantStatus: http.StatusOK,
+			wantLen:    2,
+		},
+		{
+			name:       "nil tracker returns 503",
+			tracker:    nil,
+			path:       "/api/v1/issues",
+			wantStatus: http.StatusServiceUnavailable,
+			wantError:  "issue tracker not available",
+		},
+		{
+			name:       "tracker error returns 500",
+			tracker:    &mockTracker{listErr: errors.New("api rate limit")},
+			path:       "/api/v1/issues",
+			wantStatus: http.StatusInternalServerError,
+			wantError:  "failed to list issues",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestAPI(t, tt.tracker, nil, nil)
+
+			resp := doGet(t, ts.URL+tt.path)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+			}
+
+			if tt.wantError != "" {
+				var body map[string]string
+				decodeJSON(t, resp, &body)
+				if body["error"] != tt.wantError {
+					t.Errorf("error = %q, want %q", body["error"], tt.wantError)
+				}
+				return
+			}
+
+			var issues []map[string]any
+			decodeJSON(t, resp, &issues)
+			if len(issues) != tt.wantLen {
+				t.Errorf("issue count = %d, want %d", len(issues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestGetIssue(t *testing.T) {
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	tracker := newMockTracker(
+		&forge.Issue{Number: 42, Title: "Test issue", Body: "Some body", State: forge.StateOpen, CreatedAt: now, UpdatedAt: now},
+	)
+
+	tests := []struct {
+		name       string
+		tracker    forge.IssueTracker
+		path       string
+		wantStatus int
+		wantTitle  string
+		wantError  string
+	}{
+		{
+			name:       "existing issue",
+			tracker:    tracker,
+			path:       "/api/v1/issues/42",
+			wantStatus: http.StatusOK,
+			wantTitle:  "Test issue",
+		},
+		{
+			name:       "not found",
+			tracker:    tracker,
+			path:       "/api/v1/issues/999",
+			wantStatus: http.StatusNotFound,
+			wantError:  "issue not found",
+		},
+		{
+			name:       "invalid number",
+			tracker:    tracker,
+			path:       "/api/v1/issues/abc",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid issue number",
+		},
+		{
+			name:       "zero number",
+			tracker:    tracker,
+			path:       "/api/v1/issues/0",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid issue number",
+		},
+		{
+			name:       "nil tracker",
+			tracker:    nil,
+			path:       "/api/v1/issues/1",
+			wantStatus: http.StatusServiceUnavailable,
+			wantError:  "issue tracker not available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestAPI(t, tt.tracker, nil, nil)
+
+			resp := doGet(t, ts.URL+tt.path)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			if tt.wantError != "" {
+				var body map[string]string
+				decodeJSON(t, resp, &body)
+				if body["error"] != tt.wantError {
+					t.Errorf("error = %q, want %q", body["error"], tt.wantError)
+				}
+				return
+			}
+
+			var issue map[string]any
+			decodeJSON(t, resp, &issue)
+			if title, ok := issue["title"].(string); !ok || title != tt.wantTitle {
+				t.Errorf("title = %v, want %q", issue["title"], tt.wantTitle)
+			}
+		})
+	}
+}
+
+func TestListSessions(t *testing.T) {
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	ms := &mockStore{
+		sessions: []*models.Session{
+			{ID: "s1", IssueNumber: 1, AgentType: "code-gen", Provider: "ollama", Model: "qwen2.5:7b", Status: models.SessionStatusActive, StartedAt: now, CreatedAt: now, UpdatedAt: now},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		store      store.Store
+		path       string
+		wantStatus int
+		wantLen    int
+	}{
+		{
+			name:       "with sessions",
+			store:      ms,
+			path:       "/api/v1/sessions",
+			wantStatus: http.StatusOK,
+			wantLen:    1,
+		},
+		{
+			name:       "with status filter",
+			store:      ms,
+			path:       "/api/v1/sessions?status=active",
+			wantStatus: http.StatusOK,
+			wantLen:    1,
+		},
+		{
+			name:       "nil store returns empty array",
+			store:      nil,
+			path:       "/api/v1/sessions",
+			wantStatus: http.StatusOK,
+			wantLen:    0,
+		},
+		{
+			name:       "store error returns 500",
+			store:      &mockStore{listErr: errors.New("db error")},
+			path:       "/api/v1/sessions",
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestAPI(t, nil, tt.store, nil)
+
+			resp := doGet(t, ts.URL+tt.path)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var sessions []map[string]any
+				decodeJSON(t, resp, &sessions)
+				if len(sessions) != tt.wantLen {
+					t.Errorf("session count = %d, want %d", len(sessions), tt.wantLen)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCosts(t *testing.T) {
+	mc := &mockCosts{
+		summary: digest.CostSummary{
+			TokensUsed:         50000,
+			EstimatedCostUSD:   1.25,
+			BudgetRemainingUSD: 8.75,
+		},
+	}
+
+	tests := []struct {
+		name       string
+		costs      digest.CostSource
+		path       string
+		wantStatus int
+		wantTokens float64
+	}{
+		{
+			name:       "with cost data",
+			costs:      mc,
+			path:       "/api/v1/costs",
+			wantStatus: http.StatusOK,
+			wantTokens: 50000,
+		},
+		{
+			name:       "with since param",
+			costs:      mc,
+			path:       "/api/v1/costs?since=1h",
+			wantStatus: http.StatusOK,
+			wantTokens: 50000,
+		},
+		{
+			name:       "nil costs returns zeroed response",
+			costs:      nil,
+			path:       "/api/v1/costs",
+			wantStatus: http.StatusOK,
+			wantTokens: 0,
+		},
+		{
+			name:       "invalid since duration",
+			costs:      mc,
+			path:       "/api/v1/costs?since=invalid",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestAPI(t, nil, nil, tt.costs)
+
+			resp := doGet(t, ts.URL+tt.path)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var body map[string]any
+				decodeJSON(t, resp, &body)
+				tokens, _ := body["tokens_used"].(float64)
+				if tokens != tt.wantTokens {
+					t.Errorf("tokens_used = %v, want %v", tokens, tt.wantTokens)
+				}
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		tracker     forge.IssueTracker
+		store       store.Store
+		costs       digest.CostSource
+		wantHealthy bool
+		wantForge   bool
+		wantDB      bool
+	}{
+		{
+			name:        "all dependencies available",
+			tracker:     newMockTracker(),
+			store:       &mockStore{},
+			costs:       &mockCosts{},
+			wantHealthy: true,
+			wantForge:   true,
+			wantDB:      true,
+		},
+		{
+			name:        "no dependencies",
+			tracker:     nil,
+			store:       nil,
+			costs:       nil,
+			wantHealthy: false,
+			wantForge:   false,
+			wantDB:      false,
+		},
+		{
+			name:        "partial dependencies tracker only",
+			tracker:     newMockTracker(),
+			store:       nil,
+			costs:       nil,
+			wantHealthy: false,
+			wantForge:   true,
+			wantDB:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestAPI(t, tt.tracker, tt.store, tt.costs)
+
+			resp := doGet(t, ts.URL+"/api/v1/status")
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+
+			var body map[string]any
+			decodeJSON(t, resp, &body)
+
+			if healthy, ok := body["healthy"].(bool); !ok || healthy != tt.wantHealthy {
+				t.Errorf("healthy = %v, want %v", body["healthy"], tt.wantHealthy)
+			}
+			if forgeConnected, ok := body["forge_connected"].(bool); !ok || forgeConnected != tt.wantForge {
+				t.Errorf("forge_connected = %v, want %v", body["forge_connected"], tt.wantForge)
+			}
+			if dbConnected, ok := body["database_connected"].(bool); !ok || dbConnected != tt.wantDB {
+				t.Errorf("database_connected = %v, want %v", body["database_connected"], tt.wantDB)
+			}
+		})
+	}
+}
+
+func TestIssueResponseEmptySlices(t *testing.T) {
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	tracker := newMockTracker(
+		&forge.Issue{Number: 1, Title: "No labels", State: forge.StateOpen, CreatedAt: now, UpdatedAt: now},
+	)
+	ts := newTestAPI(t, tracker, nil, nil)
+
+	resp := doGet(t, ts.URL+"/api/v1/issues")
+	defer func() { _ = resp.Body.Close() }()
+
+	// Verify that nil slices are serialized as empty arrays, not null.
+	var raw json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var issues []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &issues); err != nil {
+		t.Fatalf("unmarshal issues: %v", err)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected at least one issue")
+	}
+
+	// labels and assignees should be [] not null.
+	for _, field := range []string{"labels", "assignees"} {
+		val := string(issues[0][field])
+		if val == "null" {
+			t.Errorf("%s = null, want empty array []", field)
+		}
+	}
+}

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+// issueResponse is the JSON representation of a forge issue.
+type issueResponse struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	Body      string    `json:"body"`
+	State     string    `json:"state"`
+	Labels    []string  `json:"labels"`
+	Assignees []string  `json:"assignees"`
+	CreatedAt string    `json:"created_at"`
+	UpdatedAt string    `json:"updated_at"`
+	ClosedAt  *string   `json:"closed_at,omitempty"`
+}
+
+// toIssueResponse converts a forge.Issue to the API response type.
+func toIssueResponse(iss *forge.Issue) issueResponse {
+	r := issueResponse{
+		Number:    iss.Number,
+		Title:     iss.Title,
+		Body:      iss.Body,
+		State:     string(iss.State),
+		Labels:    iss.Labels,
+		Assignees: iss.Assignees,
+		CreatedAt: iss.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		UpdatedAt: iss.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+	if iss.ClosedAt != nil {
+		s := iss.ClosedAt.Format("2006-01-02T15:04:05Z")
+		r.ClosedAt = &s
+	}
+	// Ensure nil slices are serialized as empty arrays.
+	if r.Labels == nil {
+		r.Labels = []string{}
+	}
+	if r.Assignees == nil {
+		r.Assignees = []string{}
+	}
+	return r
+}
+
+// handleListIssues handles GET /api/v1/issues.
+// Supports query params: state, labels, page, per_page.
+func (a *API) handleListIssues(w http.ResponseWriter, r *http.Request) {
+	if a.tracker == nil {
+		writeError(w, http.StatusServiceUnavailable, "issue tracker not available")
+		return
+	}
+
+	opts := &forge.ListOptions{}
+
+	if state := r.URL.Query().Get("state"); state != "" {
+		opts.State = forge.State(state)
+	} else {
+		opts.State = forge.StateOpen
+	}
+
+	if labels := r.URL.Query().Get("labels"); labels != "" {
+		opts.Labels = strings.Split(labels, ",")
+	}
+
+	if page := r.URL.Query().Get("page"); page != "" {
+		if n, err := strconv.Atoi(page); err == nil && n > 0 {
+			opts.Page = n
+		}
+	}
+
+	if perPage := r.URL.Query().Get("per_page"); perPage != "" {
+		if n, err := strconv.Atoi(perPage); err == nil && n > 0 {
+			opts.PerPage = n
+		}
+	}
+
+	issues, err := a.tracker.ListIssues(r.Context(), opts)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list issues")
+		return
+	}
+
+	resp := make([]issueResponse, 0, len(issues))
+	for _, iss := range issues {
+		resp = append(resp, toIssueResponse(iss))
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleGetIssue handles GET /api/v1/issues/{number}.
+func (a *API) handleGetIssue(w http.ResponseWriter, r *http.Request) {
+	if a.tracker == nil {
+		writeError(w, http.StatusServiceUnavailable, "issue tracker not available")
+		return
+	}
+
+	numStr := r.PathValue("number")
+	num, err := strconv.Atoi(numStr)
+	if err != nil || num < 1 {
+		writeError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	issue, err := a.tracker.GetIssue(r.Context(), num)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "issue not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toIssueResponse(issue))
+}

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// sessionResponse is the JSON representation of a session.
+type sessionResponse struct {
+	ID          string  `json:"id"`
+	IssueNumber int     `json:"issue_number"`
+	AgentType   string  `json:"agent_type"`
+	Provider    string  `json:"provider"`
+	Model       string  `json:"model"`
+	Status      string  `json:"status"`
+	StartedAt   string  `json:"started_at"`
+	FinishedAt  *string `json:"finished_at,omitempty"`
+	Error       string  `json:"error,omitempty"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+// toSessionResponse converts a models.Session to the API response type.
+func toSessionResponse(s *models.Session) sessionResponse {
+	r := sessionResponse{
+		ID:          s.ID,
+		IssueNumber: s.IssueNumber,
+		AgentType:   s.AgentType,
+		Provider:    s.Provider,
+		Model:       s.Model,
+		Status:      string(s.Status),
+		StartedAt:   s.StartedAt.Format(time.RFC3339),
+		Error:       s.Error,
+		CreatedAt:   s.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:   s.UpdatedAt.Format(time.RFC3339),
+	}
+	if s.FinishedAt != nil {
+		ts := s.FinishedAt.Format(time.RFC3339)
+		r.FinishedAt = &ts
+	}
+	return r
+}
+
+// handleListSessions handles GET /api/v1/sessions.
+// Supports query param: status (defaults to all sessions via empty status).
+func (a *API) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	if a.store == nil {
+		writeJSON(w, http.StatusOK, []sessionResponse{})
+		return
+	}
+
+	status := models.SessionStatus(r.URL.Query().Get("status"))
+
+	sessions, err := a.store.ListSessions(r.Context(), status)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list sessions")
+		return
+	}
+
+	resp := make([]sessionResponse, 0, len(sessions))
+	for _, s := range sessions {
+		resp = append(resp, toSessionResponse(s))
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// costResponse is the JSON representation of a cost summary.
+type costResponse struct {
+	TokensUsed         int     `json:"tokens_used"`
+	EstimatedCostUSD   float64 `json:"estimated_cost_usd"`
+	BudgetRemainingUSD float64 `json:"budget_remaining_usd"`
+}
+
+// handleGetCosts handles GET /api/v1/costs.
+// Supports query param: since (duration, defaults to 24h).
+func (a *API) handleGetCosts(w http.ResponseWriter, r *http.Request) {
+	if a.costs == nil {
+		writeJSON(w, http.StatusOK, costResponse{})
+		return
+	}
+
+	sinceStr := r.URL.Query().Get("since")
+	if sinceStr == "" {
+		sinceStr = "24h"
+	}
+
+	dur, err := time.ParseDuration(sinceStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid since duration")
+		return
+	}
+
+	since := time.Now().Add(-dur)
+	summary := a.costs.ComputeCostSince(r.Context(), since)
+
+	writeJSON(w, http.StatusOK, costResponse{
+		TokensUsed:         summary.TokensUsed,
+		EstimatedCostUSD:   summary.EstimatedCostUSD,
+		BudgetRemainingUSD: summary.BudgetRemainingUSD,
+	})
+}

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"net/http"
+)
+
+// statusResponse is the JSON representation of system status.
+type statusResponse struct {
+	Healthy           bool `json:"healthy"`
+	ForgeConnected    bool `json:"forge_connected"`
+	DatabaseConnected bool `json:"database_connected"`
+}
+
+// handleStatus handles GET /api/v1/status.
+// Returns the health of external dependencies.
+func (a *API) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	resp := statusResponse{
+		ForgeConnected:    a.tracker != nil,
+		DatabaseConnected: a.store != nil,
+	}
+	resp.Healthy = resp.ForgeConnected && resp.DatabaseConnected
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,11 +11,17 @@ import (
 	"time"
 )
 
+// APIRegistrar can register REST API routes on an http.ServeMux.
+type APIRegistrar interface {
+	RegisterRoutes(mux *http.ServeMux)
+}
+
 // Config holds server configuration.
 type Config struct {
-	Addr       string       // listen address, e.g. ":8080"
-	AuthToken  string       //nolint:gosec // G117: config field, not a hardcoded secret
-	MCPHandler http.Handler // optional MCP protocol handler; nil keeps the 501 placeholder
+	Addr       string         // listen address, e.g. ":8080"
+	AuthToken  string         //nolint:gosec // G117: config field, not a hardcoded secret
+	MCPHandler http.Handler   // optional MCP protocol handler; nil keeps the 501 placeholder
+	APIHandler APIRegistrar   // optional REST API handler; nil keeps the 501 placeholder
 }
 
 // Server is the main HTTP server.
@@ -119,7 +125,12 @@ func (s *Server) registerRoutes() {
 		s.mux.HandleFunc("POST /mcp", s.handleNotImplemented)
 	}
 
-	s.mux.HandleFunc("/api/v1/", s.handleNotImplemented)
+	if s.cfg.APIHandler != nil {
+		s.cfg.APIHandler.RegisterRoutes(s.mux)
+	} else {
+		s.mux.HandleFunc("/api/v1/", s.handleNotImplemented)
+	}
+
 	s.mux.HandleFunc("/", s.handleNotImplemented)
 }
 


### PR DESCRIPTION
## Summary

- Add `internal/api/` package with 5 REST endpoints for the web dashboard
- `GET /api/v1/issues` -- list issues with state/labels/pagination query params
- `GET /api/v1/issues/{number}` -- get single issue by number
- `GET /api/v1/sessions` -- list sessions with optional status filter
- `GET /api/v1/costs` -- cost summary with configurable time window (default 24h)
- `GET /api/v1/status` -- system health check (forge + database connectivity)
- Add `APIRegistrar` interface to `server.Config` for clean route registration
- Wire API handler in `main.go` -- works even without GitHub credentials (graceful nil handling)
- 16 table-driven tests covering all endpoints and edge cases

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` -- all 107 tests pass (16 new)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` cross-compile clean
- [x] `golangci-lint run ./internal/api/... ./internal/server/... ./cmd/samverk/...` -- 0 issues
- [x] Pre-push hook passes (build + test + lint + markdownlint)

Closes #116

Co-Authored-By: Claude <noreply@anthropic.com>