### PR TITLE
fix(#231): use RELEASE_PLEASE_TOKEN so release PRs trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Fixes #231`n`nOne-line change: `secrets.GITHUB_TOKEN` -> `secrets.RELEASE_PLEASE_TOKEN`
