### PR TITLE
feat: claude-cli provider uses Claude Code auth instead of API credits

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/herbhall/samverk/internal/prwatcher"
 	"github.com/herbhall/samverk/internal/provider"
 	"github.com/herbhall/samverk/internal/provider/claude"
+	"github.com/herbhall/samverk/internal/provider/claudecli"
 	"github.com/herbhall/samverk/internal/provider/ollama"
 	"github.com/herbhall/samverk/internal/provider/openai"
 	"github.com/herbhall/samverk/internal/server"
@@ -525,6 +526,9 @@ func providerFactory(name string, cfg provider.ProviderConfig) (provider.Provide
 			baseURL = "http://localhost:11434"
 		}
 		return ollama.New(baseURL), nil
+	case "claude-cli":
+		model := cfg.DefaultModel
+		return claudecli.New(model), nil
 	default:
 		return nil, fmt.Errorf("provider %q: unknown type %q", name, cfg.Type)
 	}

--- a/deploy/config/providers.yaml
+++ b/deploy/config/providers.yaml
@@ -2,16 +2,21 @@
 # Configure which AI providers are available for agent work.
 
 providers:
+  claude-cli:
+    type: claude-cli
+    default_model: claude-sonnet-4-6
+
   claude:
     type: claude
     api_key_env: ANTHROPIC_API_KEY
-    default_model: claude-sonnet-4-20250514
+    default_model: claude-sonnet-4-6
 
   ollama:
     type: ollama
     base_url: http://192.168.1.207:11434
+    default_model: qwen2.5-coder:7b
 
 # Routing chains: tried in order, first healthy provider wins.
 routing:
-  default: [claude, ollama]
-  frontend: [claude]
+  default: [claude-cli, ollama]
+  frontend: [claude-cli]

--- a/internal/provider/claudecli/claudecli.go
+++ b/internal/provider/claudecli/claudecli.go
@@ -1,0 +1,84 @@
+// Package claudecli implements provider.Provider by shelling out to the
+// Claude Code CLI (`claude --print`). This uses the user's Max plan
+// authentication from ~/.claude instead of requiring separate API credits.
+package claudecli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+// Compile-time check that Client satisfies provider.Provider.
+var _ provider.Provider = (*Client)(nil)
+
+const defaultTimeout = 300 * time.Second
+
+// Client invokes the claude CLI binary for chat completions.
+type Client struct {
+	claudeBin string
+	model     string
+	timeout   time.Duration
+}
+
+// New creates a claude-cli provider. If model is empty, the CLI uses its default.
+func New(model string) *Client {
+	return &Client{
+		claudeBin: "claude",
+		model:     model,
+		timeout:   defaultTimeout,
+	}
+}
+
+// Chat builds a prompt from the request messages, invokes `claude --print`,
+// and returns the CLI output as the assistant response.
+func (c *Client) Chat(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+	var prompt strings.Builder
+	for _, m := range req.Messages {
+		if m.Role == provider.RoleSystem {
+			fmt.Fprintf(&prompt, "%s\n\n", m.Content)
+		}
+	}
+	for _, m := range req.Messages {
+		if m.Role == provider.RoleUser {
+			fmt.Fprintf(&prompt, "%s", m.Content)
+		}
+	}
+
+	args := []string{"--print", prompt.String()}
+	if c.model != "" {
+		args = append(args, "--model", c.model)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, c.claudeBin, args...) //nolint:gosec // G204: claudeBin is set internally
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("claude-cli: exec: %w", err)
+	}
+
+	return &provider.ChatResponse{
+		Model: c.model,
+		Message: provider.Message{
+			Role:    provider.RoleAssistant,
+			Content: strings.TrimSpace(string(out)),
+		},
+	}, nil
+}
+
+// Healthy returns true if the claude binary is found and responds to --version.
+func (c *Client) Healthy(ctx context.Context) bool {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	err := exec.CommandContext(ctx, c.claudeBin, "--version").Run() //nolint:gosec // G204: claudeBin is set internally
+	return err == nil
+}
+
+// Name returns the provider identifier.
+func (c *Client) Name() string { return "claude-cli" }

--- a/internal/provider/claudecli/claudecli_test.go
+++ b/internal/provider/claudecli/claudecli_test.go
@@ -1,0 +1,103 @@
+package claudecli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+func TestNew(t *testing.T) {
+	c := New("claude-sonnet-4-6")
+	if c.claudeBin != "claude" {
+		t.Errorf("claudeBin = %q, want 'claude'", c.claudeBin)
+	}
+	if c.model != "claude-sonnet-4-6" {
+		t.Errorf("model = %q, want 'claude-sonnet-4-6'", c.model)
+	}
+	if c.timeout != defaultTimeout {
+		t.Errorf("timeout = %v, want %v", c.timeout, defaultTimeout)
+	}
+}
+
+func TestName(t *testing.T) {
+	c := New("")
+	if c.Name() != "claude-cli" {
+		t.Errorf("Name() = %q, want 'claude-cli'", c.Name())
+	}
+}
+
+func TestChatBuildsPrompt(t *testing.T) {
+	// Use a binary that echoes input to verify prompt construction.
+	// On systems without 'echo', this test verifies structure only.
+	c := &Client{
+		claudeBin: "echo",
+		model:     "",
+		timeout:   defaultTimeout,
+	}
+
+	resp, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: "You are helpful."},
+			{Role: provider.RoleUser, Content: "Hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Message.Role != provider.RoleAssistant {
+		t.Errorf("role = %q, want 'assistant'", resp.Message.Role)
+	}
+	// echo outputs the args: "--print <prompt>" or similar.
+	// We just verify it didn't error.
+	if resp.Message.Content == "" {
+		t.Error("expected non-empty content from echo")
+	}
+}
+
+func TestChatWithModel(t *testing.T) {
+	c := &Client{
+		claudeBin: "echo",
+		model:     "claude-sonnet-4-6",
+		timeout:   defaultTimeout,
+	}
+
+	resp, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "test"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want 'claude-sonnet-4-6'", resp.Model)
+	}
+}
+
+func TestHealthyWithMissingBinary(t *testing.T) {
+	c := &Client{
+		claudeBin: "nonexistent-binary-that-does-not-exist",
+		timeout:   defaultTimeout,
+	}
+	if c.Healthy(context.Background()) {
+		t.Error("Healthy() should return false for missing binary")
+	}
+}
+
+func TestChatExecError(t *testing.T) {
+	c := &Client{
+		claudeBin: "nonexistent-binary-that-does-not-exist",
+		timeout:   defaultTimeout,
+	}
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "test"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Chat() should return error for missing binary")
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/provider/claudecli/` package that shells out to `claude --print` for AI completions
- Uses Claude Code CLI authentication (Max plan) instead of consuming API credits
- Wired into provider factory with `claude-cli` type in `cmd/samverk/main.go`
- Updated `deploy/config/providers.yaml` to use `claude-cli` as primary provider

## Test plan

- [x] Unit tests pass (`go test ./internal/provider/claudecli/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)
- [x] Cross-compile check (`GOOS=linux GOARCH=amd64 go build ./...`)

Closes #218

Co-Authored-By: Claude <noreply@anthropic.com>