### PR TITLE
feat: add multi-project support (#114)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -41,7 +41,7 @@ func main() {
 }
 
 func serveCmd() *cobra.Command {
-	var addr, owner, repo, dbPath string
+	var addr, owner, repo, dbPath, projectsConfig string
 	var budget float64
 
 	cmd := &cobra.Command{
@@ -100,6 +100,53 @@ func serveCmd() *cobra.Command {
 				// The GitHub Client implements both IssueTracker and RepoReader.
 				var repoReader forge.RepoReader = ghClient
 				mcpHandler := internalmcp.NewHandler(tracker, costs, st, policy, repoReader)
+
+				// Wire multi-project support.
+				registry := internalmcp.NewProjectRegistry()
+
+				// Register the default project from --owner/--repo flags.
+				defaultProject := &internalmcp.Project{
+					Name:    repo,
+					Owner:   owner,
+					Repo:    repo,
+					Tracker: tracker,
+					Reader:  repoReader,
+				}
+				if regErr := registry.Register(defaultProject); regErr != nil {
+					slog.Warn("could not register default project", "error", regErr)
+				}
+
+				// Load additional projects from config file if it exists.
+				if projectsConfig != "" {
+					if configs, loadErr := internalmcp.LoadProjectConfig(projectsConfig); loadErr == nil {
+						for _, pc := range configs {
+							// Skip if already registered as the default.
+							if pc.Name == repo && pc.Owner == owner && pc.Repo == repo {
+								continue
+							}
+							ghExtra := github.New(pc.Owner, pc.Repo, httpClient)
+							p := &internalmcp.Project{
+								Name:    pc.Name,
+								Owner:   pc.Owner,
+								Repo:    pc.Repo,
+								Tracker: ghExtra,
+								Reader:  ghExtra,
+							}
+							if regErr := registry.Register(p); regErr != nil {
+								slog.Warn("could not register project from config",
+									"name", pc.Name, "error", regErr)
+							} else {
+								slog.Info("registered project from config",
+									"name", pc.Name, "owner", pc.Owner, "repo", pc.Repo)
+							}
+						}
+					} else if !os.IsNotExist(loadErr) {
+						slog.Warn("could not load projects config",
+							"path", projectsConfig, "error", loadErr)
+					}
+				}
+
+				mcpHandler.SetProjects(registry)
 				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
 				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
 			} else {
@@ -124,6 +171,7 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&owner, "owner", "", "GitHub repository owner")
 	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository name")
 	cmd.Flags().StringVar(&dbPath, "db", ".samverk/samverk.db", "Path to SQLite database for session/cost tracking")
+	cmd.Flags().StringVar(&projectsConfig, "projects-config", ".samverk/server.yaml", "Path to multi-project YAML config")
 	cmd.Flags().Float64Var(&budget, "budget", 0, "Daily budget in USD (0 = unlimited)")
 	return cmd
 }

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -23,6 +23,7 @@ type Handler struct {
 	policy   autonomy.AutonomyPolicy // may be nil (no enforcement)
 	pending  *pendingActions          // Tier 3 action queue
 	repo     forge.RepoReader        // may be nil (no repo browsing)
+	projects *ProjectRegistry        // may be nil (single-project mode)
 }
 
 // NewHandler creates a new MCP tool handler with its dependencies.
@@ -41,6 +42,38 @@ func NewHandler(tracker forge.IssueTracker, costs digest.CostSource, s store.Sto
 		pending:  newPendingActions(),
 		repo:     repo,
 	}
+}
+
+// SetProjects attaches a project registry to the handler for multi-project support.
+// When set, tools resolve tracker and repo through the active project.
+func (h *Handler) SetProjects(reg *ProjectRegistry) {
+	h.projects = reg
+}
+
+// activeTracker returns the IssueTracker to use for the current context.
+// If a project registry is configured, it uses the active project's tracker.
+// Otherwise, it falls back to the handler's directly-configured tracker.
+func (h *Handler) activeTracker() forge.IssueTracker {
+	if h.projects != nil {
+		p, err := h.projects.Active()
+		if err == nil && p.Tracker != nil {
+			return p.Tracker
+		}
+	}
+	return h.tracker
+}
+
+// activeReader returns the RepoReader to use for the current context.
+// If a project registry is configured, it uses the active project's reader.
+// Otherwise, it falls back to the handler's directly-configured reader.
+func (h *Handler) activeReader() forge.RepoReader {
+	if h.projects != nil {
+		p, err := h.projects.Active()
+		if err == nil && p.Reader != nil {
+			return p.Reader
+		}
+	}
+	return h.repo
 }
 
 // checkTier evaluates the autonomy tier for an action. Returns nil if the action
