### PR TITLE
fix(#247): dispatcher routing gate for terminal labels and human agent type

### DIFF
--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -137,6 +137,16 @@ func (d *Dispatcher) handleOpened(ctx context.Context, ev forge.Event) error {
 		}
 	}
 
+	// Skip issues that are already in a terminal or human-managed state.
+	labels := make(map[string]bool, len(issue.Labels))
+	for _, l := range issue.Labels {
+		labels[l] = true
+	}
+	if labels["status:needs-human"] || labels["status:blocked"] || labels["status:claimed"] || labels["status:in-progress"] {
+		d.logger.Printf("skipping #%d: already has status label", issue.Number)
+		return nil
+	}
+
 	agentType, err := d.classify(ctx, issue)
 	if err != nil {
 		return d.escalate(ctx, issue.Number, "invalid_frontmatter", err.Error())

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -519,14 +519,13 @@ func TestHandleOpened_NoFrontmatter_AgentHumanLabel(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if hasLabel(issue.Labels, "status:needs-human") {
-		t.Error("did not expect status:needs-human for agent:human label")
+	// agent:human issues are now intercepted by the route() human gate:
+	// status:needs-human is added and no pool submission occurs.
+	if !hasLabel(issue.Labels, "status:needs-human") {
+		t.Error("expected status:needs-human for agent:human classified issue")
 	}
-	if !hasLabel(issue.Labels, "status:claimed") {
-		t.Error("expected status:claimed after heuristic routing")
-	}
-	if len(issue.Assignees) == 0 || issue.Assignees[0] != "human" {
-		t.Errorf("expected assignee human, got %v", issue.Assignees)
+	if hasLabel(issue.Labels, "status:claimed") {
+		t.Error("did not expect status:claimed — human issues must not be dispatched")
 	}
 }
 
@@ -981,6 +980,157 @@ func TestHandleEvent_UnknownTypeStillLogs(t *testing.T) {
 		IssueNumber: 1,
 	})
 	// No panic, no error — the handler exists now.
+}
+
+func TestHandleOpened_SkipsNeedsHuman(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	tracker.mu.Lock()
+	tracker.issues[10] = &forge.Issue{
+		Number: 10,
+		Title:  "Needs human review",
+		Body:   "Some body",
+		State:  forge.StateOpen,
+		Labels: []string{"status:needs-human"},
+	}
+	tracker.mu.Unlock()
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 10,
+	})
+	if err != nil {
+		t.Fatalf("handleOpened returned error: %v", err)
+	}
+
+	tracker.mu.Lock()
+	issue := tracker.issues[10]
+	tracker.mu.Unlock()
+
+	if hasLabel(issue.Labels, "status:claimed") {
+		t.Error("expected no status:claimed label — issue should be skipped")
+	}
+}
+
+func TestHandleOpened_SkipsBlocked(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	tracker.mu.Lock()
+	tracker.issues[11] = &forge.Issue{
+		Number: 11,
+		Title:  "Blocked issue",
+		Body:   "Some body",
+		State:  forge.StateOpen,
+		Labels: []string{"status:blocked"},
+	}
+	tracker.mu.Unlock()
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 11,
+	})
+	if err != nil {
+		t.Fatalf("handleOpened returned error: %v", err)
+	}
+
+	tracker.mu.Lock()
+	issue := tracker.issues[11]
+	tracker.mu.Unlock()
+
+	if hasLabel(issue.Labels, "status:claimed") {
+		t.Error("expected no status:claimed label — issue should be skipped")
+	}
+}
+
+func TestHandleOpened_SkipsClaimed(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	tracker.mu.Lock()
+	tracker.issues[12] = &forge.Issue{
+		Number: 12,
+		Title:  "Already claimed",
+		Body:   "Some body",
+		State:  forge.StateOpen,
+		Labels: []string{"status:claimed"},
+	}
+	tracker.mu.Unlock()
+
+	err := d.handleOpened(context.Background(), forge.Event{
+		Type:        forge.EventIssueOpened,
+		IssueNumber: 12,
+	})
+	if err != nil {
+		t.Fatalf("handleOpened returned error: %v", err)
+	}
+
+	tracker.mu.Lock()
+	calls := make([]string, len(tracker.calls))
+	copy(calls, tracker.calls)
+	tracker.mu.Unlock()
+
+	// Verify Assign was never called (no routing occurred).
+	for _, c := range calls {
+		if c == "Assign" {
+			t.Error("Assign was called — issue should have been skipped before routing")
+		}
+	}
+}
+
+func TestRoute_HumanAgentNotDispatched(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	tracker.mu.Lock()
+	tracker.issues[20] = &forge.Issue{
+		Number: 20,
+		Title:  "Human task",
+		Body:   "Requires human decision",
+		State:  forge.StateOpen,
+		Labels: []string{"agent:human"},
+	}
+	tracker.mu.Unlock()
+
+	issue := &forge.Issue{
+		Number: 20,
+		Title:  "Human task",
+		Body:   "Requires human decision",
+		State:  forge.StateOpen,
+		Labels: []string{"agent:human"},
+	}
+
+	err := d.route(context.Background(), issue, models.AgentTypeHuman)
+	if err != nil {
+		t.Fatalf("route returned error: %v", err)
+	}
+
+	tracker.mu.Lock()
+	routedIssue := tracker.issues[20]
+	calls := make([]string, len(tracker.calls))
+	copy(calls, tracker.calls)
+	tracker.mu.Unlock()
+
+	// status:needs-human must be set.
+	if !hasLabel(routedIssue.Labels, "status:needs-human") {
+		t.Error("expected status:needs-human label to be added")
+	}
+
+	// Assign must NOT be called — no agent pool submission.
+	for _, c := range calls {
+		if c == "Assign" {
+			t.Error("Assign was called — human issues must not be dispatched to agent pool")
+		}
+	}
+
+	// claimed map must not contain the issue.
+	d.mu.Lock()
+	_, inClaimed := d.claimed[20]
+	d.mu.Unlock()
+	if inClaimed {
+		t.Error("issue #20 should not be in claimed map — human issues are not routed")
+	}
 }
 
 func hasLabel(labels []string, target string) bool {

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -144,6 +144,15 @@ func selectProviderKey(issue *forge.Issue, agentType models.AgentType) (key, rea
 // and records the claim in memory. Any failure count accumulated from prior
 // timeout cycles is carried forward so the escalation threshold is not reset.
 func (d *Dispatcher) route(ctx context.Context, issue *forge.Issue, agentType models.AgentType) error {
+	// Human-typed issues are tracked but never submitted to the agent pool.
+	if agentType == models.AgentTypeHuman {
+		d.logger.Printf("issue #%d classified as human — not dispatching to agent pool", issue.Number)
+		if err := d.tracker.AddLabel(ctx, issue.Number, "status:needs-human"); err != nil {
+			d.logger.Printf("add needs-human to #%d: %v", issue.Number, err)
+		}
+		return nil
+	}
+
 	if err := d.tracker.RemoveLabel(ctx, issue.Number, "status:queued"); err != nil {
 		d.logger.Printf("remove queued label from #%d: %v", issue.Number, err)
 	}


### PR DESCRIPTION
## Summary

- Label gate in `handleOpened`: skip issues with `status:needs-human`, `status:blocked`, `status:claimed`, or `status:in-progress` — prevents duplicate routing on dispatcher restart
- Human agent gate in `route()`: issues classified as `AgentTypeHuman` get `status:needs-human` and are never submitted to the agent pool

## Test plan

- [x] `make ci` passes (build + tests + lint)
- [x] `TestHandleOpened_SkipsNeedsHuman` — issue with status:needs-human is not re-routed
- [x] `TestHandleOpened_SkipsBlocked` — issue with status:blocked is not re-routed
- [x] `TestHandleOpened_SkipsClaimed` — issue with status:claimed is not re-routed
- [x] `TestRoute_HumanAgentNotDispatched` — human-typed issue gets status:needs-human, not claimed
- [x] `TestHandleOpened_NoFrontmatter_AgentHumanLabel` updated to reflect new behavior

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)