### PR TITLE
feat: wire dispatcher to agent pool for task execution (#135)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -9,13 +9,19 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/herbhall/samverk/internal/agent"
 	"github.com/herbhall/samverk/internal/api"
 	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/internal/cost"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/dispatcher"
 	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/internal/forge/github"
 	internalmcp "github.com/herbhall/samverk/internal/mcp"
+	"github.com/herbhall/samverk/internal/provider"
+	"github.com/herbhall/samverk/internal/provider/claude"
+	"github.com/herbhall/samverk/internal/provider/ollama"
+	"github.com/herbhall/samverk/internal/provider/openai"
 	"github.com/herbhall/samverk/internal/server"
 	"github.com/herbhall/samverk/internal/store"
 	"github.com/herbhall/samverk/internal/version"
@@ -192,8 +198,9 @@ func serveCmd() *cobra.Command {
 }
 
 func dispatchCmd() *cobra.Command {
-	var owner, repo, dbPath string
-	var pollSeconds int
+	var owner, repo, dbPath, providersConfig string
+	var pollSeconds, workers int
+	var budget float64
 
 	cmd := &cobra.Command{
 		Use:   "dispatch",
@@ -241,7 +248,21 @@ func dispatchCmd() *cobra.Command {
 				}
 			}
 
-			disp := dispatcher.New(ghClient, policy, st, nil)
+			// Load provider registry and construct agent pool if config exists.
+			var pool *agent.Pool
+			if providersConfig != "" {
+				registry, regErr := provider.LoadRegistry(providersConfig, providerFactory)
+				if regErr != nil {
+					slog.Warn("could not load provider registry, agents disabled", "path", providersConfig, "error", regErr)
+				} else {
+					costs := cost.NewTracker(st, budget, 24)
+					pool = agent.NewPool(registry, ghClient, st, costs, workers)
+					defer pool.Shutdown()
+					slog.Info("agent pool started", "workers", workers, "providers", len(registry.List(ctx)))
+				}
+			}
+
+			disp := dispatcher.New(ghClient, policy, st, pool, nil)
 			slog.Info("starting dispatcher", "owner", owner, "repo", repo)
 
 			if err := disp.Run(ctx); err != nil && err != context.Canceled {
@@ -254,7 +275,10 @@ func dispatchCmd() *cobra.Command {
 	cmd.Flags().StringVar(&owner, "owner", "", "GitHub repository owner")
 	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository name")
 	cmd.Flags().StringVar(&dbPath, "db", ".samverk/samverk.db", "Path to SQLite database")
+	cmd.Flags().StringVar(&providersConfig, "providers-config", ".samverk/providers.yaml", "Path to provider registry YAML config")
 	cmd.Flags().IntVar(&pollSeconds, "poll-interval", 30, "Polling interval in seconds")
+	cmd.Flags().IntVar(&workers, "workers", 3, "Number of agent worker goroutines")
+	cmd.Flags().Float64Var(&budget, "budget", 0, "Daily budget in USD (0 = unlimited)")
 
 	return cmd
 }
@@ -448,5 +472,41 @@ func versionCmd() *cobra.Command {
 			fmt.Printf("samverk %s (commit: %s, built: %s)\n",
 				version.Version, version.GitCommit, version.BuildDate)
 		},
+	}
+}
+
+// providerFactory constructs a provider.Provider from YAML config.
+// It wires the concrete provider sub-packages (claude, openai, ollama)
+// so the registry package doesn't import them directly.
+func providerFactory(name string, cfg provider.ProviderConfig) (provider.Provider, error) {
+	switch cfg.Type {
+	case "claude":
+		apiKey := os.Getenv(cfg.APIKeyEnv)
+		if apiKey == "" {
+			return nil, fmt.Errorf("provider %q: env var %s is not set", name, cfg.APIKeyEnv)
+		}
+		model := cfg.DefaultModel
+		if model == "" {
+			model = "claude-sonnet-4-20250514"
+		}
+		return claude.New(apiKey, model), nil
+	case "openai":
+		apiKey := os.Getenv(cfg.APIKeyEnv)
+		if apiKey == "" {
+			return nil, fmt.Errorf("provider %q: env var %s is not set", name, cfg.APIKeyEnv)
+		}
+		model := cfg.DefaultModel
+		if model == "" {
+			model = "gpt-4o"
+		}
+		return openai.New(apiKey, model), nil
+	case "ollama":
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "http://localhost:11434"
+		}
+		return ollama.New(baseURL), nil
+	default:
+		return nil, fmt.Errorf("provider %q: unknown type %q", name, cfg.Type)
 	}
 }

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/herbhall/samverk/internal/agent"
 	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/internal/store"