@@ -80,6 +113,7 @@ func newMCPServer(h *Handler) *gosdk.Server {
 
 	registerTools(srv, h)
 	registerRepoTools(srv, h)
+	registerProjectTools(srv, h)
 	return srv
 }
 

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -272,14 +272,15 @@ func TestToolsListDiscovery(t *testing.T) {
 		"approve_action", "reject_action",
 		"list_files", "read_file", "get_diff", "list_branches",
 		"get_commit_log", "search_code",
+		"list_projects", "set_project",
 	}
 	for _, name := range expectedTools {
 		if !toolNames[name] {
 			t.Errorf("%s tool not found in tools/list", name)
 		}
 	}
-	if len(result.Tools) != 21 {
-		t.Errorf("expected 21 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 23 {
+		t.Errorf("expected 23 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -1,0 +1,164 @@
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/herbhall/samverk/internal/forge"
+	"gopkg.in/yaml.v3"
+)
+
+// Project represents a registered project with its forge connection.
+type Project struct {
+	Name    string             `json:"name" yaml:"name"`
+	Owner   string             `json:"owner" yaml:"owner"`
+	Repo    string             `json:"repo" yaml:"repo"`
+	Tracker forge.IssueTracker `json:"-" yaml:"-"`
+	Reader  forge.RepoReader   `json:"-" yaml:"-"`
+}
+
+// ProjectRegistry manages the set of available projects.
+type ProjectRegistry struct {
+	mu       sync.RWMutex
+	projects map[string]*Project
+	active   string // name of the currently active project
+}
+
+// NewProjectRegistry creates a new empty project registry.
+func NewProjectRegistry() *ProjectRegistry {
+	return &ProjectRegistry{
+		projects: make(map[string]*Project),
+	}
+}
+
+// Register adds a project to the registry. Returns an error if the name is
+// empty or already registered. The first registered project becomes active.
+func (r *ProjectRegistry) Register(p *Project) error {
+	if p.Name == "" {
+		return fmt.Errorf("project name must not be empty")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.projects[p.Name]; exists {
+		return fmt.Errorf("project %q is already registered", p.Name)
+	}
+
+	r.projects[p.Name] = p
+
+	// First registered project becomes active automatically.
+	if r.active == "" {
+		r.active = p.Name
+	}
+
+	return nil
+}
+
+// SetActive switches the active project context.
+// Returns an error if the named project is not registered.
+func (r *ProjectRegistry) SetActive(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.projects[name]; !exists {
+		return fmt.Errorf("project %q not found", name)
+	}
+
+	r.active = name
+	return nil
+}
+
+// Active returns the currently active project.
+// Returns an error if no projects are registered or no project is active.
+func (r *ProjectRegistry) Active() (*Project, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.projects) == 0 {
+		return nil, fmt.Errorf("no projects registered")
+	}
+
+	p, exists := r.projects[r.active]
+	if !exists {
+		return nil, fmt.Errorf("active project %q not found in registry", r.active)
+	}
+
+	return p, nil
+}
+
+// List returns all registered projects sorted by name.
+func (r *ProjectRegistry) List() []*Project {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*Project, 0, len(r.projects))
+	for _, p := range r.projects {
+		result = append(result, p)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+// Get retrieves a project by name.
+func (r *ProjectRegistry) Get(name string) (*Project, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	p, exists := r.projects[name]
+	return p, exists
+}
+
+// ActiveName returns the name of the currently active project.
+func (r *ProjectRegistry) ActiveName() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.active
+}
+
+// ProjectConfig is the YAML-serializable configuration for a project.
+type ProjectConfig struct {
+	Name  string `yaml:"name"`
+	Owner string `yaml:"owner"`
+	Repo  string `yaml:"repo"`
+}
+
+// projectsFileConfig is the top-level YAML structure for the projects config file.
+type projectsFileConfig struct {
+	Projects []ProjectConfig `yaml:"projects"`
+}
+
+// LoadProjectConfig reads and parses a YAML projects configuration file.
+func LoadProjectConfig(path string) ([]ProjectConfig, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is from trusted CLI flag
+	if err != nil {
+		return nil, fmt.Errorf("reading project config %s: %w", path, err)
+	}
+
+	var cfg projectsFileConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing project config %s: %w", path, err)
+	}
+
+	// Validate each project entry.
+	for i, p := range cfg.Projects {
+		if p.Name == "" {
+			return nil, fmt.Errorf("project at index %d: name is required", i)
+		}
+		if p.Owner == "" {
+			return nil, fmt.Errorf("project %q: owner is required", p.Name)
+		}
+		if p.Repo == "" {
+			return nil, fmt.Errorf("project %q: repo is required", p.Name)
+		}
+	}
+
+	return cfg.Projects, nil
+}

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -1,0 +1,546 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	internalmcp "github.com/herbhall/samverk/internal/mcp"
+)
+
+// newHTTPTestServer wraps an http.Handler in an httptest.Server with cleanup.
+func newHTTPTestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestProjectRegistry_RegisterAndList(t *testing.T) {
+	tests := []struct {
+		name     string
+		projects []*internalmcp.Project
+		wantLen  int
+		wantErr  bool
+	}{
+		{
+			name: "register single project",
+			projects: []*internalmcp.Project{
+				{Name: "alpha", Owner: "org", Repo: "alpha"},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "register multiple projects",
+			projects: []*internalmcp.Project{
+				{Name: "alpha", Owner: "org", Repo: "alpha"},
+				{Name: "beta", Owner: "org", Repo: "beta"},
+				{Name: "gamma", Owner: "org", Repo: "gamma"},
+			},
+			wantLen: 3,
+		},
+		{
+			name: "duplicate name returns error",
+			projects: []*internalmcp.Project{
+				{Name: "alpha", Owner: "org", Repo: "alpha"},
+				{Name: "alpha", Owner: "org", Repo: "alpha-2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty name returns error",
+			projects: []*internalmcp.Project{
+				{Name: "", Owner: "org", Repo: "alpha"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := internalmcp.NewProjectRegistry()
+			var lastErr error
+			for _, p := range tc.projects {
+				if err := reg.Register(p); err != nil {
+					lastErr = err
+				}
+			}
+
+			if tc.wantErr {
+				if lastErr == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if lastErr != nil {
+				t.Fatalf("unexpected error: %v", lastErr)
+			}
+
+			list := reg.List()
+			if len(list) != tc.wantLen {
+				t.Errorf("want %d projects, got %d", tc.wantLen, len(list))
+			}
+
+			// Verify list is sorted by name.
+			for i := 1; i < len(list); i++ {
+				if list[i-1].Name >= list[i].Name {
+					t.Errorf("list not sorted: %q >= %q at index %d", list[i-1].Name, list[i].Name, i)
+				}
+			}
+		})
+	}
+}
+
+func TestProjectRegistry_SetActive(t *testing.T) {
+	reg := internalmcp.NewProjectRegistry()
+	_ = reg.Register(&internalmcp.Project{Name: "alpha", Owner: "org", Repo: "alpha"})
+	_ = reg.Register(&internalmcp.Project{Name: "beta", Owner: "org", Repo: "beta"})
+
+	// First registered project should be active by default.
+	active, err := reg.Active()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active.Name != "alpha" {
+		t.Errorf("expected default active to be %q, got %q", "alpha", active.Name)
+	}
+
+	// Switch to beta.
+	if err := reg.SetActive("beta"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	active, err = reg.Active()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active.Name != "beta" {
+		t.Errorf("expected active to be %q, got %q", "beta", active.Name)
+	}
+
+	// Switch back to alpha.
+	if err := reg.SetActive("alpha"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	active, err = reg.Active()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active.Name != "alpha" {
+		t.Errorf("expected active to be %q, got %q", "alpha", active.Name)
+	}
+}
+
+func TestProjectRegistry_SetActive_NotFound(t *testing.T) {
+	reg := internalmcp.NewProjectRegistry()
+	_ = reg.Register(&internalmcp.Project{Name: "alpha", Owner: "org", Repo: "alpha"})
+
+	err := reg.SetActive("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown project, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got %q", err.Error())
+	}
+}
+
+func TestProjectRegistry_Active_NoProjects(t *testing.T) {
+	reg := internalmcp.NewProjectRegistry()
+
+	_, err := reg.Active()
+	if err == nil {
+		t.Fatal("expected error for empty registry, got nil")
+	}
+	if !strings.Contains(err.Error(), "no projects registered") {
+		t.Errorf("expected 'no projects registered' in error, got %q", err.Error())
+	}
+}
+
+func TestProjectRegistry_Get(t *testing.T) {
+	reg := internalmcp.NewProjectRegistry()
+	_ = reg.Register(&internalmcp.Project{Name: "alpha", Owner: "org", Repo: "alpha"})
+
+	p, ok := reg.Get("alpha")
+	if !ok {
+		t.Fatal("expected project 'alpha' to be found")
+	}
+	if p.Owner != "org" {
+		t.Errorf("expected owner %q, got %q", "org", p.Owner)
+	}
+
+	_, ok = reg.Get("missing")
+	if ok {
+		t.Error("expected project 'missing' not to be found")
+	}
+}
+
+func TestLoadProjectConfig(t *testing.T) {
+	content := `projects:
+  - name: samverk
+    owner: HerbHall
+    repo: samverk
+  - name: devkit
+    owner: HerbHall
+    repo: devkit
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "server.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+
+	configs, err := internalmcp.LoadProjectConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(configs) != 2 {
+		t.Fatalf("expected 2 configs, got %d", len(configs))
+	}
+
+	if configs[0].Name != "samverk" {
+		t.Errorf("expected first project name %q, got %q", "samverk", configs[0].Name)
+	}
+	if configs[0].Owner != "HerbHall" {
+		t.Errorf("expected first project owner %q, got %q", "HerbHall", configs[0].Owner)
+	}
+	if configs[0].Repo != "samverk" {
+		t.Errorf("expected first project repo %q, got %q", "samverk", configs[0].Repo)
+	}
+	if configs[1].Name != "devkit" {
+		t.Errorf("expected second project name %q, got %q", "devkit", configs[1].Name)
+	}
+}
+
+func TestLoadProjectConfig_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name:    "invalid YAML",
+			content: "{{invalid yaml",
+			wantErr: "parsing project config",
+		},
+		{
+			name: "missing name",
+			content: `projects:
+  - owner: HerbHall
+    repo: samverk
+`,
+			wantErr: "name is required",
+		},
+		{
+			name: "missing owner",
+			content: `projects:
+  - name: samverk
+    repo: samverk
+`,
+			wantErr: "owner is required",
+		},
+		{
+			name: "missing repo",
+			content: `projects:
+  - name: samverk
+    owner: HerbHall
+`,
+			wantErr: "repo is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "server.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("writing test config: %v", err)
+			}
+
+			_, err := internalmcp.LoadProjectConfig(path)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestLoadProjectConfig_FileNotFound(t *testing.T) {
+	_, err := internalmcp.LoadProjectConfig("/nonexistent/path/server.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+// --- MCP tool integration tests for list_projects and set_project ---
+
+func TestListProjects_NoRegistry(t *testing.T) {
+	// Handler without project registry returns "not configured" message.
+	ts := newTestMCPServer(t, &mockTracker{}, nil)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      100,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name":      "list_projects",
+			"arguments": map[string]any{},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "not configured") {
+		t.Errorf("expected 'not configured' message, got %q", result.Content[0].Text)
+	}
+}
+
+func TestListProjects_WithRegistry(t *testing.T) {
+	tracker := &mockTracker{}
+	h := internalmcp.NewHandler(tracker, nil, nil, nil, nil)
+
+	reg := internalmcp.NewProjectRegistry()
+	_ = reg.Register(&internalmcp.Project{
+		Name: "alpha", Owner: "org", Repo: "alpha", Tracker: tracker,
+	})
+	_ = reg.Register(&internalmcp.Project{
+		Name: "beta", Owner: "org", Repo: "beta", Tracker: tracker,
+	})
+	h.SetProjects(reg)
+
+	handler := internalmcp.NewHTTPHandler(h)
+	ts := newHTTPTestServer(t, handler)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      101,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name":      "list_projects",
+			"arguments": map[string]any{},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+
+	// Parse the JSON array to verify structure.
+	var projects []struct {
+		Name   string `json:"name"`
+		Owner  string `json:"owner"`
+		Repo   string `json:"repo"`
+		Active bool   `json:"active"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &projects); err != nil {
+		t.Fatalf("unmarshal projects list: %v\ntext: %s", err, result.Content[0].Text)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("expected 2 projects, got %d", len(projects))
+	}
+
+	// Projects should be sorted alphabetically, alpha first.
+	if projects[0].Name != "alpha" {
+		t.Errorf("expected first project %q, got %q", "alpha", projects[0].Name)
+	}
+	if !projects[0].Active {
+		t.Error("expected first project to be active")
+	}
+	if projects[1].Name != "beta" {
+		t.Errorf("expected second project %q, got %q", "beta", projects[1].Name)
+	}
+	if projects[1].Active {
+		t.Error("expected second project to be inactive")
+	}
+}
+
+func TestSetProject(t *testing.T) {
+	tracker := &mockTracker{}
+	h := internalmcp.NewHandler(tracker, nil, nil, nil, nil)
+
+	reg := internalmcp.NewProjectRegistry()
+	_ = reg.Register(&internalmcp.Project{
+		Name: "alpha", Owner: "org", Repo: "alpha", Tracker: tracker,
+	})
+	_ = reg.Register(&internalmcp.Project{
+		Name: "beta", Owner: "org", Repo: "beta", Tracker: tracker,
+	})
+	h.SetProjects(reg)
+
+	handler := internalmcp.NewHTTPHandler(h)
+	ts := newHTTPTestServer(t, handler)
+
+	// Switch to beta.
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      102,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "set_project",
+			"arguments": map[string]any{
+				"name": "beta",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+	if !strings.Contains(result.Content[0].Text, "beta") {
+		t.Errorf("expected response to mention 'beta', got %q", result.Content[0].Text)
+	}
+	if !strings.Contains(result.Content[0].Text, "Switched") {
+		t.Errorf("expected 'Switched' confirmation, got %q", result.Content[0].Text)
+	}
+
+	// Verify beta is now active via list_projects.
+	respBody = postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      103,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name":      "list_projects",
+			"arguments": map[string]any{},
+		},
+	})
+
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	var projects []struct {
+		Name   string `json:"name"`
+		Active bool   `json:"active"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &projects); err != nil {
+		t.Fatalf("unmarshal projects: %v", err)
+	}
+	for _, p := range projects {
+		if p.Name == "beta" && !p.Active {
+			t.Error("expected beta to be active after set_project")
+		}
+		if p.Name == "alpha" && p.Active {
+			t.Error("expected alpha to be inactive after set_project to beta")
+		}
+	}
+}
+
+func TestSetProject_NotFound(t *testing.T) {
+	tracker := &mockTracker{}
+	h := internalmcp.NewHandler(tracker, nil, nil, nil, nil)
+
+	reg := internalmcp.NewProjectRegistry()
+	_ = reg.Register(&internalmcp.Project{
+		Name: "alpha", Owner: "org", Repo: "alpha", Tracker: tracker,
+	})
+	h.SetProjects(reg)
+
+	handler := internalmcp.NewHTTPHandler(h)
+	ts := newHTTPTestServer(t, handler)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      104,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "set_project",
+			"arguments": map[string]any{
+				"name": "nonexistent",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	// Expect either protocol error or isError in result.
+	if resp.Error != nil {
+		return
+	}
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true for unknown project")
+	}
+}
+
+func TestSetProject_NoRegistry(t *testing.T) {
+	ts := newTestMCPServer(t, &mockTracker{}, nil)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      105,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "set_project",
+			"arguments": map[string]any{
+				"name": "alpha",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	// Expect error since multi-project is not configured.
+	if resp.Error != nil {
+		return
+	}
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true when registry is nil")
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -193,7 +193,7 @@ func (h *Handler) handleGetDigest(
 	}
 
 	sinceTime := time.Now().Add(-dur)
-	data, err := digest.BuildDigest(ctx, h.tracker, h.costs, sinceTime)
+	data, err := digest.BuildDigest(ctx, h.activeTracker(), h.costs, sinceTime)
 	if err != nil {
 		return nil, nil, fmt.Errorf("building digest: %w", err)
 	}
@@ -231,7 +231,7 @@ func (h *Handler) handleAddLabel(
 }
 
 func (h *Handler) executeAddLabel(ctx context.Context, input addLabelInput) (*gosdk.CallToolResult, error) {
-	if err := h.tracker.AddLabel(ctx, input.IssueNumber, input.Label); err != nil {
+	if err := h.activeTracker().AddLabel(ctx, input.IssueNumber, input.Label); err != nil {
 		return nil, fmt.Errorf("adding label: %w", err)
 	}
 
@@ -269,7 +269,7 @@ func (h *Handler) handleRemoveLabel(
 }
 
 func (h *Handler) executeRemoveLabel(ctx context.Context, input removeLabelInput) (*gosdk.CallToolResult, error) {
-	if err := h.tracker.RemoveLabel(ctx, input.IssueNumber, input.Label); err != nil {
+	if err := h.activeTracker().RemoveLabel(ctx, input.IssueNumber, input.Label); err != nil {
 		return nil, fmt.Errorf("removing label: %w", err)
 	}
 
@@ -307,7 +307,7 @@ func (h *Handler) handleAddComment(
 }
 
 func (h *Handler) executeAddComment(ctx context.Context, input addCommentInput) (*gosdk.CallToolResult, error) {
-	comment, err := h.tracker.AddComment(ctx, input.IssueNumber, input.Body)
+	comment, err := h.activeTracker().AddComment(ctx, input.IssueNumber, input.Body)
 	if err != nil {
 		return nil, fmt.Errorf("adding comment: %w", err)
 	}
@@ -350,7 +350,7 @@ func (h *Handler) handleCreateIssue(
 }
 
 func (h *Handler) executeCreateIssue(ctx context.Context, input createIssueInput) (*gosdk.CallToolResult, error) {
-	issue, err := h.tracker.CreateIssue(ctx, &forge.CreateIssueRequest{
+	issue, err := h.activeTracker().CreateIssue(ctx, &forge.CreateIssueRequest{
 		Title:     input.Title,
 		Body:      input.Body,
 		Labels:    input.Labels,
@@ -391,7 +391,7 @@ func (h *Handler) handleListIssues(
 		PerPage:  input.PerPage,
 	}
 
-	issues, err := h.tracker.ListIssues(ctx, opts)
+	issues, err := h.activeTracker().ListIssues(ctx, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("listing issues: %w", err)
 	}
@@ -418,7 +418,7 @@ func (h *Handler) handleGetIssue(
 		return nil, nil, fmt.Errorf("issue_number must be greater than 0")
 	}
 
-	issue, err := h.tracker.GetIssue(ctx, input.IssueNumber)
+	issue, err := h.activeTracker().GetIssue(ctx, input.IssueNumber)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting issue: %w", err)
 	}
@@ -465,7 +465,7 @@ func (h *Handler) executeUpdateIssue(ctx context.Context, input updateIssueInput
 		req.State = &s
 	}
 
-	issue, err := h.tracker.UpdateIssue(ctx, input.IssueNumber, req)
+	issue, err := h.activeTracker().UpdateIssue(ctx, input.IssueNumber, req)
 	if err != nil {
 		return nil, fmt.Errorf("updating issue: %w", err)
 	}
@@ -506,7 +506,7 @@ func (h *Handler) handleCloseIssue(
 
 func (h *Handler) executeCloseIssue(ctx context.Context, input closeIssueInput) (*gosdk.CallToolResult, error) {
 	closedState := forge.StateClosed
-	_, err := h.tracker.UpdateIssue(ctx, input.IssueNumber, &forge.UpdateIssueRequest{
+	_, err := h.activeTracker().UpdateIssue(ctx, input.IssueNumber, &forge.UpdateIssueRequest{
 		State: &closedState,
 	})
 	if err != nil {
@@ -545,7 +545,7 @@ func (h *Handler) handleReopenIssue(
 
 func (h *Handler) executeReopenIssue(ctx context.Context, input reopenIssueInput) (*gosdk.CallToolResult, error) {
 	openState := forge.StateOpen
-	_, err := h.tracker.UpdateIssue(ctx, input.IssueNumber, &forge.UpdateIssueRequest{
+	_, err := h.activeTracker().UpdateIssue(ctx, input.IssueNumber, &forge.UpdateIssueRequest{
 		State: &openState,
 	})
 	if err != nil {
@@ -586,7 +586,7 @@ func (h *Handler) handleSetLabels(
 }
 
 func (h *Handler) executeSetLabels(ctx context.Context, input setLabelsInput) (*gosdk.CallToolResult, error) {
-	if err := h.tracker.SetLabels(ctx, input.IssueNumber, input.Labels); err != nil {
+	if err := h.activeTracker().SetLabels(ctx, input.IssueNumber, input.Labels); err != nil {
 		return nil, fmt.Errorf("setting labels: %w", err)
 	}
 
@@ -610,7 +610,7 @@ func (h *Handler) handleListComments(
 		return nil, nil, fmt.Errorf("issue_number must be greater than 0")
 	}
 
-	comments, err := h.tracker.ListComments(ctx, input.IssueNumber)
+	comments, err := h.activeTracker().ListComments(ctx, input.IssueNumber)
 	if err != nil {
 		return nil, nil, fmt.Errorf("listing comments: %w", err)
 	}

--- a/internal/mcp/tools_projects.go
+++ b/internal/mcp/tools_projects.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// listProjectsInput is the typed input for the list_projects tool.
+type listProjectsInput struct{}
+
+// setProjectInput is the typed input for the set_project tool.
+type setProjectInput struct {
+	Name string `json:"name" jsonschema:"required,the project name to switch to"`
+}
+
+// projectInfo is the JSON output for a single project in list_projects.
+type projectInfo struct {
+	Name   string `json:"name"`
+	Owner  string `json:"owner"`
+	Repo   string `json:"repo"`
+	Active bool   `json:"active"`
+}
+
+// registerProjectTools adds project management tools to the MCP server.
+func registerProjectTools(srv *gosdk.Server, h *Handler) {
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "list_projects",
+		Description: "List all registered projects with their active status",
+	}, h.handleListProjects)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "set_project",
+		Description: "Switch the active project context",
+	}, h.handleSetProject)
+}
+
+// handleListProjects returns all registered projects with their active status.
+func (h *Handler) handleListProjects(
+	_ context.Context,
+	_ *gosdk.CallToolRequest,
+	_ listProjectsInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.projects == nil {
+		return &gosdk.CallToolResult{
+			Content: []gosdk.Content{
+				&gosdk.TextContent{Text: "multi-project support not configured"},
+			},
+		}, nil, nil
+	}
+
+	projects := h.projects.List()
+	activeName := h.projects.ActiveName()
+
+	infos := make([]projectInfo, 0, len(projects))
+	for _, p := range projects {
+		infos = append(infos, projectInfo{
+			Name:   p.Name,
+			Owner:  p.Owner,
+			Repo:   p.Repo,
+			Active: p.Name == activeName,
+		})
+	}
+
+	result, err := json.Marshal(infos)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshalling projects: %w", err)
+	}
+
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: string(result)},
+		},
+	}, nil, nil
+}
+
+// handleSetProject switches the active project context.
+func (h *Handler) handleSetProject(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	input setProjectInput,
+) (*gosdk.CallToolResult, any, error) {
+	if h.projects == nil {
+		return nil, nil, fmt.Errorf("multi-project support not configured")
+	}
+
+	if input.Name == "" {
+		return nil, nil, fmt.Errorf("name must not be empty")
+	}
+
+	if err := h.projects.SetActive(input.Name); err != nil {
+		return nil, nil, fmt.Errorf("setting active project: %w", err)
+	}
+
+	h.recorder.recordToolCall(ctx, "set_project", 0)
+
+	p, _ := h.projects.Active()
+	text := fmt.Sprintf("Switched to project %q (%s/%s)", p.Name, p.Owner, p.Repo)
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{
+			&gosdk.TextContent{Text: text},
+		},
+	}, nil, nil
+}

--- a/internal/mcp/tools_repo.go
+++ b/internal/mcp/tools_repo.go
@@ -82,7 +82,7 @@ func (h *Handler) handleListFiles(
 	_ *gosdk.CallToolRequest,
 	input listFilesInput,
 ) (*gosdk.CallToolResult, any, error) {
-	if h.repo == nil {
+	if h.activeReader() == nil {
 		return &gosdk.CallToolResult{
 			Content: []gosdk.Content{
 				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
@@ -90,7 +90,7 @@ func (h *Handler) handleListFiles(
 		}, nil, nil
 	}
 
-	entries, err := h.repo.ListFiles(ctx, input.Path, input.Ref)
+	entries, err := h.activeReader().ListFiles(ctx, input.Path, input.Ref)
 	if err != nil {
 		return nil, nil, fmt.Errorf("listing files: %w", err)
 	}
@@ -113,7 +113,7 @@ func (h *Handler) handleReadFile(
 	_ *gosdk.CallToolRequest,
 	input readFileInput,
 ) (*gosdk.CallToolResult, any, error) {
-	if h.repo == nil {
+	if h.activeReader() == nil {
 		return &gosdk.CallToolResult{
 			Content: []gosdk.Content{
 				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
@@ -125,7 +125,7 @@ func (h *Handler) handleReadFile(
 		return nil, nil, fmt.Errorf("path must not be empty")
 	}
 
-	data, err := h.repo.ReadFile(ctx, input.Path, input.Ref)
+	data, err := h.activeReader().ReadFile(ctx, input.Path, input.Ref)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading file: %w", err)
 	}
@@ -168,7 +168,7 @@ func (h *Handler) handleGetDiff(
 	_ *gosdk.CallToolRequest,
 	input getDiffInput,
 ) (*gosdk.CallToolResult, any, error) {
-	if h.repo == nil {
+	if h.activeReader() == nil {
 		return &gosdk.CallToolResult{
 			Content: []gosdk.Content{
 				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
@@ -183,7 +183,7 @@ func (h *Handler) handleGetDiff(
 		return nil, nil, fmt.Errorf("head must not be empty")
 	}
 
-	diff, err := h.repo.GetDiff(ctx, input.Base, input.Head)
+	diff, err := h.activeReader().GetDiff(ctx, input.Base, input.Head)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting diff: %w", err)
 	}
@@ -201,7 +201,7 @@ func (h *Handler) handleListBranches(
 	_ *gosdk.CallToolRequest,
 	_ listBranchesInput,
 ) (*gosdk.CallToolResult, any, error) {
-	if h.repo == nil {
+	if h.activeReader() == nil {
 		return &gosdk.CallToolResult{
 			Content: []gosdk.Content{
 				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
@@ -209,7 +209,7 @@ func (h *Handler) handleListBranches(
 		}, nil, nil
 	}
 
-	branches, err := h.repo.ListBranches(ctx)
+	branches, err := h.activeReader().ListBranches(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("listing branches: %w", err)
 	}
@@ -232,7 +232,7 @@ func (h *Handler) handleGetCommitLog(
 	_ *gosdk.CallToolRequest,
 	input getCommitLogInput,
 ) (*gosdk.CallToolResult, any, error) {
-	if h.repo == nil {
+	if h.activeReader() == nil {
 		return &gosdk.CallToolResult{
 			Content: []gosdk.Content{
 				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
@@ -249,7 +249,7 @@ func (h *Handler) handleGetCommitLog(
 		limit = 20
 	}
 
-	commits, err := h.repo.GetCommitLog(ctx, branch, limit)
+	commits, err := h.activeReader().GetCommitLog(ctx, branch, limit)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting commit log: %w", err)
 	}
@@ -272,7 +272,7 @@ func (h *Handler) handleSearchCode(
 	_ *gosdk.CallToolRequest,
 	input searchCodeInput,
 ) (*gosdk.CallToolResult, any, error) {
-	if h.repo == nil {
+	if h.activeReader() == nil {
 		return &gosdk.CallToolResult{
 			Content: []gosdk.Content{
 				&gosdk.TextContent{Text: "repo operations not available: no RepoReader configured"},
@@ -284,7 +284,7 @@ func (h *Handler) handleSearchCode(
 		return nil, nil, fmt.Errorf("query must not be empty")
 	}
 
-	results, err := h.repo.SearchCode(ctx, input.Query)
+	results, err := h.activeReader().SearchCode(ctx, input.Query)
 	if err != nil {
 		return nil, nil, fmt.Errorf("searching code: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Add `ProjectRegistry` for managing multiple repos from a single Samverk instance
- New MCP tools: `list_projects` (read-only) and `set_project` (switches active context)
- Existing tools resolve active project via `activeTracker()`/`activeReader()` helpers
- Projects loadable from `.samverk/server.yaml` config or `--owner/--repo` flags
- Fully backwards compatible: single-project mode works without config file
- 13 new tests covering registry, config parsing, and MCP tool integration

Closes #114

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + 13 new)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [x] `golangci-lint run` -- 0 issues
- [x] Pre-push hook passes (build + test + lint + markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)