### PR TITLE
feat(ci): add Gitea Actions CI and security workflows

### DIFF
--- a/.gitea/workflows/gitea-ci.yml
+++ b/.gitea/workflows/gitea-ci.yml
@@ -1,0 +1,136 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Gitea Actions uses the same concurrency syntax; context prefix is gitea.
+concurrency:
+  group: ci-${{ gitea.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web:
+    name: Build SPA
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install and build
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Copy dist to static
+        run: cp -r web/dist/* internal/server/static/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spa-dist
+          path: internal/server/static/
+          retention-days: 1
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # golangci-lint-action is not mirrored on Gitea; use go run instead.
+      # Cache Go modules manually since golangci-lint-action no longer provides it.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ gitea.runner.os }}-go-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ gitea.runner.os }}-go-lint-
+
+      - name: golangci-lint
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run ./...
+
+  build:
+    name: Build
+    needs: [web]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ gitea.runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ gitea.runner.os }}-go-build-
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: spa-dist
+          path: internal/server/static/
+
+      - run: go build ./cmd/samverk/
+
+  test:
+    name: Test
+    needs: [web]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ gitea.runner.os }}-go-test-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ gitea.runner.os }}-go-test-
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: spa-dist
+          path: internal/server/static/
+
+      - run: go test -race ./...
+
+  markdown:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # DavidAnson/markdownlint-cli2-action may not be mirrored on Gitea; use npx.
+      - name: markdownlint
+        run: >
+          npx --yes markdownlint-cli2
+          "**/*.md"
+          "!CHANGELOG.md"
+          "!node_modules"
+          "!web/node_modules"

--- a/.gitea/workflows/security.yml
+++ b/.gitea/workflows/security.yml
@@ -1,0 +1,39 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+
+jobs:
+  govulncheck:
+    name: Go Vulnerability Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  trivy:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # trivy is available as a standalone binary; install via script.
+      - name: Install trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sh -s -- -b /usr/local/bin
+
+      - name: Scan filesystem
+        run: trivy fs --exit-code 1 --severity HIGH,CRITICAL .


### PR DESCRIPTION
## Summary

- `.gitea/workflows/gitea-ci.yml`: port of `ci.yml` for Gitea Actions
  - `github.` context prefix → `gitea.`
  - `golangci-lint-action@v7` → `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run ./...`
  - `DavidAnson/markdownlint-cli2-action@v19` → `npx markdownlint-cli2`
  - Added `actions/cache@v4` for Go modules (golangci-lint-action no longer provides it)

- `.gitea/workflows/security.yml`: CodeQL replacement for Gitea
  - `govulncheck` for Go module vulnerability database scanning
  - `trivy fs` for filesystem scanning (HIGH + CRITICAL severity)
  - Runs on push, PR, and weekly schedule

`release-please.yml` is intentionally not ported — kept on GitHub as source of truth. Tags mirror to Gitea via B21.

## Test plan

- [x] YAML syntax valid
- [x] `golangci-lint run` — 0 issues (no Go changes)
- [x] `markdownlint-cli2` — 0 errors
- [x] Full CI (pre-push hook) — green

Closes #269
Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)