### PR TITLE
fix(#228): graceful shutdown

### DIFF
--- a/deploy/samverk-dispatch.service
+++ b/deploy/samverk-dispatch.service
@@ -26,6 +26,13 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=samverk-dispatch
 
+# Graceful shutdown: only signal the main PID so child processes (claude-cli)
+# are left running and the Go drain logic (pool.Shutdown) can finish them.
+KillMode=process
+# 30 minutes — matches opus provider timeout (900s) with headroom for
+# session teardown and issue updates.
+TimeoutStopSec=1800
+
 # Security hardening
 NoNewPrivileges=true
 ProtectSystem=strict

--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -97,8 +97,10 @@ func (p *Pool) Shutdown() {
 	p.shutdown = true
 	p.mu.Unlock()
 
+	p.logger.Info("agent pool draining", slog.Int("queued", len(p.tasks)))
 	close(p.tasks)
 	p.wg.Wait()
+	p.logger.Info("agent pool drained")
 	close(p.done)
 }
 

--- a/internal/provider/claudecli/claudecli.go
+++ b/internal/provider/claudecli/claudecli.go
@@ -77,6 +77,10 @@ func (c *Client) Chat(ctx context.Context, req provider.ChatRequest) (*provider.
 
 	cmd := exec.CommandContext(ctx, c.claudeBin, args...) //nolint:gosec // G204: claudeBin is set internally
 	cmd.Stdin = strings.NewReader(prompt.String())        // prompt via stdin — argument mode hangs
+	// Place the subprocess in its own process group so that signals sent to
+	// the parent's process group (e.g. from a misconfigured KillMode) do not
+	// propagate to claude-cli. Belt-and-suspenders alongside KillMode=process.
+	setProcessGroup(cmd)
 
 	// Inherit environment but strip ANTHROPIC_API_KEY so the CLI uses
 	// OAuth credentials (~/.claude) instead of API credits.

--- a/internal/provider/claudecli/sysproc_linux.go
+++ b/internal/provider/claudecli/sysproc_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package claudecli
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup places cmd in its own process group (Setpgid=true).
+// This prevents signals sent to the parent's process group from propagating
+// to the claude-cli subprocess — belt-and-suspenders alongside KillMode=process
+// in the systemd service unit.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/provider/claudecli/sysproc_other.go
+++ b/internal/provider/claudecli/sysproc_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package claudecli
+
+import "os/exec"
+
+// setProcessGroup is a no-op on non-Linux platforms.
+// Setpgid subprocess isolation only applies to the Linux deployment target (CT 202).
+func setProcessGroup(_ *exec.Cmd) {}


### PR DESCRIPTION
Fixes #228

## Changes

- `deploy/samverk-dispatch.service`: adds `KillMode=process` and `TimeoutStopSec=1800`
- `internal/provider/claudecli/claudecli.go`: calls `setProcessGroup(cmd)` before exec
- `internal/provider/claudecli/sysproc_linux.go`: Linux impl — `Setpgid: true`
- `internal/provider/claudecli/sysproc_other.go`: no-op for Windows/macOS builds
- `internal/agent/pool.go`: logs `agent pool draining` / `agent pool drained` on shutdown

## Why

Default `KillMode=control-group` sends SIGTERM to the entire cgroup, killing claude-cli subprocesses directly (exit 143). `KillMode=process` restricts the signal to the main PID so the Go drain logic (`pool.Shutdown` + `wg.Wait`) can run to completion. `TimeoutStopSec=1800` prevents systemd from SIGKILL-ing the process before a 900s opus session can finish.
