### PR TITLE
feat: build and embed React SPA in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  web:
+    name: Build SPA
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install and build
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Copy dist to static
+        run: cp -r web/dist/* internal/server/static/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spa-dist
+          path: internal/server/static/
+          retention-days: 1
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -30,6 +59,7 @@ jobs:
 
   build:
     name: Build
+    needs: [web]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,11 +67,17 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: spa-dist
+          path: internal/server/static/
 
       - run: go build ./cmd/samverk/
 
   test:
     name: Test
+    needs: [web]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +85,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: spa-dist
+          path: internal/server/static/
 
       - run: go test -race ./...
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,9 +75,7 @@ jobs:
           pnpm run build
 
       - name: Embed frontend in Go binary
-        run: |
-          rm -rf internal/dashboard/dist
-          cp -r web/dist internal/dashboard/dist
+        run: cp -r web/dist/* internal/server/static/
 
       - name: Build binary
         env:


### PR DESCRIPTION
## Summary

- Adds `web` job to CI workflow: Node 22 + pnpm build, uploads SPA as artifact
- Build and test jobs download SPA artifact before Go compilation
- Fixes nightly workflow embed path from `internal/dashboard/dist` to `internal/server/static/`
- Ensures the Go binary always embeds a freshly built SPA in CI

Closes #197

## Test plan

- [x] Local build and tests pass
- [x] Lint and markdownlint clean
- [ ] CI workflow runs web job, build/test jobs download artifact successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)