@@ -28,6 +29,7 @@ type Dispatcher struct {
 	tracker forge.IssueTracker
 	policy  autonomy.AutonomyPolicy
 	store   store.Store
+	pool    *agent.Pool
 	config  *Config
 	claimed map[int]*claimedIssue
 	mu      sync.Mutex
@@ -35,8 +37,9 @@ type Dispatcher struct {
 	stop    context.CancelFunc
 }
 
-// New creates a Dispatcher with the given dependencies.
-func New(tracker forge.IssueTracker, policy autonomy.AutonomyPolicy, st store.Store, cfg *Config) *Dispatcher {
+// New creates a Dispatcher with the given dependencies. The pool parameter
+// is optional; when nil, routed issues are labeled but no agent tasks are spawned.
+func New(tracker forge.IssueTracker, policy autonomy.AutonomyPolicy, st store.Store, pool *agent.Pool, cfg *Config) *Dispatcher {
 	if cfg == nil {
 		cfg = DefaultConfig()
 	}
@@ -44,6 +47,7 @@ func New(tracker forge.IssueTracker, policy autonomy.AutonomyPolicy, st store.St
 		tracker: tracker,
 		policy:  policy,
 		store:   st,
+		pool:    pool,
 		config:  cfg,
 		claimed: make(map[int]*claimedIssue),
 		logger:  log.Default(),

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -254,14 +254,14 @@ func newTestDispatcher(tracker *mockTracker) *Dispatcher {
 	// Use short intervals for tests.
 	cfg.HeartbeatInterval = 100 * time.Millisecond
 	cfg.HeartbeatCheckInterval = 50 * time.Millisecond
-	return New(tracker, &mockPolicy{costThreshold: 5.0}, nil, cfg)
+	return New(tracker, &mockPolicy{costThreshold: 5.0}, nil, nil, cfg)
 }
 
 // --- Tests ---
 
 func TestNewDispatcher(t *testing.T) {
 	tracker := newMockTracker()
-	d := New(tracker, &mockPolicy{costThreshold: 5.0}, nil, nil)
+	d := New(tracker, &mockPolicy{costThreshold: 5.0}, nil, nil, nil)
 	if d == nil {
 		t.Fatal("expected non-nil dispatcher")
 	}

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/herbhall/samverk/internal/agent"
 	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/pkg/models"
 )
@@ -63,6 +64,31 @@ func (d *Dispatcher) route(ctx context.Context, issue *forge.Issue, agentType mo
 	d.mu.Unlock()
 
 	d.logger.Printf("routed issue #%d to %s", issue.Number, agentType)
+
+	// Submit to agent pool if available.
+	if d.pool != nil && d.store != nil {
+		sessionID := fmt.Sprintf("sess_%d_%d", issue.Number, time.Now().Unix())
+		session := &models.Session{
+			ID:          sessionID,
+			IssueNumber: issue.Number,
+			AgentType:   string(agentType),
+			Status:      models.SessionStatusPending,
+			StartedAt:   time.Now(),
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		}
+		if err := d.store.CreateSession(ctx, session); err != nil {
+			return fmt.Errorf("create session for #%d: %w", issue.Number, err)
+		}
+		task := agent.Task{
+			Issue:     issue,
+			AgentType: agentType,
+			SessionID: sessionID,
+		}
+		if err := d.pool.Submit(task); err != nil {
+			return fmt.Errorf("submit agent task for #%d: %w", issue.Number, err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Wire `dispatcher.route()` to `agent.Pool.Submit()` so routed issues spawn agent tasks with session lifecycle tracking
- Add `providerFactory` in `cmd/samverk/main.go` that maps YAML config types (`claude`, `openai`, `ollama`) to concrete provider clients
- Add `--providers-config`, `--workers`, and `--budget` flags to `samverk dispatch` command
- Update `dispatcher.New()` signature to accept optional `*agent.Pool` (nil-safe: when nil, issues are labeled but no agents spawn)

## Test plan

- [x] All 17 test packages pass (203+ tests)
- [x] Cross-compile `GOOS=linux GOARCH=amd64 go build ./...`
- [x] golangci-lint: 0 issues
- [x] Pre-push hook: build + test + lint + markdownlint all pass

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)