### PR TITLE
fix: dispatcher heuristic fallback for issues without frontmatter

### DIFF
--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/pkg/models"
 )
 
 // mockTracker implements forge.IssueTracker for testing.
@@ -359,6 +360,170 @@ func TestHandleOpened_NoFrontmatter(t *testing.T) {
 
 	if !hasLabel(issue.Labels, "status:needs-human") {
 		t.Error("expected status:needs-human label for missing frontmatter")
+	}
+}
+
+func TestClassifyByHeuristic(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		labels   []string
+		wantType models.AgentType
+	}{
+		{
+			name:     "agent:human label",
+			title:    "Some issue",
+			labels:   []string{"agent:human"},
+			wantType: models.AgentTypeHuman,
+		},
+		{
+			name:     "type:spike label",
+			title:    "Investigate options",
+			labels:   []string{"type:spike"},
+			wantType: models.AgentTypeResearch,
+		},
+		{
+			name:     "type:research label",
+			title:    "Explore alternatives",
+			labels:   []string{"type:research"},
+			wantType: models.AgentTypeResearch,
+		},
+		{
+			name:     "bug label",
+			title:    "Something is broken",
+			labels:   []string{"bug"},
+			wantType: models.AgentTypeCodeGen,
+		},
+		{
+			name:     "fix: title prefix",
+			title:    "fix: null pointer in handler",
+			labels:   nil,
+			wantType: models.AgentTypeCodeGen,
+		},
+		{
+			name:     "feat: title prefix",
+			title:    "feat: add dark mode",
+			labels:   nil,
+			wantType: models.AgentTypeCodeGen,
+		},
+		{
+			name:     "feature: title prefix",
+			title:    "feature: new dashboard",
+			labels:   nil,
+			wantType: models.AgentTypeCodeGen,
+		},
+		{
+			name:     "docs: title prefix",
+			title:    "docs: update README",
+			labels:   nil,
+			wantType: models.AgentTypeDocs,
+		},
+		{
+			name:     "chore: title prefix",
+			title:    "chore: bump dependencies",
+			labels:   nil,
+			wantType: models.AgentTypeDocs,
+		},
+		{
+			name:     "test: title prefix",
+			title:    "test: add unit tests for router",
+			labels:   nil,
+			wantType: models.AgentTypeTest,
+		},
+		{
+			name:     "agent:human takes priority over bug",
+			title:    "Something broken",
+			labels:   []string{"agent:human", "bug"},
+			wantType: models.AgentTypeHuman,
+		},
+		{
+			name:     "no match returns empty",
+			title:    "Random issue title",
+			labels:   []string{"enhancement"},
+			wantType: "",
+		},
+		{
+			name:     "case insensitive title prefix",
+			title:    "FIX: uppercase prefix",
+			labels:   nil,
+			wantType: models.AgentTypeCodeGen,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &forge.Issue{
+				Number: 99,
+				Title:  tt.title,
+				Labels: tt.labels,
+			}
+			got := classifyByHeuristic(issue)
+			if got != tt.wantType {
+				t.Errorf("classifyByHeuristic() = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestHandleOpened_NoFrontmatter_BugLabel(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	issue := &forge.Issue{
+		Number: 1,
+		Title:  "Something is broken",
+		Body:   "No frontmatter here, just a plain issue body.",
+		State:  forge.StateOpen,
+		Labels: []string{"bug"},
+	}
+	tracker.issues[1] = issue
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 1,
+		Issue:       issue,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if hasLabel(issue.Labels, "status:needs-human") {
+		t.Error("did not expect status:needs-human for issue with bug label")
+	}
+	if !hasLabel(issue.Labels, "status:claimed") {
+		t.Error("expected status:claimed after heuristic routing")
+	}
+}
+
+func TestHandleOpened_NoFrontmatter_AgentHumanLabel(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	issue := &forge.Issue{
+		Number: 1,
+		Title:  "Design review needed",
+		Body:   "Plain issue without frontmatter.",
+		State:  forge.StateOpen,
+		Labels: []string{"agent:human"},
+	}
+	tracker.issues[1] = issue
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 1,
+		Issue:       issue,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if hasLabel(issue.Labels, "status:needs-human") {
+		t.Error("did not expect status:needs-human for agent:human label")
+	}
+	if !hasLabel(issue.Labels, "status:claimed") {
+		t.Error("expected status:claimed after heuristic routing")
+	}
+	if len(issue.Assignees) == 0 || issue.Assignees[0] != "human" {
+		t.Errorf("expected assignee human, got %v", issue.Assignees)
 	}
 }
 

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -3,6 +3,7 @@ package dispatcher
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/herbhall/samverk/internal/agent"
@@ -30,7 +31,10 @@ func (d *Dispatcher) classify(_ context.Context, issue *forge.Issue) (models.Age
 		return "", fmt.Errorf("classify issue #%d: %w", issue.Number, err)
 	}
 	if fm == nil {
-		return "", fmt.Errorf("classify issue #%d: no frontmatter found", issue.Number)
+		if at := classifyByHeuristic(issue); at != "" {
+			return at, nil
+		}
+		return "", fmt.Errorf("classify issue #%d: no frontmatter found and no heuristic match", issue.Number)
 	}
 	if fm.AgentType == "" {
 		return "", fmt.Errorf("classify issue #%d: agent_type is empty", issue.Number)
@@ -39,6 +43,44 @@ func (d *Dispatcher) classify(_ context.Context, issue *forge.Issue) (models.Age
 		return "", fmt.Errorf("classify issue #%d: unknown agent_type %q", issue.Number, fm.AgentType)
 	}
 	return fm.AgentType, nil
+}
+
+// classifyByHeuristic attempts to determine the agent type from issue labels
+// and title prefix when no YAML frontmatter is present.
+// Returns empty string if no heuristic matches.
+func classifyByHeuristic(issue *forge.Issue) models.AgentType {
+	labels := make(map[string]bool, len(issue.Labels))
+	for _, l := range issue.Labels {
+		labels[l] = true
+	}
+
+	// Label-based rules (highest priority).
+	if labels["agent:human"] {
+		return models.AgentTypeHuman
+	}
+	if labels["type:spike"] || labels["type:research"] {
+		return models.AgentTypeResearch
+	}
+	if labels["bug"] {
+		return models.AgentTypeCodeGen
+	}
+
+	// Title-prefix rules.
+	lower := strings.ToLower(issue.Title)
+	switch {
+	case strings.HasPrefix(lower, "fix:") || strings.HasPrefix(lower, "fix("):
+		return models.AgentTypeCodeGen
+	case strings.HasPrefix(lower, "feat:") || strings.HasPrefix(lower, "feat("),
+		strings.HasPrefix(lower, "feature:") || strings.HasPrefix(lower, "feature("):
+		return models.AgentTypeCodeGen
+	case strings.HasPrefix(lower, "docs:") || strings.HasPrefix(lower, "docs("),
+		strings.HasPrefix(lower, "chore:") || strings.HasPrefix(lower, "chore("):
+		return models.AgentTypeDocs
+	case strings.HasPrefix(lower, "test:") || strings.HasPrefix(lower, "test("):
+		return models.AgentTypeTest
+	}
+
+	return ""
 }
 
 // route assigns the issue to the agent pool matching agentType.


### PR DESCRIPTION
## Summary

- When an issue has no YAML frontmatter, the dispatcher now attempts heuristic classification using issue labels and title prefix before escalating to `status:needs-human`
- Heuristic priority: `agent:human` label > `type:spike`/`type:research` labels > `bug` label > `fix:`/`feat:` title prefix > `docs:`/`chore:` title prefix > `test:` title prefix
- Only genuinely unclassifiable issues (no frontmatter, no matching labels, no recognized title prefix) escalate

Fixes #180

## Test plan

- [x] Unit test: `classifyByHeuristic` with 13 table-driven cases covering all heuristic rules, priority ordering, case insensitivity, and no-match fallback
- [x] Integration test: `TestHandleOpened_NoFrontmatter_BugLabel` — issue with `bug` label routes to `code-gen`, not `needs-human`
- [x] Integration test: `TestHandleOpened_NoFrontmatter_AgentHumanLabel` — issue with `agent:human` label routes to `human`
- [x] Existing test: `TestHandleOpened_NoFrontmatter` — plain issue with no labels/prefix still escalates (preserved)
- [x] All 264 tests pass, 0 lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)