### PR TITLE
fix: make redeploy works on Windows, stops services before scp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build test test-race test-coverage test-integration test-all lint lint-md lint-all ci hooks run clean web dev-web \
-       cross-build deploy deploy-binary deploy-config redeploy
+       cross-build cross-build-full deploy deploy-binary deploy-config redeploy redeploy-full
 
 # Binary
 BIN=samverk
@@ -61,16 +61,20 @@ hooks:
 run: build
 	./bin/$(BIN) serve
 
-# Cross-compile for Linux (deploy target)
+# Cross-compile for Linux (deploy target) — no web dependency for Windows compat
 DEPLOY_HOST ?= 192.168.1.161
 DEPLOY_USER ?= root
 
-cross-build: web
+cross-build:
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/$(BIN)-linux-amd64 ./cmd/samverk/
 	@echo "Built bin/$(BIN)-linux-amd64"
 
-# Deploy binary to the remote host
+# Cross-compile with fresh SPA build (requires bash/node)
+cross-build-full: web cross-build
+
+# Deploy binary to the remote host (stops services first to avoid binary lock)
 deploy-binary: cross-build
+	ssh $(DEPLOY_USER)@$(DEPLOY_HOST) 'systemctl stop samverk-dispatch samverk-serve 2>/dev/null || true'
 	scp bin/$(BIN)-linux-amd64 $(DEPLOY_USER)@$(DEPLOY_HOST):/usr/local/bin/$(BIN)
 	@echo "Binary deployed to $(DEPLOY_HOST)"
 
@@ -82,17 +86,21 @@ deploy-config:
 
 # Full deploy: build, copy binary + configs, run installer, restart services
 deploy: deploy-binary deploy-config
-	ssh $(DEPLOY_USER)@$(DEPLOY_HOST) 'systemctl stop samverk-dispatch samverk-serve 2>/dev/null; \
-		sed -i "s/\r$$//" /tmp/install.sh && bash /tmp/install.sh && \
+	ssh $(DEPLOY_USER)@$(DEPLOY_HOST) 'sed -i "s/\r$$//" /tmp/install.sh && bash /tmp/install.sh && \
 		systemctl start samverk-serve samverk-dispatch'
 	@echo "Deployment complete. Services restarted."
 
-# One-step redeploy with health verification
+# One-step redeploy with health verification (no SPA rebuild)
 redeploy:
 	$(MAKE) deploy DEPLOY_HOST=192.168.1.162
 	@echo "Verifying health..."
 	@sleep 3
 	@ssh root@192.168.1.162 'curl -sf http://localhost:8080/healthz' && echo " OK" || (echo " FAIL"; exit 1)
+
+# Full redeploy including SPA rebuild (requires bash/node)
+redeploy-full:
+	$(MAKE) web
+	$(MAKE) redeploy
 
 clean:
 	rm -rf bin/ coverage.out

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,68 @@
+# deploy.ps1 — Windows-native deploy script for Samverk
+# Usage: .\scripts\deploy.ps1 [-Host 192.168.1.162] [-User root] [-RebuildWeb]
+param(
+    [string]$DeployHost = "192.168.1.162",
+    [string]$DeployUser = "root",
+    [switch]$RebuildWeb
+)
+
+$ErrorActionPreference = "Stop"
+
+$BIN = "samverk"
+$VERSION_PKG = "github.com/herbhall/samverk/internal/version"
+$VERSION = (git describe --tags --always --dirty 2>$null) ?? "dev"
+$COMMIT = (git rev-parse --short HEAD 2>$null) ?? "unknown"
+$DATE = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
+$LDFLAGS = "-s -w -X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.GitCommit=${COMMIT} -X ${VERSION_PKG}.BuildDate=${DATE}"
+
+# Step 1: Optionally rebuild SPA
+if ($RebuildWeb) {
+    Write-Host "Building SPA..." -ForegroundColor Cyan
+    Push-Location web
+    try {
+        npx pnpm install --no-frozen-lockfile
+        npx pnpm build
+    } finally {
+        Pop-Location
+    }
+    Copy-Item -Recurse -Force "web\dist\*" "internal\server\static\"
+}
+
+# Step 2: Cross-compile for Linux
+Write-Host "Cross-compiling for Linux amd64..." -ForegroundColor Cyan
+$env:GOOS = "linux"
+$env:GOARCH = "amd64"
+$env:CGO_ENABLED = "0"
+try {
+    go build -ldflags $LDFLAGS -o "bin\${BIN}-linux-amd64" ./cmd/samverk/
+} finally {
+    Remove-Item Env:GOOS -ErrorAction SilentlyContinue
+    Remove-Item Env:GOARCH -ErrorAction SilentlyContinue
+    Remove-Item Env:CGO_ENABLED -ErrorAction SilentlyContinue
+}
+Write-Host "Built bin\${BIN}-linux-amd64" -ForegroundColor Green
+
+# Step 3: Stop services on remote host
+Write-Host "Stopping services on ${DeployHost}..." -ForegroundColor Cyan
+ssh "${DeployUser}@${DeployHost}" "systemctl stop samverk-dispatch samverk-serve 2>/dev/null || true"
+
+# Step 4: Copy binary
+Write-Host "Deploying binary..." -ForegroundColor Cyan
+scp "bin\${BIN}-linux-amd64" "${DeployUser}@${DeployHost}:/usr/local/bin/${BIN}"
+
+# Step 5: Copy config and restart
+Write-Host "Deploying config and restarting..." -ForegroundColor Cyan
+scp deploy/samverk-serve.service deploy/samverk-dispatch.service "${DeployUser}@${DeployHost}:/tmp/"
+scp deploy/install.sh "${DeployUser}@${DeployHost}:/tmp/install.sh"
+ssh "${DeployUser}@${DeployHost}" "sed -i 's/\r$//' /tmp/install.sh && bash /tmp/install.sh && systemctl start samverk-serve samverk-dispatch"
+
+# Step 6: Health check
+Write-Host "Verifying health..." -ForegroundColor Cyan
+Start-Sleep -Seconds 3
+$health = ssh "${DeployUser}@${DeployHost}" "curl -sf http://localhost:8080/healthz"
+if ($LASTEXITCODE -eq 0) {
+    Write-Host " OK" -ForegroundColor Green
+} else {
+    Write-Host " FAIL" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
## Summary

- Remove `web` dependency from `cross-build` so it works without bash/node on Windows
- Stop services before `scp` in `deploy-binary` to avoid binary lock on Linux
- Remove redundant `systemctl stop` from `deploy` target (now in `deploy-binary`)
- Add `cross-build-full` and `redeploy-full` targets for when SPA rebuild is needed
- Add `scripts/deploy.ps1` as PowerShell alternative to `make redeploy`

Closes #210

## Test plan

- [x] `go build ./...` passes
- [x] All tests pass
- [x] Lint and markdownlint clean
- [ ] `make cross-build` succeeds on Windows without bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)