### PR TITLE
feat: add API key management (#119)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -33,6 +33,7 @@ func main() {
 	root.AddCommand(serveCmd())
 	root.AddCommand(dispatchCmd())
 	root.AddCommand(digestCmd())
+	root.AddCommand(keyCmd())
 	root.AddCommand(versionCmd())
 
 	if err := root.Execute(); err != nil {
@@ -41,7 +42,7 @@ func main() {
 }
 
 func serveCmd() *cobra.Command {
-	var addr, owner, repo, dbPath, projectsConfig string
+	var addr, owner, repo, dbPath, projectsConfig, authKeysPath string
 	var budget float64
 
 	cmd := &cobra.Command{
@@ -56,7 +57,20 @@ func serveCmd() *cobra.Command {
 			// Wire Bearer token auth for MCP endpoint.
 			cfg.AuthToken = os.Getenv("SAMVERK_AUTH_TOKEN")
 			if cfg.AuthToken != "" {
-				slog.Info("MCP authentication enabled")
+				slog.Info("MCP authentication enabled (env token)")
+			}
+
+			// Load YAML-backed API key store if the file exists.
+			if authKeysPath != "" {
+				if _, statErr := os.Stat(authKeysPath); statErr == nil {
+					ks, ksErr := server.NewKeyStore(authKeysPath)
+					if ksErr != nil {
+						slog.Warn("could not load API key store", "path", authKeysPath, "error", ksErr)
+					} else {
+						cfg.KeyStore = ks
+						slog.Info("API key authentication enabled", "keys", len(ks.List()), "path", authKeysPath)
+					}
+				}
 			}
 
 			// Open SQLite store for session/cost recording.
@@ -172,6 +186,7 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository name")
 	cmd.Flags().StringVar(&dbPath, "db", ".samverk/samverk.db", "Path to SQLite database for session/cost tracking")
 	cmd.Flags().StringVar(&projectsConfig, "projects-config", ".samverk/server.yaml", "Path to multi-project YAML config")
+	cmd.Flags().StringVar(&authKeysPath, "auth-keys", ".samverk/auth.yaml", "Path to API key YAML file")
 	cmd.Flags().Float64Var(&budget, "budget", 0, "Daily budget in USD (0 = unlimited)")
 	return cmd
 }
@@ -306,6 +321,121 @@ func digestCmd() *cobra.Command {
 	cmd.Flags().StringVar(&since, "since", "24h", "Time window for digest (e.g., 24h, 720h)")
 	cmd.Flags().StringVar(&dbPath, "db", ".samverk/samverk.db", "Path to SQLite database for cost tracking")
 	cmd.Flags().Float64Var(&budget, "budget", 0, "Daily budget in USD (0 = unlimited)")
+
+	return cmd
+}
+
+func keyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key",
+		Short: "Manage API keys for server authentication",
+	}
+
+	cmd.AddCommand(keyCreateCmd())
+	cmd.AddCommand(keyListCmd())
+	cmd.AddCommand(keyRevokeCmd())
+
+	return cmd
+}
+
+func keyCreateCmd() *cobra.Command {
+	var name, authKeysPath string
+	var projects []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new API key",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+
+			ks, err := server.NewKeyStore(authKeysPath)
+			if err != nil {
+				return fmt.Errorf("load key store: %w", err)
+			}
+
+			plaintext, err := ks.Create(name, projects)
+			if err != nil {
+				return fmt.Errorf("create key: %w", err)
+			}
+
+			fmt.Printf("API key created. Token: %s\n", plaintext)
+			fmt.Println("Save this key -- it cannot be retrieved again.")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Name for the API key (required)")
+	cmd.Flags().StringSliceVar(&projects, "project", nil, "Project scope (repeatable; omit for all projects)")
+	cmd.Flags().StringVar(&authKeysPath, "auth-keys", ".samverk/auth.yaml", "Path to API key YAML file")
+
+	return cmd
+}
+
+func keyListCmd() *cobra.Command {
+	var authKeysPath string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all API keys",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ks, err := server.NewKeyStore(authKeysPath)
+			if err != nil {
+				return fmt.Errorf("load key store: %w", err)
+			}
+
+			keys := ks.List()
+			if len(keys) == 0 {
+				fmt.Println("No API keys configured.")
+				return nil
+			}
+
+			fmt.Printf("%-20s %-30s %s\n", "NAME", "PROJECTS", "CREATED")
+			fmt.Printf("%-20s %-30s %s\n", "----", "--------", "-------")
+			for i := range keys {
+				proj := "(all)"
+				if len(keys[i].Projects) > 0 {
+					proj = fmt.Sprintf("%v", keys[i].Projects)
+				}
+				fmt.Printf("%-20s %-30s %s\n", keys[i].Name, proj, keys[i].CreatedAt)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&authKeysPath, "auth-keys", ".samverk/auth.yaml", "Path to API key YAML file")
+
+	return cmd
+}
+
+func keyRevokeCmd() *cobra.Command {
+	var name, authKeysPath string
+
+	cmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke an API key by name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+
+			ks, err := server.NewKeyStore(authKeysPath)
+			if err != nil {
+				return fmt.Errorf("load key store: %w", err)
+			}
+
+			if err := ks.Revoke(name); err != nil {
+				return fmt.Errorf("revoke key: %w", err)
+			}
+
+			fmt.Printf("API key %q revoked.\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Name of the API key to revoke (required)")
+	cmd.Flags().StringVar(&authKeysPath, "auth-keys", ".samverk/auth.yaml", "Path to API key YAML file")
 
 	return cmd
 }

--- a/internal/server/apikey.go
+++ b/internal/server/apikey.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// APIKey represents a stored API key with metadata.
+type APIKey struct {
+	Name      string   `yaml:"name"`
+	Hash      string   `yaml:"hash"`       // SHA-256 hex of the plaintext key
+	Projects  []string `yaml:"projects"`   // empty = all projects
+	CreatedAt string   `yaml:"created_at"` // RFC3339
+}
+
+// keyFile is the on-disk YAML structure.
+type keyFile struct {
+	Keys []APIKey `yaml:"keys"`
+}
+
+// KeyStore manages API keys stored in a YAML file.
+type KeyStore struct {
+	mu   sync.RWMutex
+	path string
+	keys []APIKey
+}
+
+// NewKeyStore loads a KeyStore from the given YAML file path.
+// If the file does not exist, it is created with an empty key list.
+func NewKeyStore(path string) (*KeyStore, error) {
+	ks := &KeyStore{path: path}
+
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path from trusted config
+	if os.IsNotExist(err) {
+		// Ensure parent directory exists, then write an empty file.
+		if mkErr := os.MkdirAll(filepath.Dir(path), 0o700); mkErr != nil {
+			return nil, fmt.Errorf("create key store directory: %w", mkErr)
+		}
+		if writeErr := ks.flush(); writeErr != nil {
+			return nil, fmt.Errorf("create key store file: %w", writeErr)
+		}
+		return ks, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read key store: %w", err)
+	}
+
+	var f keyFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse key store: %w", err)
+	}
+	ks.keys = f.Keys
+	return ks, nil
+}
+
+// Create generates a new API key, stores its hash, and returns the plaintext.
+// The plaintext is only available at creation time.
+func (ks *KeyStore) Create(name string, projects []string) (string, error) {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	// Reject duplicate names.
+	for i := range ks.keys {
+		if ks.keys[i].Name == name {
+			return "", fmt.Errorf("key with name %q already exists", name)
+		}
+	}
+
+	// Generate 32 random bytes -> 64 hex chars.
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate random key: %w", err)
+	}
+	plaintext := "sk_" + hex.EncodeToString(raw)
+
+	hash := sha256.Sum256([]byte(plaintext))
+	hashHex := hex.EncodeToString(hash[:])
+
+	if projects == nil {
+		projects = []string{}
+	}
+
+	key := APIKey{
+		Name:      name,
+		Hash:      hashHex,
+		Projects:  projects,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	ks.keys = append(ks.keys, key)
+
+	if err := ks.flush(); err != nil {
+		// Roll back the append on write failure.
+		ks.keys = ks.keys[:len(ks.keys)-1]
+		return "", fmt.Errorf("save key store: %w", err)
+	}
+	return plaintext, nil
+}
+
+// List returns all stored keys. Hashes are included for display purposes.
+func (ks *KeyStore) List() []APIKey {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	result := make([]APIKey, len(ks.keys))
+	copy(result, ks.keys)
+	return result
+}
+
+// Revoke removes a key by name.
+func (ks *KeyStore) Revoke(name string) error {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	idx := -1
+	for i := range ks.keys {
+		if ks.keys[i].Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("key %q not found", name)
+	}
+
+	ks.keys = append(ks.keys[:idx], ks.keys[idx+1:]...)
+
+	if err := ks.flush(); err != nil {
+		return fmt.Errorf("save key store: %w", err)
+	}
+	return nil
+}
+
+// Validate checks a plaintext token against all stored key hashes.
+// Returns the matching APIKey and true if found, or nil and false otherwise.
+// Uses constant-time comparison to prevent timing attacks.
+func (ks *KeyStore) Validate(token string) (*APIKey, bool) {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	hash := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	for i := range ks.keys {
+		if subtle.ConstantTimeCompare([]byte(tokenHash), []byte(ks.keys[i].Hash)) == 1 {
+			key := ks.keys[i]
+			return &key, true
+		}
+	}
+	return nil, false
+}
+
+// ValidateForProject checks a plaintext token and verifies it has access
+// to the given project. Unscoped keys (empty Projects) have access to all
+// projects.
+func (ks *KeyStore) ValidateForProject(token, project string) bool {
+	key, ok := ks.Validate(token)
+	if !ok {
+		return false
+	}
+
+	// Unscoped key: access to all projects.
+	if len(key.Projects) == 0 {
+		return true
+	}
+
+	for _, p := range key.Projects {
+		if p == project {
+			return true
+		}
+	}
+	return false
+}
+
+// flush writes the current key list to disk. Caller must hold ks.mu.
+func (ks *KeyStore) flush() error {
+	f := keyFile{Keys: ks.keys}
+	if f.Keys == nil {
+		f.Keys = []APIKey{}
+	}
+
+	data, err := yaml.Marshal(&f)
+	if err != nil {
+		return fmt.Errorf("marshal key store: %w", err)
+	}
+	return os.WriteFile(ks.path, data, 0o600)
+}

--- a/internal/server/apikey_test.go
+++ b/internal/server/apikey_test.go
@@ -1,0 +1,226 @@
+package server_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/herbhall/samverk/internal/server"
+)
+
+func tempKeyStorePath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "auth.yaml")
+}
+
+func TestKeyStore_CreateAndValidate(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	plaintext, err := ks.Create("test-key", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if plaintext == "" {
+		t.Fatal("Create returned empty plaintext")
+	}
+	if len(plaintext) < 64 {
+		t.Errorf("plaintext too short: got %d chars", len(plaintext))
+	}
+
+	key, ok := ks.Validate(plaintext)
+	if !ok {
+		t.Fatal("Validate returned false for valid key")
+	}
+	if key.Name != "test-key" {
+		t.Errorf("key name = %q, want %q", key.Name, "test-key")
+	}
+
+	// Wrong token should fail.
+	_, ok = ks.Validate("sk_wrong")
+	if ok {
+		t.Fatal("Validate returned true for invalid key")
+	}
+}
+
+func TestKeyStore_Create_DuplicateName(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	if _, err := ks.Create("dupe", nil); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	_, err = ks.Create("dupe", nil)
+	if err == nil {
+		t.Fatal("expected error for duplicate name, got nil")
+	}
+}
+
+func TestKeyStore_Revoke(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	plaintext, err := ks.Create("revoke-me", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := ks.Revoke("revoke-me"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	_, ok := ks.Validate(plaintext)
+	if ok {
+		t.Fatal("Validate returned true after revocation")
+	}
+}
+
+func TestKeyStore_Revoke_NotFound(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	err = ks.Revoke("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for revoking nonexistent key, got nil")
+	}
+}
+
+func TestKeyStore_ValidateForProject(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	plaintext, err := ks.Create("scoped-key", []string{"project-a", "project-b"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !ks.ValidateForProject(plaintext, "project-a") {
+		t.Error("ValidateForProject returned false for allowed project-a")
+	}
+	if !ks.ValidateForProject(plaintext, "project-b") {
+		t.Error("ValidateForProject returned false for allowed project-b")
+	}
+}
+
+func TestKeyStore_ValidateForProject_Denied(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	plaintext, err := ks.Create("scoped-key", []string{"project-a"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if ks.ValidateForProject(plaintext, "project-c") {
+		t.Error("ValidateForProject returned true for disallowed project-c")
+	}
+}
+
+func TestKeyStore_ValidateForProject_Unscoped(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	plaintext, err := ks.Create("unscoped-key", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !ks.ValidateForProject(plaintext, "any-project") {
+		t.Error("ValidateForProject returned false for unscoped key")
+	}
+	if !ks.ValidateForProject(plaintext, "another-project") {
+		t.Error("ValidateForProject returned false for unscoped key on another project")
+	}
+}
+
+func TestKeyStore_Persistence(t *testing.T) {
+	path := tempKeyStorePath(t)
+
+	ks1, err := server.NewKeyStore(path)
+	if err != nil {
+		t.Fatalf("NewKeyStore (first): %v", err)
+	}
+
+	plaintext, err := ks1.Create("persist-key", []string{"proj"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Reload from the same file.
+	ks2, err := server.NewKeyStore(path)
+	if err != nil {
+		t.Fatalf("NewKeyStore (reload): %v", err)
+	}
+
+	key, ok := ks2.Validate(plaintext)
+	if !ok {
+		t.Fatal("Validate failed after reload")
+	}
+	if key.Name != "persist-key" {
+		t.Errorf("key name = %q, want %q", key.Name, "persist-key")
+	}
+	if len(key.Projects) != 1 || key.Projects[0] != "proj" {
+		t.Errorf("key projects = %v, want [proj]", key.Projects)
+	}
+}
+
+func TestKeyStore_List(t *testing.T) {
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	if _, err := ks.Create("key-a", nil); err != nil {
+		t.Fatalf("Create key-a: %v", err)
+	}
+	if _, err := ks.Create("key-b", []string{"proj-1"}); err != nil {
+		t.Fatalf("Create key-b: %v", err)
+	}
+
+	keys := ks.List()
+	if len(keys) != 2 {
+		t.Fatalf("List returned %d keys, want 2", len(keys))
+	}
+
+	if keys[0].Name != "key-a" {
+		t.Errorf("keys[0].Name = %q, want %q", keys[0].Name, "key-a")
+	}
+	if keys[1].Name != "key-b" {
+		t.Errorf("keys[1].Name = %q, want %q", keys[1].Name, "key-b")
+	}
+	if len(keys[1].Projects) != 1 || keys[1].Projects[0] != "proj-1" {
+		t.Errorf("keys[1].Projects = %v, want [proj-1]", keys[1].Projects)
+	}
+	if keys[0].CreatedAt == "" {
+		t.Error("keys[0].CreatedAt is empty")
+	}
+}
+
+func TestKeyStore_NewKeyStore_CreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "subdir", "auth.yaml")
+
+	ks, err := server.NewKeyStore(path)
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+	_ = ks
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Error("expected key store file to be created")
+	}
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -7,11 +7,13 @@ import (
 )
 
 // BearerAuth returns middleware that validates Bearer token authentication.
-// If token is empty, the middleware is a no-op (passes through).
-func BearerAuth(token string) func(http.Handler) http.Handler {
+// It checks the env-var token first (backwards compatible), then falls back
+// to the KeyStore if provided. If both token and keyStore are empty/nil,
+// the middleware is a no-op (passes through).
+func BearerAuth(token string, keyStore *KeyStore) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if token == "" {
+			if token == "" && keyStore == nil {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -28,12 +30,23 @@ func BearerAuth(token string) func(http.Handler) http.Handler {
 				return
 			}
 
-			if subtle.ConstantTimeCompare([]byte(auth[len(prefix):]), []byte(token)) != 1 {
-				writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "invalid token"})
+			bearerToken := auth[len(prefix):]
+
+			// Try env-var token first (constant-time comparison).
+			if token != "" && subtle.ConstantTimeCompare([]byte(bearerToken), []byte(token)) == 1 {
+				next.ServeHTTP(w, r)
 				return
 			}
 
-			next.ServeHTTP(w, r)
+			// Fall back to KeyStore validation.
+			if keyStore != nil {
+				if _, ok := keyStore.Validate(bearerToken); ok {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "invalid token"})
 		})
 	}
 }

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -66,7 +66,7 @@ func TestBearerAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := server.BearerAuth(tt.token)(okHandler)
+			handler := server.BearerAuth(tt.token, nil)(okHandler)
 
 			req := httptest.NewRequest(http.MethodPost, "/mcp", http.NoBody)
 			if tt.authHeader != "" {
@@ -88,6 +88,79 @@ func TestBearerAuth(t *testing.T) {
 				if body["error"] != tt.wantError {
 					t.Errorf("error = %q, want %q", body["error"], tt.wantError)
 				}
+			}
+		})
+	}
+}
+
+func TestBearerAuth_WithKeyStore(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	ks, err := server.NewKeyStore(tempKeyStorePath(t))
+	if err != nil {
+		t.Fatalf("NewKeyStore: %v", err)
+	}
+
+	apiKey, err := ks.Create("test-api-key", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		token      string // env-var token
+		authHeader string
+		wantStatus int
+	}{
+		{
+			name:       "env token wins when both configured",
+			token:      "env-secret",
+			authHeader: "Bearer env-secret",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "keystore fallback when env token mismatches",
+			token:      "env-secret",
+			authHeader: "Bearer " + apiKey,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "keystore-only auth with no env token",
+			token:      "",
+			authHeader: "Bearer " + apiKey,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "neither matches returns 401",
+			token:      "env-secret",
+			authHeader: "Bearer totally-wrong",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "keystore configured but missing header returns 401",
+			token:      "",
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := server.BearerAuth(tt.token, ks)(okHandler)
+
+			req := httptest.NewRequest(http.MethodPost, "/mcp", http.NoBody)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
 			}
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ type APIRegistrar interface {
 type Config struct {
 	Addr       string         // listen address, e.g. ":8080"
 	AuthToken  string         //nolint:gosec // G117: config field, not a hardcoded secret
+	KeyStore   *KeyStore      // YAML-backed API key store (may be nil)
 	MCPHandler http.Handler   // optional MCP protocol handler; nil keeps the 501 placeholder
 	APIHandler APIRegistrar   // optional REST API handler; nil keeps the 501 placeholder
 }
@@ -117,8 +118,8 @@ func (s *Server) registerRoutes() {
 
 	if s.cfg.MCPHandler != nil {
 		handler := s.cfg.MCPHandler
-		if s.cfg.AuthToken != "" {
-			handler = BearerAuth(s.cfg.AuthToken)(handler)
+		if s.cfg.AuthToken != "" || s.cfg.KeyStore != nil {
+			handler = BearerAuth(s.cfg.AuthToken, s.cfg.KeyStore)(handler)
 		}
 		s.mux.Handle("POST /mcp", handler)
 	} else {


### PR DESCRIPTION
## Summary

- Add `KeyStore` backed by `.samverk/auth.yaml` with SHA-256 hashed keys
- CLI commands: `samverk key create/list/revoke` with `--name` and `--project` flags
- Key format: `sk_` prefix + 64 hex chars (32 random bytes from crypto/rand)
- `BearerAuth` middleware updated to check env token first, then KeyStore fallback
- Constant-time hash comparison via `crypto/subtle` prevents timing attacks
- Per-key project scoping: empty scope = all projects access
- Fully backwards compatible: `SAMVERK_AUTH_TOKEN` env var still works
- 15 new tests covering key CRUD, persistence, scoping, and auth flow

Closes #119

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + 15 new)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [x] `golangci-lint run` -- 0 issues
- [x] Pre-push hook passes (build + test + lint + markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)