### PR TITLE
feat: PR watcher auto-merges eligible pull requests

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/internal/forge/github"
 	internalmcp "github.com/herbhall/samverk/internal/mcp"
+	"github.com/herbhall/samverk/internal/prwatcher"
 	"github.com/herbhall/samverk/internal/provider"
 	"github.com/herbhall/samverk/internal/provider/claude"
 	"github.com/herbhall/samverk/internal/provider/ollama"
@@ -27,6 +28,7 @@ import (
 	"github.com/herbhall/samverk/internal/version"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 )
 
 func main() {
@@ -268,8 +270,22 @@ func dispatchCmd() *cobra.Command {
 			disp := dispatcher.New(ghClient, policy, st, pool, nil)
 			slog.Info("starting dispatcher", "owner", owner, "repo", repo)
 
-			if err := disp.Run(ctx); err != nil && err != context.Canceled {
-				return fmt.Errorf("dispatcher error: %w", err)
+			g, gctx := errgroup.WithContext(ctx)
+
+			g.Go(func() error {
+				return disp.Run(gctx)
+			})
+
+			// Start PR watcher if auto-merge is enabled.
+			if policyCfg.Merge.AutoMergeOnCIPass {
+				pw := prwatcher.New(ghClient, policyCfg.Merge, time.Duration(pollSeconds)*time.Second)
+				g.Go(func() error {
+					return pw.Run(gctx)
+				})
+			}
+
+			if err := g.Wait(); err != nil && err != context.Canceled {
+				return fmt.Errorf("dispatch error: %w", err)
 			}
 			return nil
 		},

--- a/deploy/config/autonomy.yaml
+++ b/deploy/config/autonomy.yaml
@@ -7,3 +7,13 @@ defaults:
 tier_overrides: {}
 agents: {}
 branches: {}
+
+merge:
+  auto_merge_on_ci_pass: true
+  trusted_authors:
+    - herbhall
+    - samverk-bot
+  require_all_checks_pass: true
+  exclude_labels:
+    - do-not-merge
+    - wip

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.4.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/oauth2 v0.35.0
+	golang.org/x/sync v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.46.1
 )

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/autonomy/config.go
+++ b/internal/autonomy/config.go
@@ -16,6 +16,15 @@ type Config struct {
 	TierOverrides map[ActionType]Tier        `yaml:"tier_overrides"`
 	Agents        map[string]ScopedOverrides `yaml:"agents"`
 	Branches      map[string]ScopedOverrides `yaml:"branches"`
+	Merge         MergeConfig                `yaml:"merge"`
+}
+
+// MergeConfig controls auto-merge behavior for agent PRs.
+type MergeConfig struct {
+	AutoMergeOnCIPass     bool     `yaml:"auto_merge_on_ci_pass"`
+	TrustedAuthors        []string `yaml:"trusted_authors"`
+	RequireAllChecksPass  bool     `yaml:"require_all_checks_pass"`
+	ExcludeLabels         []string `yaml:"exclude_labels"`
 }
 
 // Defaults holds global default values.

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -124,12 +124,28 @@ const (
 	MergeMethodRebase MergeMethod = "rebase"
 )
 
+// CheckStatus represents the state of a CI check.
+type CheckStatus string
+
+const (
+	CheckStatusSuccess CheckStatus = "success"
+	CheckStatusFailure CheckStatus = "failure"
+	CheckStatusPending CheckStatus = "pending"
+)
+
+// Check represents a single CI status check on a pull request.
+type Check struct {
+	Name   string      `json:"name"`
+	Status CheckStatus `json:"status"`
+}
+
 // PullRequestManager provides pull request operations on a git forge.
 type PullRequestManager interface {
 	CreatePullRequest(ctx context.Context, req *CreatePRRequest) (*PullRequest, error)
 	GetPullRequest(ctx context.Context, number int) (*PullRequest, error)
 	ListPullRequests(ctx context.Context, opts *ListPROptions) ([]*PullRequest, error)
 	MergePullRequest(ctx context.Context, number int, method MergeMethod, commitMsg string) error
+	GetPRChecks(ctx context.Context, number int) ([]Check, error)
 }
 
 // PullRequest represents a pull request in Samverk's domain.
@@ -140,8 +156,10 @@ type PullRequest struct {
 	State     State     `json:"state"`
 	Head      string    `json:"head"`
 	Base      string    `json:"base"`
+	Author    string    `json:"author"`
 	Mergeable bool      `json:"mergeable"`
 	Draft     bool      `json:"draft"`
+	Labels    []string  `json:"labels"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/forge/gitea/gitea.go
+++ b/internal/forge/gitea/gitea.go
@@ -15,8 +15,9 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ forge.IssueTracker = (*Client)(nil)
-	_ forge.RepoWriter   = (*Client)(nil)
+	_ forge.IssueTracker      = (*Client)(nil)
+	_ forge.RepoWriter        = (*Client)(nil)
+	_ forge.PullRequestManager = (*Client)(nil)
 )
 
 // Client implements forge.IssueTracker for Gitea repositories.
@@ -495,6 +496,31 @@ func (c *Client) CreateBranch(_ context.Context, _ string) error {
 // CreateOrUpdateFile is not yet implemented for Gitea.
 func (c *Client) CreateOrUpdateFile(_ context.Context, _, _, _, _ string) error {
 	return ErrNotImplemented
+}
+
+// CreatePullRequest is not yet implemented for Gitea.
+func (c *Client) CreatePullRequest(_ context.Context, _ *forge.CreatePRRequest) (*forge.PullRequest, error) {
+	return nil, ErrNotImplemented
+}
+
+// GetPullRequest is not yet implemented for Gitea.
+func (c *Client) GetPullRequest(_ context.Context, _ int) (*forge.PullRequest, error) {
+	return nil, ErrNotImplemented
+}
+
+// ListPullRequests is not yet implemented for Gitea.
+func (c *Client) ListPullRequests(_ context.Context, _ *forge.ListPROptions) ([]*forge.PullRequest, error) {
+	return nil, ErrNotImplemented
+}
+
+// MergePullRequest is not yet implemented for Gitea.
+func (c *Client) MergePullRequest(_ context.Context, _ int, _ forge.MergeMethod, _ string) error {
+	return ErrNotImplemented
+}
+
+// GetPRChecks is not yet implemented for Gitea.
+func (c *Client) GetPRChecks(_ context.Context, _ int) ([]forge.Check, error) {
+	return nil, ErrNotImplemented
 }
 
 // stringSliceEqual reports whether two string slices have the same elements.

--- a/internal/forge/github/pulls.go
+++ b/internal/forge/github/pulls.go
@@ -85,6 +85,41 @@ func (c *Client) MergePullRequest(ctx context.Context, number int, method forge.
 	return nil
 }
 
+// GetPRChecks returns the combined commit status checks for a pull request's head.
+func (c *Client) GetPRChecks(ctx context.Context, number int) ([]forge.Check, error) {
+	pr, _, err := c.gh.PullRequests.Get(ctx, c.owner, c.repo, number)
+	if err != nil {
+		return nil, fmt.Errorf("github: get PR #%d for checks: %w", number, err)
+	}
+
+	ref := pr.Head.GetSHA()
+	if ref == "" {
+		return nil, nil
+	}
+
+	status, _, err := c.gh.Repositories.GetCombinedStatus(ctx, c.owner, c.repo, ref, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github: get combined status for %s: %w", ref, err)
+	}
+
+	checks := make([]forge.Check, 0, len(status.Statuses))
+	for _, s := range status.Statuses {
+		cs := forge.CheckStatusPending
+		switch s.GetState() {
+		case "success":
+			cs = forge.CheckStatusSuccess
+		case "failure", "error":
+			cs = forge.CheckStatusFailure
+		}
+		checks = append(checks, forge.Check{
+			Name:   s.GetContext(),
+			Status: cs,
+		})
+	}
+
+	return checks, nil
+}
+
 // convertPR transforms a GitHub SDK pull request into a forge.PullRequest.
 func convertPR(gh *gogithub.PullRequest) *forge.PullRequest {
 	pr := &forge.PullRequest{
@@ -104,6 +139,15 @@ func convertPR(gh *gogithub.PullRequest) *forge.PullRequest {
 	if gh.Base != nil {
 		pr.Base = gh.Base.GetRef()
 	}
+	if gh.User != nil {
+		pr.Author = gh.User.GetLogin()
+	}
+
+	labels := make([]string, 0, len(gh.Labels))
+	for _, l := range gh.Labels {
+		labels = append(labels, l.GetName())
+	}
+	pr.Labels = labels
 
 	return pr
 }

--- a/internal/mcp/tools_prs_test.go
+++ b/internal/mcp/tools_prs_test.go
@@ -53,6 +53,10 @@ func (m *mockPRManager) MergePullRequest(_ context.Context, number int, method f
 	return nil
 }
 
+func (m *mockPRManager) GetPRChecks(_ context.Context, _ int) ([]forge.Check, error) {
+	return nil, nil
+}
+
 // newTestMCPServerWithPR sets up an httptest.Server with a PR manager wired.
 func newTestMCPServerWithPR(t *testing.T, tracker forge.IssueTracker, prm forge.PullRequestManager) *httptest.Server {
 	t.Helper()

--- a/internal/prwatcher/watcher.go
+++ b/internal/prwatcher/watcher.go
@@ -1,0 +1,156 @@
+// Package prwatcher monitors open pull requests and auto-merges eligible ones.
+//
+// Eligibility requires: not draft, trusted author, no excluded labels,
+// all CI checks passed, and mergeable. The watcher runs concurrently with
+// the dispatcher via errgroup.
+package prwatcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+// Watcher polls open PRs and auto-merges eligible ones.
+type Watcher struct {
+	prManager forge.PullRequestManager
+	mergeCfg  autonomy.MergeConfig
+	interval  time.Duration
+	logger    *slog.Logger
+}
+
+// New creates a Watcher with the given PR manager and merge policy.
+func New(pm forge.PullRequestManager, cfg autonomy.MergeConfig, interval time.Duration) *Watcher {
+	return &Watcher{
+		prManager: pm,
+		mergeCfg:  cfg,
+		interval:  interval,
+		logger:    slog.Default(),
+	}
+}
+
+// Run polls open PRs at the configured interval until the context is cancelled.
+func (w *Watcher) Run(ctx context.Context) error {
+	if !w.mergeCfg.AutoMergeOnCIPass {
+		w.logger.Info("pr-watcher: auto-merge disabled, exiting")
+		return nil
+	}
+
+	w.logger.Info("pr-watcher: starting", "interval", w.interval)
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := w.poll(ctx); err != nil {
+				w.logger.Error("pr-watcher: poll error", "error", err)
+			}
+		}
+	}
+}
+
+// poll lists open PRs and attempts to merge eligible ones.
+func (w *Watcher) poll(ctx context.Context) error {
+	prs, err := w.prManager.ListPullRequests(ctx, &forge.ListPROptions{
+		State:   forge.StateOpen,
+		PerPage: 50,
+	})
+	if err != nil {
+		return fmt.Errorf("list open PRs: %w", err)
+	}
+
+	for _, pr := range prs {
+		if !w.isEligible(pr) {
+			continue
+		}
+
+		checks, err := w.prManager.GetPRChecks(ctx, pr.Number)
+		if err != nil {
+			w.logger.Error("pr-watcher: get checks", "pr", pr.Number, "error", err)
+			continue
+		}
+
+		if !w.allChecksPassed(checks) {
+			continue
+		}
+
+		w.logger.Info("pr-watcher: merging", "pr", pr.Number, "title", pr.Title)
+		commitMsg := fmt.Sprintf("auto-merge: %s (#%d)", pr.Title, pr.Number)
+		if err := w.prManager.MergePullRequest(ctx, pr.Number, forge.MergeMethodSquash, commitMsg); err != nil {
+			w.logger.Error("pr-watcher: merge failed", "pr", pr.Number, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// isEligible checks static PR attributes against merge policy.
+func (w *Watcher) isEligible(pr *forge.PullRequest) bool {
+	if pr.Draft {
+		return false
+	}
+
+	if !pr.Mergeable {
+		return false
+	}
+
+	if !w.isTrustedAuthor(pr.Author) {
+		return false
+	}
+
+	if w.hasExcludedLabel(pr.Labels) {
+		return false
+	}
+
+	return true
+}
+
+// isTrustedAuthor checks if the PR author is in the trusted list.
+// An empty trusted list means all authors are trusted.
+func (w *Watcher) isTrustedAuthor(author string) bool {
+	if len(w.mergeCfg.TrustedAuthors) == 0 {
+		return true
+	}
+	for _, a := range w.mergeCfg.TrustedAuthors {
+		if a == author {
+			return true
+		}
+	}
+	return false
+}
+
+// hasExcludedLabel checks if any PR label is in the exclude list.
+func (w *Watcher) hasExcludedLabel(labels []string) bool {
+	for _, l := range labels {
+		for _, excl := range w.mergeCfg.ExcludeLabels {
+			if l == excl {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// allChecksPassed returns true if all checks have succeeded.
+// An empty check list is treated as pending (not passed).
+func (w *Watcher) allChecksPassed(checks []forge.Check) bool {
+	if len(checks) == 0 {
+		return false
+	}
+
+	for _, c := range checks {
+		if c.Status != forge.CheckStatusSuccess {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/prwatcher/watcher_test.go
+++ b/internal/prwatcher/watcher_test.go
@@ -1,0 +1,142 @@
+package prwatcher
+
+import (
+	"testing"
+
+	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+func TestIsEligible(t *testing.T) {
+	baseCfg := autonomy.MergeConfig{
+		AutoMergeOnCIPass: true,
+		TrustedAuthors:    []string{"bot", "agent"},
+		ExcludeLabels:     []string{"do-not-merge", "wip"},
+	}
+
+	tests := []struct {
+		name string
+		pr   *forge.PullRequest
+		want bool
+	}{
+		{
+			name: "eligible PR",
+			pr: &forge.PullRequest{
+				Number:    1,
+				Author:    "bot",
+				Draft:     false,
+				Mergeable: true,
+				Labels:    []string{"auto"},
+			},
+			want: true,
+		},
+		{
+			name: "draft PR",
+			pr: &forge.PullRequest{
+				Number:    2,
+				Author:    "bot",
+				Draft:     true,
+				Mergeable: true,
+			},
+			want: false,
+		},
+		{
+			name: "not mergeable",
+			pr: &forge.PullRequest{
+				Number:    3,
+				Author:    "bot",
+				Draft:     false,
+				Mergeable: false,
+			},
+			want: false,
+		},
+		{
+			name: "untrusted author",
+			pr: &forge.PullRequest{
+				Number:    4,
+				Author:    "stranger",
+				Draft:     false,
+				Mergeable: true,
+			},
+			want: false,
+		},
+		{
+			name: "excluded label",
+			pr: &forge.PullRequest{
+				Number:    5,
+				Author:    "agent",
+				Draft:     false,
+				Mergeable: true,
+				Labels:    []string{"approved", "do-not-merge"},
+			},
+			want: false,
+		},
+	}
+
+	w := &Watcher{mergeCfg: baseCfg}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := w.isEligible(tt.pr)
+			if got != tt.want {
+				t.Errorf("isEligible() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTrustedAuthor_EmptyList(t *testing.T) {
+	w := &Watcher{mergeCfg: autonomy.MergeConfig{TrustedAuthors: nil}}
+	if !w.isTrustedAuthor("anyone") {
+		t.Error("empty trusted list should trust all authors")
+	}
+}
+
+func TestAllChecksPassed(t *testing.T) {
+	w := &Watcher{}
+
+	tests := []struct {
+		name   string
+		checks []forge.Check
+		want   bool
+	}{
+		{
+			name:   "empty checks - not passed",
+			checks: nil,
+			want:   false,
+		},
+		{
+			name: "all success",
+			checks: []forge.Check{
+				{Name: "ci/build", Status: forge.CheckStatusSuccess},
+				{Name: "ci/test", Status: forge.CheckStatusSuccess},
+			},
+			want: true,
+		},
+		{
+			name: "one pending",
+			checks: []forge.Check{
+				{Name: "ci/build", Status: forge.CheckStatusSuccess},
+				{Name: "ci/test", Status: forge.CheckStatusPending},
+			},
+			want: false,
+		},
+		{
+			name: "one failure",
+			checks: []forge.Check{
+				{Name: "ci/build", Status: forge.CheckStatusFailure},
+				{Name: "ci/test", Status: forge.CheckStatusSuccess},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := w.allChecksPassed(tt.checks)
+			if got != tt.want {
+				t.Errorf("allChecksPassed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/prwatcher/` package that polls open PRs and auto-merges eligible ones
- Eligibility: not draft, trusted author, no excluded labels, all CI checks passed, mergeable
- Extends `forge.PullRequestManager` with `GetPRChecks` for CI status checks
- Adds `Author` and `Labels` fields to `forge.PullRequest` for policy evaluation
- Adds `MergeConfig` to autonomy policy (auto_merge_on_ci_pass, trusted_authors, exclude_labels)
- Runs concurrently with dispatcher via `errgroup` in the dispatch command
- Updates deploy config with merge section for CT 202

Closes #204

## Test plan

- [x] Unit tests for eligibility checks (draft, author, labels, mergeability)
- [x] Unit tests for CI check evaluation (all pass, pending, failure, empty)
- [x] Trusted author empty list = trust all
- [x] All existing tests pass (269 across 18 packages)
- [x] Build passes, lint clean, markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)