### PR TITLE
feat: scaffold web dashboard with React + Vite + TypeScript (#115)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ config/local/
 
 # One-time setup scripts
 setup-github.ps1
+
+# Web dashboard
+web/node_modules/
+web/dist/

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Samverk Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@samverk/dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router": "^7.0.0",
+    "@tanstack/react-query": "^5.0.0",
+    "zustand": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react-swc": "^4.0.0",
+    "typescript": "~5.7.0",
+    "vite": "^6.0.0",
+    "eslint": "^9.0.0",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/vite": "^4.0.0"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,15 @@
+import { Routes, Route } from 'react-router'
+import { Layout } from './components/Layout'
+import { Dashboard } from './pages/Dashboard'
+import { Issues } from './pages/Issues'
+
+export function App() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<Dashboard />} />
+        <Route path="issues" element={<Issues />} />
+      </Route>
+    </Routes>
+  )
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,0 +1,33 @@
+import { Outlet, NavLink } from 'react-router'
+
+export function Layout() {
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <aside className="w-56 border-r bg-white p-4">
+        <h1 className="mb-6 text-lg font-bold">Samverk</h1>
+        <nav className="space-y-1">
+          <NavLink
+            to="/"
+            end
+            className={({ isActive }) =>
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+            }
+          >
+            Dashboard
+          </NavLink>
+          <NavLink
+            to="/issues"
+            className={({ isActive }) =>
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+            }
+          >
+            Issues
+          </NavLink>
+        </nav>
+      </aside>
+      <main className="flex-1 overflow-auto p-6">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,70 @@
+const BASE = '/api/v1'
+
+async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`API ${res.status}: ${body}`)
+  }
+  return res.json()
+}
+
+export interface Issue {
+  number: number
+  title: string
+  body: string
+  state: string
+  labels: string[]
+  assignees: string[]
+  created_at: string
+  updated_at: string
+  closed_at: string | null
+}
+
+export interface Session {
+  id: string
+  issue_number: number
+  agent_type: string
+  provider: string
+  model: string
+  status: string
+  started_at: string
+  finished_at: string | null
+}
+
+export interface CostSummary {
+  total_cost_usd: number
+  total_input_tokens: number
+  total_output_tokens: number
+  record_count: number
+}
+
+export interface SystemStatus {
+  healthy: boolean
+  github_connected: boolean
+  database_connected: boolean
+  tool_count: number
+}
+
+export const api = {
+  listIssues: (params?: { state?: string; page?: number }) =>
+    fetchJSON<Issue[]>(`/issues${params ? '?' + new URLSearchParams(params as Record<string, string>).toString() : ''}`),
+
+  getIssue: (number: number) =>
+    fetchJSON<Issue>(`/issues/${number}`),
+
+  listSessions: () =>
+    fetchJSON<Session[]>('/sessions'),
+
+  getCosts: () =>
+    fetchJSON<CostSummary>('/costs'),
+
+  getStatus: () =>
+    fetchJSON<SystemStatus>('/status'),
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,1 @@
+export type { Issue, Session, CostSummary, SystemStatus } from './api'

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,25 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { App } from './App'
+import './index.css'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+    },
+  },
+})
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </StrictMode>,
+)

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,0 +1,8 @@
+export function Dashboard() {
+  return (
+    <div>
+      <h2 className="mb-4 text-2xl font-bold">Dashboard</h2>
+      <p className="text-gray-600">Project overview will appear here.</p>
+    </div>
+  )
+}

--- a/web/src/pages/Issues.tsx
+++ b/web/src/pages/Issues.tsx
@@ -1,0 +1,8 @@
+export function Issues() {
+  return (
+    <div>
+      <h2 className="mb-4 text-2xl font-bold">Issues</h2>
+      <p className="text-gray-600">Issue tracker will appear here.</p>
+    </div>
+  )
+}

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tsc/tsconfig.app.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tsc/tsconfig.node.tsbuildinfo",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+      '/mcp': 'http://localhost:8080',
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+})


### PR DESCRIPTION
## Summary

- Create `web/` directory with React 19 + Vite 6 + TypeScript SPA scaffold
- React Router for client-side routing (Dashboard + Issues pages)
- TanStack Query v5 for server state, Zustand v5 for client state
- Tailwind CSS v4 via `@tailwindcss/vite` plugin
- Typed fetch wrapper for `/api/v1/` endpoints matching Go API response types
- Vite dev proxy to Go backend on `:8080`
- Layout shell with sidebar navigation
- Add `web/node_modules/` and `web/dist/` to `.gitignore`

Note: This is the frontend scaffold only. No `pnpm install` or build step yet -- that requires Node.js in the build pipeline. The Go embed directive will be added in a follow-up when the frontend build is integrated.

## Test plan

- [x] `go build ./...` passes (no Go changes beyond .gitignore)
- [x] `go test ./...` -- all 107 tests pass
- [x] Pre-push hook passes (build + test + lint + markdownlint)
- [x] TypeScript files follow React 19 + Vite 6 conventions
- [x] API client types match Go response structs

Closes #115

Co-Authored-By: Claude <noreply@anthropic.com>