### PR TITLE
feat: Claude and OpenAI provider clients

### DIFF
--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -1,0 +1,234 @@
+// Package claude implements the provider.Provider interface using
+// the Anthropic Claude Messages API over raw net/http (no SDK dependency).
+package claude
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+// Compile-time check that Client satisfies provider.Provider.
+var _ provider.Provider = (*Client)(nil)
+
+const (
+	defaultBaseURL   = "https://api.anthropic.com"
+	defaultMaxTokens = 4096
+	defaultTimeout   = 120 * time.Second
+	apiVersion       = "2023-06-01"
+)
+
+// Client is an HTTP client for the Anthropic Claude Messages API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	model      string
+	maxTokens  int
+	httpClient *http.Client
+}
+
+// Option is a functional option for the Client.
+type Option func(*Client)
+
+// WithBaseURL overrides the default API base URL.
+func WithBaseURL(url string) Option {
+	return func(c *Client) {
+		c.baseURL = strings.TrimRight(url, "/")
+	}
+}
+
+// WithHTTPClient overrides the default HTTP client.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = hc
+	}
+}
+
+// WithMaxTokens overrides the default max_tokens for requests.
+func WithMaxTokens(n int) Option {
+	return func(c *Client) {
+		c.maxTokens = n
+	}
+}
+
+// New creates a new Claude API client.
+func New(apiKey, model string, opts ...Option) *Client {
+	c := &Client{
+		baseURL:   defaultBaseURL,
+		apiKey:    apiKey,
+		model:     model,
+		maxTokens: defaultMaxTokens,
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// claudeRequest is the request body for the Claude Messages API.
+type claudeRequest struct {
+	Model     string            `json:"model"`
+	MaxTokens int               `json:"max_tokens"`
+	System    string            `json:"system,omitempty"`
+	Messages  []claudeMessage   `json:"messages"`
+}
+
+// claudeMessage is a message in the Claude Messages API format.
+type claudeMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// claudeResponse is the response body from the Claude Messages API.
+type claudeResponse struct {
+	Content []contentBlock `json:"content"`
+	Model   string         `json:"model"`
+	Usage   claudeUsage    `json:"usage"`
+}
+
+// contentBlock is a single content block in a Claude response.
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// claudeUsage contains token counts from the Claude API.
+type claudeUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// Chat sends a chat completion request to POST /v1/messages.
+// System messages are extracted from req.Messages and placed in the
+// top-level "system" field as required by the Claude API.
+func (c *Client) Chat(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+	model := req.Model
+	if model == "" {
+		model = c.model
+	}
+
+	// Extract system messages and convert remaining to Claude format.
+	var systemParts []string
+	messages := make([]claudeMessage, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		if m.Role == provider.RoleSystem {
+			systemParts = append(systemParts, m.Content)
+			continue
+		}
+		messages = append(messages, claudeMessage{
+			Role:    string(m.Role),
+			Content: m.Content,
+		})
+	}
+
+	cr := claudeRequest{
+		Model:     model,
+		MaxTokens: c.maxTokens,
+		System:    strings.Join(systemParts, "\n"),
+		Messages:  messages,
+	}
+
+	var resp claudeResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/messages", cr, &resp); err != nil {
+		return nil, fmt.Errorf("claude: chat: %w", err)
+	}
+
+	// Concatenate all text content blocks into a single response.
+	var textParts []string
+	for _, block := range resp.Content {
+		if block.Type == "text" {
+			textParts = append(textParts, block.Text)
+		}
+	}
+
+	return &provider.ChatResponse{
+		Model: resp.Model,
+		Message: provider.Message{
+			Role:    provider.RoleAssistant,
+			Content: strings.Join(textParts, ""),
+		},
+		PromptTokens:     resp.Usage.InputTokens,
+		CompletionTokens: resp.Usage.OutputTokens,
+	}, nil
+}
+
+// Healthy returns true if the Claude API is reachable.
+// It sends a minimal Chat request with 1 max_token.
+func (c *Client) Healthy(ctx context.Context) bool {
+	cr := claudeRequest{
+		Model:     c.model,
+		MaxTokens: 1,
+		Messages: []claudeMessage{
+			{Role: "user", Content: "ping"},
+		},
+	}
+
+	var resp claudeResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/messages", cr, &resp); err != nil {
+		return false
+	}
+	return true
+}
+
+// Name returns the provider identifier.
+func (c *Client) Name() string {
+	return "claude"
+}
+
+// doJSON is the generic HTTP helper. It marshals body to JSON (if non-nil),
+// makes a request with the given context, sets Claude-specific headers,
+// checks the status code, and unmarshals the response into result.
+func (c *Client) doJSON(ctx context.Context, method, path string, body, result any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	if bodyReader == nil {
+		bodyReader = http.NoBody
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", apiVersion)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL is from trusted baseURL config
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil {
+		if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/claude/claude_test.go
+++ b/internal/provider/claude/claude_test.go
@@ -1,0 +1,347 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+// newTestClient creates a Client pointed at a test HTTP server.
+func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := New("test-api-key", "claude-sonnet-4-20250514", WithBaseURL(srv.URL))
+	return c, srv
+}
+
+// writeJSON is a test helper that writes a JSON response.
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode json: %v", err)
+	}
+}
+
+func TestChat(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		// Verify headers.
+		if got := r.Header.Get("x-api-key"); got != "test-api-key" {
+			t.Errorf("x-api-key = %q, want %q", got, "test-api-key")
+		}
+		if got := r.Header.Get("anthropic-version"); got != apiVersion {
+			t.Errorf("anthropic-version = %q, want %q", got, apiVersion)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want %q", got, "application/json")
+		}
+
+		var req claudeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		if req.Model != "claude-sonnet-4-20250514" {
+			t.Errorf("Model = %q, want %q", req.Model, "claude-sonnet-4-20250514")
+		}
+		if req.MaxTokens != defaultMaxTokens {
+			t.Errorf("MaxTokens = %d, want %d", req.MaxTokens, defaultMaxTokens)
+		}
+
+		writeJSON(t, w, http.StatusOK, claudeResponse{
+			Content: []contentBlock{
+				{Type: "text", Text: "Hello from Claude!"},
+			},
+			Model: req.Model,
+			Usage: claudeUsage{
+				InputTokens:  15,
+				OutputTokens: 8,
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	resp, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "claude-sonnet-4-20250514",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if resp.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("Model = %q, want %q", resp.Model, "claude-sonnet-4-20250514")
+	}
+	if resp.Message.Role != provider.RoleAssistant {
+		t.Errorf("Message.Role = %q, want %q", resp.Message.Role, provider.RoleAssistant)
+	}
+	if resp.Message.Content != "Hello from Claude!" {
+		t.Errorf("Message.Content = %q, want %q", resp.Message.Content, "Hello from Claude!")
+	}
+	if resp.PromptTokens != 15 {
+		t.Errorf("PromptTokens = %d, want 15", resp.PromptTokens)
+	}
+	if resp.CompletionTokens != 8 {
+		t.Errorf("CompletionTokens = %d, want 8", resp.CompletionTokens)
+	}
+}
+
+func TestChatSystemMessageExtraction(t *testing.T) {
+	var gotReq claudeRequest
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusOK, claudeResponse{
+			Content: []contentBlock{
+				{Type: "text", Text: "response"},
+			},
+			Model: gotReq.Model,
+			Usage: claudeUsage{InputTokens: 10, OutputTokens: 5},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: "You are a helpful assistant."},
+			{Role: provider.RoleUser, Content: "Hi"},
+			{Role: provider.RoleAssistant, Content: "Hello!"},
+			{Role: provider.RoleUser, Content: "How are you?"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	// System message should be extracted into the top-level system field.
+	if gotReq.System != "You are a helpful assistant." {
+		t.Errorf("System = %q, want %q", gotReq.System, "You are a helpful assistant.")
+	}
+
+	// Only non-system messages should remain in the messages array.
+	if len(gotReq.Messages) != 3 {
+		t.Fatalf("len(Messages) = %d, want 3", len(gotReq.Messages))
+	}
+	if gotReq.Messages[0].Role != "user" {
+		t.Errorf("Messages[0].Role = %q, want %q", gotReq.Messages[0].Role, "user")
+	}
+	if gotReq.Messages[1].Role != "assistant" {
+		t.Errorf("Messages[1].Role = %q, want %q", gotReq.Messages[1].Role, "assistant")
+	}
+	if gotReq.Messages[2].Role != "user" {
+		t.Errorf("Messages[2].Role = %q, want %q", gotReq.Messages[2].Role, "user")
+	}
+}
+
+func TestChatMultipleSystemMessages(t *testing.T) {
+	var gotReq claudeRequest
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusOK, claudeResponse{
+			Content: []contentBlock{{Type: "text", Text: "ok"}},
+			Model:   gotReq.Model,
+			Usage:   claudeUsage{InputTokens: 5, OutputTokens: 1},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: "You are helpful."},
+			{Role: provider.RoleSystem, Content: "Be concise."},
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	// Multiple system messages should be joined with newline.
+	want := "You are helpful.\nBe concise."
+	if gotReq.System != want {
+		t.Errorf("System = %q, want %q", gotReq.System, want)
+	}
+
+	if len(gotReq.Messages) != 1 {
+		t.Fatalf("len(Messages) = %d, want 1", len(gotReq.Messages))
+	}
+}
+
+func TestChatDefaultModel(t *testing.T) {
+	var gotReq claudeRequest
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusOK, claudeResponse{
+			Content: []contentBlock{{Type: "text", Text: "ok"}},
+			Model:   gotReq.Model,
+			Usage:   claudeUsage{InputTokens: 5, OutputTokens: 1},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	// Send request without model -- should use client default.
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if gotReq.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("Model = %q, want %q", gotReq.Model, "claude-sonnet-4-20250514")
+	}
+}
+
+func TestChatError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"type":"invalid_request_error","message":"bad request"}}`, http.StatusBadRequest)
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+}
+
+func TestChatServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}
+
+func TestHealthy(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, claudeResponse{
+			Content: []contentBlock{{Type: "text", Text: "p"}},
+			Model:   "claude-sonnet-4-20250514",
+			Usage:   claudeUsage{InputTokens: 1, OutputTokens: 1},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	if !c.Healthy(context.Background()) {
+		t.Error("Healthy = false, want true")
+	}
+}
+
+func TestHealthyDown(t *testing.T) {
+	// Point at an invalid URL to simulate unreachable server.
+	c := New("test-key", "test-model", WithBaseURL("http://127.0.0.1:1"))
+
+	if c.Healthy(context.Background()) {
+		t.Error("Healthy = true, want false for unreachable server")
+	}
+}
+
+func TestHealthyNon200(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	if c.Healthy(context.Background()) {
+		t.Error("Healthy = true, want false for 401 response")
+	}
+}
+
+func TestName(t *testing.T) {
+	c := New("key", "model")
+
+	if got := c.Name(); got != "claude" {
+		t.Errorf("Name() = %q, want %q", got, "claude")
+	}
+}
+
+func TestWithMaxTokens(t *testing.T) {
+	var gotReq claudeRequest
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusOK, claudeResponse{
+			Content: []contentBlock{{Type: "text", Text: "ok"}},
+			Model:   gotReq.Model,
+			Usage:   claudeUsage{InputTokens: 5, OutputTokens: 1},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := New("test-key", "test-model", WithBaseURL(srv.URL), WithMaxTokens(8192))
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if gotReq.MaxTokens != 8192 {
+		t.Errorf("MaxTokens = %d, want 8192", gotReq.MaxTokens)
+	}
+}
+
+func TestCompileTimeInterfaceCheck(t *testing.T) {
+	// This test verifies the compile-time check at the top of claude.go.
+	// If the var _ provider.Provider = (*Client)(nil) line compiles,
+	// Client satisfies the Provider interface.
+	var _ provider.Provider = (*Client)(nil)
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -1,0 +1,208 @@
+// Package openai implements the provider.Provider interface using
+// the OpenAI Chat Completions API over raw net/http (no SDK dependency).
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+// Compile-time check that Client satisfies provider.Provider.
+var _ provider.Provider = (*Client)(nil)
+
+// Client is an HTTP client for the OpenAI Chat Completions API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	model      string
+	maxTokens  int
+	httpClient *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBaseURL overrides the default OpenAI API base URL.
+func WithBaseURL(url string) Option {
+	return func(c *Client) {
+		c.baseURL = strings.TrimRight(url, "/")
+	}
+}
+
+// WithHTTPClient overrides the default HTTP client.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = hc
+	}
+}
+
+// WithMaxTokens overrides the default max_tokens value.
+func WithMaxTokens(n int) Option {
+	return func(c *Client) {
+		c.maxTokens = n
+	}
+}
+
+// New creates a new OpenAI client with the given API key and model.
+func New(apiKey, model string, opts ...Option) *Client {
+	c := &Client{
+		baseURL:   "https://api.openai.com",
+		apiKey:    apiKey,
+		model:     model,
+		maxTokens: 4096,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// chatRequest is the OpenAI Chat Completions request body.
+type chatRequest struct {
+	Model     string        `json:"model"`
+	Messages  []chatMessage `json:"messages"`
+	MaxTokens int           `json:"max_tokens"`
+}
+
+// chatMessage is a single message in the OpenAI format.
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatResponse is the OpenAI Chat Completions response body.
+type chatResponse struct {
+	Choices []choice `json:"choices"`
+	Model   string   `json:"model"`
+	Usage   usage    `json:"usage"`
+}
+
+// choice is a single completion choice.
+type choice struct {
+	Message chatMessage `json:"message"`
+}
+
+// usage contains token usage statistics.
+type usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+// Chat sends a chat completion request to POST /v1/chat/completions.
+func (c *Client) Chat(ctx context.Context, req provider.ChatRequest) (resp *provider.ChatResponse, err error) {
+	// Convert provider messages to OpenAI format (role maps 1:1).
+	msgs := make([]chatMessage, 0, len(req.Messages))
+	for i := range req.Messages {
+		msgs = append(msgs, chatMessage{
+			Role:    string(req.Messages[i].Role),
+			Content: req.Messages[i].Content,
+		})
+	}
+
+	oaiReq := chatRequest{
+		Model:     c.model,
+		Messages:  msgs,
+		MaxTokens: c.maxTokens,
+	}
+
+	var oaiResp chatResponse
+	if err = c.doJSON(ctx, http.MethodPost, "/v1/chat/completions", oaiReq, &oaiResp); err != nil {
+		return nil, fmt.Errorf("openai: chat: %w", err)
+	}
+
+	if len(oaiResp.Choices) == 0 {
+		return nil, fmt.Errorf("openai: chat: empty choices array")
+	}
+
+	resp = &provider.ChatResponse{
+		Model: oaiResp.Model,
+		Message: provider.Message{
+			Role:    provider.Role(oaiResp.Choices[0].Message.Role),
+			Content: oaiResp.Choices[0].Message.Content,
+		},
+		PromptTokens:     oaiResp.Usage.PromptTokens,
+		CompletionTokens: oaiResp.Usage.CompletionTokens,
+	}
+	return resp, nil
+}
+
+// Healthy returns true if the OpenAI API is reachable.
+// It checks GET /v1/models which returns 200 with a list of available models.
+func (c *Client) Healthy(ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/models", http.NoBody)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL is from trusted baseURL config
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK
+}
+
+// Name returns the provider identifier.
+func (c *Client) Name() string {
+	return "openai"
+}
+
+// doJSON is the generic HTTP helper. It marshals body to JSON (if non-nil),
+// makes a request with the given context, sets auth and content-type headers,
+// checks the status code, and unmarshals the response into result (if non-nil).
+func (c *Client) doJSON(ctx context.Context, method, path string, body, result any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	if bodyReader == nil {
+		bodyReader = http.NoBody
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL is from trusted baseURL config
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil {
+		if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -1,0 +1,343 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+// newTestClient creates a Client pointed at a test HTTP server.
+func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := New("test-api-key", "gpt-4o", WithBaseURL(srv.URL))
+	return c, srv
+}
+
+// writeJSON is a test helper that writes a JSON response.
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode json: %v", err)
+	}
+}
+
+func TestChat(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header.
+		if got := r.Header.Get("Authorization"); got != "Bearer test-api-key" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer test-api-key")
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want %q", got, "application/json")
+		}
+
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		writeJSON(t, w, http.StatusOK, chatResponse{
+			Model: req.Model,
+			Choices: []choice{
+				{Message: chatMessage{Role: "assistant", Content: "Hello from OpenAI!"}},
+			},
+			Usage: usage{
+				PromptTokens:     15,
+				CompletionTokens: 8,
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	resp, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if resp.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want %q", resp.Model, "gpt-4o")
+	}
+	if resp.Message.Role != provider.RoleAssistant {
+		t.Errorf("Message.Role = %q, want %q", resp.Message.Role, provider.RoleAssistant)
+	}
+	if resp.Message.Content != "Hello from OpenAI!" {
+		t.Errorf("Message.Content = %q, want %q", resp.Message.Content, "Hello from OpenAI!")
+	}
+	if resp.PromptTokens != 15 {
+		t.Errorf("PromptTokens = %d, want 15", resp.PromptTokens)
+	}
+	if resp.CompletionTokens != 8 {
+		t.Errorf("CompletionTokens = %d, want 8", resp.CompletionTokens)
+	}
+}
+
+func TestChatMapsAllRoles(t *testing.T) {
+	var gotMessages []chatMessage
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotMessages = req.Messages
+
+		writeJSON(t, w, http.StatusOK, chatResponse{
+			Model: req.Model,
+			Choices: []choice{
+				{Message: chatMessage{Role: "assistant", Content: "response"}},
+			},
+			Usage: usage{PromptTokens: 10, CompletionTokens: 5},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: "You are a helpful assistant."},
+			{Role: provider.RoleUser, Content: "Hi"},
+			{Role: provider.RoleAssistant, Content: "Hello!"},
+			{Role: provider.RoleUser, Content: "How are you?"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if len(gotMessages) != 4 {
+		t.Fatalf("len(messages) = %d, want 4", len(gotMessages))
+	}
+
+	wantRoles := []string{"system", "user", "assistant", "user"}
+	for i, want := range wantRoles {
+		if gotMessages[i].Role != want {
+			t.Errorf("messages[%d].Role = %q, want %q", i, gotMessages[i].Role, want)
+		}
+	}
+
+	if gotMessages[0].Content != "You are a helpful assistant." {
+		t.Errorf("messages[0].Content = %q, want system prompt", gotMessages[0].Content)
+	}
+}
+
+func TestChatUsesClientModel(t *testing.T) {
+	var gotModel string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotModel = req.Model
+
+		writeJSON(t, w, http.StatusOK, chatResponse{
+			Model:   req.Model,
+			Choices: []choice{{Message: chatMessage{Role: "assistant", Content: "ok"}}},
+			Usage:   usage{PromptTokens: 1, CompletionTokens: 1},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	// Request specifies a different model -- client should use its configured model.
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if gotModel != "gpt-4o" {
+		t.Errorf("sent model = %q, want client model %q", gotModel, "gpt-4o")
+	}
+}
+
+func TestChatErrorResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"message":"rate limit exceeded"}}`, http.StatusTooManyRequests)
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for 429 response, got nil")
+	}
+}
+
+func TestChatEmptyChoices(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, chatResponse{
+			Model:   "gpt-4o",
+			Choices: []choice{},
+			Usage:   usage{PromptTokens: 10, CompletionTokens: 0},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty choices, got nil")
+	}
+}
+
+func TestHealthy(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/models", func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header is sent.
+		if got := r.Header.Get("Authorization"); got != "Bearer test-api-key" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer test-api-key")
+		}
+		writeJSON(t, w, http.StatusOK, map[string]any{
+			"data": []map[string]string{{"id": "gpt-4o"}},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	if !c.Healthy(context.Background()) {
+		t.Error("Healthy = false, want true")
+	}
+}
+
+func TestHealthyUnauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	if c.Healthy(context.Background()) {
+		t.Error("Healthy = true, want false for unauthorized")
+	}
+}
+
+func TestHealthyDown(t *testing.T) {
+	// Point at an invalid URL to simulate unreachable server.
+	c := New("test-key", "gpt-4o", WithBaseURL("http://127.0.0.1:1"))
+
+	if c.Healthy(context.Background()) {
+		t.Error("Healthy = true, want false for unreachable server")
+	}
+}
+
+func TestName(t *testing.T) {
+	c := New("key", "gpt-4o")
+
+	if got := c.Name(); got != "openai" {
+		t.Errorf("Name() = %q, want %q", got, "openai")
+	}
+}
+
+func TestCompileTimeInterfaceCheck(t *testing.T) {
+	// Verifies the compile-time check at the top of openai.go.
+	var _ provider.Provider = (*Client)(nil)
+}
+
+func TestWithMaxTokens(t *testing.T) {
+	var gotMaxTokens int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotMaxTokens = req.MaxTokens
+
+		writeJSON(t, w, http.StatusOK, chatResponse{
+			Model:   req.Model,
+			Choices: []choice{{Message: chatMessage{Role: "assistant", Content: "ok"}}},
+			Usage:   usage{PromptTokens: 1, CompletionTokens: 1},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := New("key", "gpt-4o", WithBaseURL(srv.URL), WithMaxTokens(8192))
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if gotMaxTokens != 8192 {
+		t.Errorf("max_tokens = %d, want 8192", gotMaxTokens)
+	}
+}
+
+func TestDefaultMaxTokens(t *testing.T) {
+	var gotMaxTokens int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotMaxTokens = req.MaxTokens
+
+		writeJSON(t, w, http.StatusOK, chatResponse{
+			Model:   req.Model,
+			Choices: []choice{{Message: chatMessage{Role: "assistant", Content: "ok"}}},
+			Usage:   usage{PromptTokens: 1, CompletionTokens: 1},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if gotMaxTokens != 4096 {
+		t.Errorf("default max_tokens = %d, want 4096", gotMaxTokens)
+	}
+}


### PR DESCRIPTION
## Summary

- Implement `provider.Provider` for Anthropic Claude Messages API using raw `net/http`
- Implement `provider.Provider` for OpenAI Chat Completions API using raw `net/http`
- Both follow the established Ollama client pattern (doJSON helper, functional options, compile-time interface checks)
- 24 tests total with httptest mocks, zero lint issues

## Phase 5 Wave 1

Closes #130, Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)