### PR TITLE
feat: code-gen and test agents open PRs instead of posting comments

### DIFF
--- a/internal/agent/editparser.go
+++ b/internal/agent/editparser.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"strings"
+)
+
+// FileEdit represents a single file edit extracted from an agent response.
+type FileEdit struct {
+	Path    string
+	Content string
+}
+
+// ParseResponse holds the parsed result of an agent's response.
+type ParseResponse struct {
+	Edits   []FileEdit
+	PRTitle string
+}
+
+// ParseEditBlocks extracts EDIT/END file blocks and the PR_TITLE line
+// from an agent response string. Returns nil edits if no EDIT blocks found.
+func ParseEditBlocks(response string) *ParseResponse {
+	result := &ParseResponse{}
+	lines := strings.Split(response, "\n")
+
+	var currentPath string
+	var currentContent strings.Builder
+	inBlock := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "PR_TITLE:") {
+			result.PRTitle = strings.TrimSpace(strings.TrimPrefix(trimmed, "PR_TITLE:"))
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "EDIT ") && !inBlock {
+			currentPath = strings.TrimSpace(strings.TrimPrefix(trimmed, "EDIT "))
+			currentContent.Reset()
+			inBlock = true
+			continue
+		}
+
+		if trimmed == "END" && inBlock {
+			content := currentContent.String()
+			// Remove leading newline if present (artifact of first line after EDIT).
+			content = strings.TrimPrefix(content, "\n")
+			result.Edits = append(result.Edits, FileEdit{
+				Path:    currentPath,
+				Content: content,
+			})
+			inBlock = false
+			continue
+		}
+
+		if inBlock {
+			if currentContent.Len() > 0 {
+				currentContent.WriteByte('\n')
+			}
+			currentContent.WriteString(line)
+		}
+	}
+
+	return result
+}
+
+// BranchSlug generates a branch name from an issue number and title.
+// Format: agent/issue-{N}-{slug}, truncated to 50 chars.
+func BranchSlug(issueNumber int, title string) string {
+	words := strings.Fields(strings.ToLower(title))
+	if len(words) > 5 {
+		words = words[:5]
+	}
+
+	// Keep only alphanumeric and hyphens.
+	var parts []string
+	for _, w := range words {
+		var clean strings.Builder
+		for _, r := range w {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+				clean.WriteRune(r)
+			}
+		}
+		if s := clean.String(); s != "" {
+			parts = append(parts, s)
+		}
+	}
+
+	slug := strings.Join(parts, "-")
+	branch := "agent/issue-" + itoa(issueNumber) + "-" + slug
+
+	if len(branch) > 50 {
+		branch = branch[:50]
+	}
+	// Remove trailing hyphen.
+	branch = strings.TrimRight(branch, "-")
+
+	return branch
+}
+
+// itoa is a simple int-to-string without importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	if n < 0 {
+		return "-" + itoa(-n)
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/internal/agent/editparser_test.go
+++ b/internal/agent/editparser_test.go
@@ -1,0 +1,165 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseEditBlocks(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantEdits int
+		wantTitle string
+		wantPaths []string
+	}{
+		{
+			name: "single edit block",
+			input: `EDIT internal/foo.go
+package foo
+
+func Hello() string { return "hello" }
+END
+
+PR_TITLE: feat: add hello function`,
+			wantEdits: 1,
+			wantTitle: "feat: add hello function",
+			wantPaths: []string{"internal/foo.go"},
+		},
+		{
+			name: "multiple edit blocks",
+			input: `EDIT internal/foo.go
+package foo
+END
+
+EDIT internal/foo_test.go
+package foo
+
+import "testing"
+END
+
+PR_TITLE: test: add foo tests`,
+			wantEdits: 2,
+			wantTitle: "test: add foo tests",
+			wantPaths: []string{"internal/foo.go", "internal/foo_test.go"},
+		},
+		{
+			name:      "no edit blocks - prose response",
+			input:     "I analyzed the issue and here are my findings...",
+			wantEdits: 0,
+			wantTitle: "",
+		},
+		{
+			name: "edit blocks without PR_TITLE",
+			input: `EDIT cmd/main.go
+package main
+END`,
+			wantEdits: 1,
+			wantTitle: "",
+			wantPaths: []string{"cmd/main.go"},
+		},
+		{
+			name: "PR_TITLE without edit blocks",
+			input: `Some prose response.
+PR_TITLE: fix: handle edge case`,
+			wantEdits: 0,
+			wantTitle: "fix: handle edge case",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseEditBlocks(tt.input)
+
+			if len(got.Edits) != tt.wantEdits {
+				t.Errorf("got %d edits, want %d", len(got.Edits), tt.wantEdits)
+			}
+
+			if got.PRTitle != tt.wantTitle {
+				t.Errorf("PRTitle = %q, want %q", got.PRTitle, tt.wantTitle)
+			}
+
+			for i, wantPath := range tt.wantPaths {
+				if i >= len(got.Edits) {
+					break
+				}
+				if got.Edits[i].Path != wantPath {
+					t.Errorf("edit[%d].Path = %q, want %q", i, got.Edits[i].Path, wantPath)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEditBlocks_ContentPreservation(t *testing.T) {
+	input := `EDIT internal/foo.go
+package foo
+
+// Hello returns a greeting.
+func Hello() string {
+	return "hello"
+}
+END`
+
+	got := ParseEditBlocks(input)
+	if len(got.Edits) != 1 {
+		t.Fatalf("got %d edits, want 1", len(got.Edits))
+	}
+
+	content := got.Edits[0].Content
+	if !strings.Contains(content, "package foo") {
+		t.Error("content missing package declaration")
+	}
+	if !strings.Contains(content, "// Hello returns a greeting.") {
+		t.Error("content missing comment")
+	}
+	if !strings.Contains(content, `return "hello"`) {
+		t.Error("content missing return statement")
+	}
+}
+
+func TestBranchSlug(t *testing.T) {
+	tests := []struct {
+		name   string
+		number int
+		title  string
+		want   string
+	}{
+		{
+			name:   "simple title",
+			number: 42,
+			title:  "fix widget rendering",
+			want:   "agent/issue-42-fix-widget-rendering",
+		},
+		{
+			name:   "long title truncated",
+			number: 100,
+			title:  "implement the entire authentication subsystem with OAuth support",
+			want:   "agent/issue-100-implement-the-entire-authenticatio",
+		},
+		{
+			name:   "special characters stripped",
+			number: 5,
+			title:  "fix: handle edge-case (null values)",
+			want:   "agent/issue-5-fix-handle-edge-case-null-values",
+		},
+		{
+			name:   "single word",
+			number: 1,
+			title:  "bug",
+			want:   "agent/issue-1-bug",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BranchSlug(tt.number, tt.title)
+			if got != tt.want {
+				t.Errorf("BranchSlug(%d, %q) = %q, want %q", tt.number, tt.title, got, tt.want)
+			}
+			if len(got) > 50 {
+				t.Errorf("branch name too long: %d chars", len(got))
+			}
+		})
+	}
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -17,17 +17,21 @@ import (
 )
 
 // Runner executes a single agent task: sends the issue to an AI provider,
-// records cost, and posts the response as an issue comment.
+// records cost, and posts the response as an issue comment or opens a PR.
 type Runner struct {
-	provider provider.Provider
-	model    string
-	tracker  forge.IssueTracker
-	store    store.Store
-	costs    *cost.Tracker
-	logger   *slog.Logger
+	provider   provider.Provider
+	model      string
+	tracker    forge.IssueTracker
+	repoWriter forge.RepoWriter
+	prManager  forge.PullRequestManager
+	store      store.Store
+	costs      *cost.Tracker
+	logger     *slog.Logger
 }
 
 // NewRunner creates a runner bound to a specific provider and model.
+// The repoWriter and prManager are optional; when nil, code-gen/test agents
+// fall back to posting comments instead of opening PRs.
 func NewRunner(p provider.Provider, model string, tracker forge.IssueTracker, st store.Store, costs *cost.Tracker) *Runner {
 	return &Runner{
 		provider: p,
@@ -37,6 +41,16 @@ func NewRunner(p provider.Provider, model string, tracker forge.IssueTracker, st
 		costs:    costs,
 		logger:   slog.Default(),
 	}
+}
+
+// SetRepoWriter configures write access for branch/file operations.
+func (r *Runner) SetRepoWriter(rw forge.RepoWriter) {
+	r.repoWriter = rw
+}
+
+// SetPRManager configures pull request operations.
+func (r *Runner) SetPRManager(pm forge.PullRequestManager) {
+	r.prManager = pm
 }
 
 // Run processes a single task through the AI provider pipeline.
@@ -94,15 +108,89 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		// Non-fatal: continue even if cost recording fails.
 	}
 
-	// Step 6: Post response as comment.
-	if _, err = r.tracker.AddComment(ctx, task.Issue.Number, resp.Message.Content); err != nil {
-		r.failTask(ctx, task, fmt.Sprintf("failed to post comment: %v", err))
-		return fmt.Errorf("add comment: %w", err)
+	// Step 6: Post-process response based on agent type.
+	if err = r.postProcess(ctx, task, resp.Message.Content); err != nil {
+		r.failTask(ctx, task, fmt.Sprintf("post-process error: %v", err))
+		return fmt.Errorf("post-process: %w", err)
 	}
 
 	// Step 7: Mark session completed.
 	if err = r.completeSession(ctx, task.SessionID); err != nil {
 		return fmt.Errorf("complete session: %w", err)
+	}
+
+	return nil
+}
+
+// postProcess routes the provider response to the appropriate output handler.
+// Code-gen and test agents open PRs when EDIT blocks are present and forge
+// write access is configured; all others post comments.
+func (r *Runner) postProcess(ctx context.Context, task Task, response string) error {
+	switch task.AgentType {
+	case models.AgentTypeCodeGen, models.AgentTypeTest:
+		if r.repoWriter != nil && r.prManager != nil {
+			parsed := ParseEditBlocks(response)
+			if len(parsed.Edits) > 0 {
+				return r.openPR(ctx, task, parsed)
+			}
+		}
+		// No EDIT blocks or no write access — fall back to comment.
+		return r.postComment(ctx, task, response)
+	default:
+		return r.postComment(ctx, task, response)
+	}
+}
+
+// postComment posts the response as an issue comment.
+func (r *Runner) postComment(ctx context.Context, task Task, response string) error {
+	if _, err := r.tracker.AddComment(ctx, task.Issue.Number, response); err != nil {
+		return fmt.Errorf("add comment: %w", err)
+	}
+	return nil
+}
+
+// openPR creates a branch, writes files, and opens a pull request.
+func (r *Runner) openPR(ctx context.Context, task Task, parsed *ParseResponse) error {
+	branch := BranchSlug(task.Issue.Number, task.Issue.Title)
+
+	// Create branch from main.
+	if err := r.repoWriter.CreateBranch(ctx, branch); err != nil {
+		return fmt.Errorf("create branch %q: %w", branch, err)
+	}
+
+	// Write each file edit to the branch.
+	for _, edit := range parsed.Edits {
+		msg := fmt.Sprintf("agent: update %s for issue #%d", edit.Path, task.Issue.Number)
+		if err := r.repoWriter.CreateOrUpdateFile(ctx, branch, edit.Path, edit.Content, msg); err != nil {
+			return fmt.Errorf("write file %q: %w", edit.Path, err)
+		}
+	}
+
+	// Determine PR title.
+	prTitle := parsed.PRTitle
+	if prTitle == "" {
+		prTitle = fmt.Sprintf("agent: resolve issue #%d", task.Issue.Number)
+	}
+
+	// Open PR.
+	pr, err := r.prManager.CreatePullRequest(ctx, &forge.CreatePRRequest{
+		Title: prTitle,
+		Body:  fmt.Sprintf("Closes #%d\n\nAgent-generated implementation.", task.Issue.Number),
+		Head:  branch,
+		Base:  "main",
+	})
+	if err != nil {
+		return fmt.Errorf("create PR: %w", err)
+	}
+
+	// Post comment on issue with PR link.
+	comment := fmt.Sprintf("PR opened: #%d", pr.Number)
+	if _, err = r.tracker.AddComment(ctx, task.Issue.Number, comment); err != nil {
+		r.logger.Error("failed to post PR link comment",
+			slog.String("session_id", task.SessionID),
+			slog.Int("issue", task.Issue.Number),
+			slog.String("error", err.Error()),
+		)
 	}
 
 	return nil

--- a/internal/forge/gitea/gitea.go
+++ b/internal/forge/gitea/gitea.go
@@ -13,8 +13,11 @@ import (
 	"github.com/herbhall/samverk/internal/forge"
 )
 
-// Compile-time interface check.
-var _ forge.IssueTracker = (*Client)(nil)
+// Compile-time interface checks.
+var (
+	_ forge.IssueTracker = (*Client)(nil)
+	_ forge.RepoWriter   = (*Client)(nil)
+)
 
 // Client implements forge.IssueTracker for Gitea repositories.
 type Client struct {
@@ -479,6 +482,19 @@ func extractAssigneeLogins(users []*gogitea.User) []string {
 		result = append(result, users[i].UserName)
 	}
 	return result
+}
+
+// ErrNotImplemented is returned by Gitea methods that are not yet implemented.
+var ErrNotImplemented = fmt.Errorf("gitea: not implemented")
+
+// CreateBranch is not yet implemented for Gitea.
+func (c *Client) CreateBranch(_ context.Context, _ string) error {
+	return ErrNotImplemented
+}
+
+// CreateOrUpdateFile is not yet implemented for Gitea.
+func (c *Client) CreateOrUpdateFile(_ context.Context, _, _, _, _ string) error {
+	return ErrNotImplemented
 }
 
 // stringSliceEqual reports whether two string slices have the same elements.

--- a/internal/forge/github/repo.go
+++ b/internal/forge/github/repo.go
@@ -10,8 +10,11 @@ import (
 	"github.com/herbhall/samverk/internal/forge"
 )
 
-// Compile-time interface check.
-var _ forge.RepoReader = (*Client)(nil)
+// Compile-time interface checks.
+var (
+	_ forge.RepoReader = (*Client)(nil)
+	_ forge.RepoWriter = (*Client)(nil)
+)
 
 // ListFiles returns the files and directories at the given path and ref.
 // If path is empty, the repository root is listed.
@@ -164,6 +167,62 @@ func (c *Client) GetCommitLog(ctx context.Context, branch string, limit int) ([]
 	}
 
 	return commits, nil
+}
+
+// CreateBranch creates a new branch from the default branch HEAD.
+func (c *Client) CreateBranch(ctx context.Context, name string) error {
+	// Get the default branch SHA.
+	ref, resp, err := c.gh.Git.GetRef(ctx, c.owner, c.repo, "refs/heads/main")
+	if err != nil {
+		return fmt.Errorf("github: get main ref: %w", err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	newRef := &gogithub.Reference{
+		Ref:    gogithub.Ptr("refs/heads/" + name),
+		Object: &gogithub.GitObject{SHA: ref.Object.SHA},
+	}
+
+	_, resp2, err := c.gh.Git.CreateRef(ctx, c.owner, c.repo, newRef)
+	if err != nil {
+		return fmt.Errorf("github: create branch %q: %w", name, err)
+	}
+	if resp2 != nil && resp2.Body != nil {
+		defer func() { _ = resp2.Body.Close() }()
+	}
+
+	return nil
+}
+
+// CreateOrUpdateFile creates or updates a file on the given branch.
+func (c *Client) CreateOrUpdateFile(ctx context.Context, branch, path, content, message string) error {
+	opts := &gogithub.RepositoryContentFileOptions{
+		Message: gogithub.Ptr(message),
+		Content: []byte(content),
+		Branch:  gogithub.Ptr(branch),
+	}
+
+	// Check if file exists to get its SHA for updates.
+	existing, _, resp, err := c.gh.Repositories.GetContents(ctx, c.owner, c.repo, path,
+		&gogithub.RepositoryContentGetOptions{Ref: branch})
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	if err == nil && existing != nil {
+		opts.SHA = gogithub.Ptr(existing.GetSHA())
+	}
+
+	_, resp2, err := c.gh.Repositories.CreateFile(ctx, c.owner, c.repo, path, opts)
+	if err != nil {
+		return fmt.Errorf("github: create/update file %q on %q: %w", path, branch, err)
+	}
+	if resp2 != nil && resp2.Body != nil {
+		defer func() { _ = resp2.Body.Close() }()
+	}
+
+	return nil
 }
 
 // SearchCode searches for code matching the query within this repository.

--- a/internal/forge/repo.go
+++ b/internal/forge/repo.go
@@ -38,6 +38,15 @@ type Commit struct {
 	Date    time.Time `json:"date"`
 }
 
+// RepoWriter provides write access to a git repository's contents.
+type RepoWriter interface {
+	// CreateBranch creates a new branch from the default branch HEAD.
+	CreateBranch(ctx context.Context, name string) error
+
+	// CreateOrUpdateFile creates or updates a file on the given branch.
+	CreateOrUpdateFile(ctx context.Context, branch, path, content, message string) error
+}
+
 // SearchResult represents a single code search match.
 type SearchResult struct {
 	Path       string `json:"path"`


### PR DESCRIPTION
## Summary

- Extended `forge` with `RepoWriter` interface (`CreateBranch`, `CreateOrUpdateFile`)
- GitHub adapter implements both methods via go-github; Gitea stubs with `ErrNotImplemented`
- Added EDIT/END block parser (`editparser.go`) that extracts file edits and `PR_TITLE` from agent responses
- Runner routes code-gen/test tasks through `openPR` when EDIT blocks are present; falls back to comment posting otherwise
- Branch naming: `agent/issue-{N}-{slug}`, truncated to 50 chars

## Test plan

- [x] EDIT/END parser: 5 cases (single, multiple, no blocks, no title, title only)
- [x] Content preservation test for multi-line file edits
- [x] Branch slug generation: 4 cases (simple, long/truncated, special chars, single word)
- [x] All existing runner/pool/prompt tests still pass
- [x] `make ci` passes (build, test, lint, markdownlint)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)