### PR TITLE
docs: add ADR-031 and update CLAUDE.md + status.md for dual-forge state

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: execution
-updated: 2026-03-08T15:30:00Z
+updated: 2026-03-08T22:00:00Z
 updated_by: claude-code
 ---
 
@@ -9,7 +9,7 @@ updated_by: claude-code
 ## Phase
 
 Phase 5 complete: agent runtime, provider integration, SPA embedding, PR watcher.
-Phase 4 complete (2026-03-02): MCP tools, REST API, dispatcher CLI, multi-project, web dashboard scaffold.
+Q2 2026 execution plan: 62 issues across 3 streams. Windows 1-2 agent work in progress.
 
 ## What Is Running
 
@@ -17,29 +17,80 @@ Phase 4 complete (2026-03-02): MCP tools, REST API, dispatcher CLI, multi-projec
 - MCP endpoint: POST /mcp (Streamable HTTP, auth required)
 - Dispatcher: running continuously (systemd, 30s poll, 3 workers)
 - PR watcher: runs concurrently with dispatcher (auto-merge eligible PRs)
+- Gitea: CT 200 (192.168.1.160:3000 / gitea.herbhall.net) -- primary runtime forge
 
-## Completed This Session
+## Dual-Forge Status
 
-- #233: failure counter preserves across re-queue cycles (PR #249)
-- #237: suppress 404 on RemoveLabel when label not present (PR #249)
-- #239: Ollama NewWithTimeout + wire timeout_seconds config (PR #249)
-- fix: heartbeat interval 10min → 20min for opus session headroom (PR #249)
-- Dispatcher restarted on CT 202, running clean
+| Item | Status |
+|------|--------|
+| Gitea instance (CT 200) | Running -- 1.23.7 |
+| samverk/samverk repo | Created on Gitea |
+| Gitea adapter (IssueTracker + Repo + PR) | Merged (PRs #319, #322) |
+| Integration tests against Gitea | Merged (PR #322) |
+| Gitea Actions research | Merged (PR #321) |
+| Gitea CI workflow (.gitea/workflows/) | PR #331 (auto-merge) |
+| Gitea security.yml (govulncheck + trivy) | PR #331 (auto-merge) |
+| dual-forge server.yaml config | PR #326 (auto-merge) |
+| create-issues.sh --forge gitea | PR #327 (auto-merge) |
+| migrate-issues.py (GitHub -> Gitea) | PR #330 (auto-merge) |
+| ADR-031 dual-forge model | This session |
+| Gitea Actions runner (CT 201) | Pending (B14, human setup) |
+| Bidirectional git push remote | Pending (B24, human task) |
+| MCP tools for Gitea project switching | Pending (#277) |
 
-## Queued
+## Windows 1-2 Progress (B-track)
 
-- #152: dispatcher routes to Copilot as provider
-- #153: dispatch feedback loop (depends on #144 research)
-- #157: Claude Code Remote Control spike (human task)
-- #186: `samverk status --write` CLI automation
+Completed B-track:
 
-## Last Session Summary
+- B01-B09 (#256-#264): Gitea adapter implementation (PRs #316-#319, merged)
+- B10 (#265): PR manager implementation (PR #319, merged)
+- B13 (#268): Gitea Actions compatibility research (PR #321, merged)
+- B03/B08/B10 (#258,#263,#265): Integration tests (PR #322, merged)
+- B17 (#272): dual-forge server.yaml config (PR #326, auto-merge)
+- B18 (#273): create-issues.sh --forge gitea (PR #327, auto-merge)
+- B20 (#275): issue migration script (PR #330, auto-merge)
+- B14 (#269): gitea-ci.yml (PR #331, auto-merge)
+- B15/B16 (#270/271): security.yml (PR #331, auto-merge)
+- B25 (#280): ADR-031 dual-forge model (this session)
+- B26 (#281): CLAUDE.md + status.md update (this session)
 
-Applied 4 agent-generated fixes (handoff #3). Fixed the failure counter
-reset bug (#233) that caused infinite re-queue loops, suppressed 404
-false errors on RemoveLabel (#237), added configurable Ollama timeout
-(#239), and increased heartbeat interval to 20min for opus headroom.
-All in PR #249 (auto-merge queued). Dispatcher running clean on CT 202.
+Completed W-track (metrics/scaling):
+
+- W01 (#284): PoolMetrics ring buffer (merged, PR #323)
+- W02 (#285): DispatcherMetrics ring buffer + P95 (merged, PR #323)
+- W03 (#286): SystemCollector (merged, PR #323)
+- W04 (#287): Metrics load tests (PR #325, auto-merge)
+
+Human tasks remaining:
+
+- B11 (#266): Already done (Gitea repo created)
+- B12 (#267): Verify Gitea label + webhook health
+- B14 runner (#269): Provision CT 201 as Gitea Actions runner
+- B24 (#279): Configure bidirectional git push remote
+- B21-B22: Tag mirroring (deferred to after B24)
+
+## Next Agent Tasks
+
+W-track (ready, no blockers):
+
+- W05 (#288): Add /api/v1/metrics REST endpoint
+- W06 (#289): Add metrics dashboard page to React SPA
+- W07 (#290): Add metrics to MCP get_digest
+- W08 (#292): Refactor agent pool to support dynamic add/remove
+
+B-track (ready after PRs merge):
+
+- B21 (#276): Tag mirroring GitHub -> Gitea
+- B22 (#277): MCP tools for Gitea project context switching
+- B23 (#278): Verify MCP tools vs Gitea (human verification)
+
+## Queued (pre-existing)
+
+- `#152`: dispatcher routes to Copilot as provider
+- `#153`: dispatch feedback loop (depends on #144 research)
+- `#157`: Claude Code Remote Control spike (human task)
+- `#186`: `samverk status --write` CLI automation
+- `#324`: fix panic on send-to-closed-channel in pool.Submit
 
 ## Start Here (Cold Start Protocol)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,10 @@ samverk/
 │   ├── autonomy-model.md      # Three-tier trust model for agent actions
 │   ├── user-profile.md        # Persistent user preferences across projects
 │   ├── open-questions.md      # Unresolved design and business questions
-│   └── decisions/             # Architecture Decision Records (25 total)
+│   └── decisions/             # Architecture Decision Records (31 total)
 ├── .samverk/                  # Project state (status.md) and runtime config
-├── .github/workflows/         # CI/CD pipelines
+├── .github/workflows/         # GitHub CI/CD pipelines
+├── .gitea/workflows/          # Gitea Actions CI (gitea-ci.yml, security.yml)
 └── Makefile                   # Build and development tasks
 ```
 
@@ -62,7 +63,7 @@ samverk/
 - **Git Forge:** GitHub (primary), Gitea (self-hosted), abstracted behind `IssueTracker` interface
 - **Testing:** Go stdlib + table-driven tests, Vitest + Testing Library (frontend)
 - **Build:** Make + GoReleaser
-- **CI/CD:** GitHub Actions
+- **CI/CD:** GitHub Actions (primary) + Gitea Actions (mirror CI, security.yml)
 - **Linting:** golangci-lint (Go), ESLint + TypeScript (frontend), markdownlint (docs)
 
 For full details including specific libraries, what NOT to use, and project structure rationale, see [docs/tech-stack.md](docs/tech-stack.md).
@@ -125,12 +126,14 @@ Read the repo first. Ask only if something is genuinely ambiguous after reading.
 - Per-project repos with coordination layer ([ADR-023](docs/decisions/ADR-023-per-project-repos.md))
 - Failure recovery strategy ([ADR-027](docs/decisions/ADR-027-failure-recovery.md))
 - Cross-model QA validation ([ADR-030](docs/decisions/ADR-030-cross-model-qa.md))
+- Dual-forge operational model ([ADR-031](docs/decisions/ADR-031-dual-forge-operational-model.md))
 - Unified execution plan -- Q2 2026 ([docs/unified-execution-plan.md](docs/unified-execution-plan.md))
 
 ## Infrastructure
 
 - **Proxmox host:** `root@192.168.1.203` (SSH key auth configured)
 - **Samverk container:** `root@192.168.1.162` CT 202 (SSH key auth configured)
+- **Gitea instance:** CT 200 (`192.168.1.160:3000`, `gitea.herbhall.net`) -- primary runtime forge for dispatcher
 - **Health check:** `curl http://192.168.1.162:8080/healthz`
 - **Deploy command:** `make deploy DEPLOY_HOST=192.168.1.162`
 - **Redeploy shortcut:** `make redeploy` -- cross-compiles, deploys, restarts services, and verifies the health check in one step. Use this after any code change that should reach the live server.

--- a/docs/decisions/ADR-031-dual-forge-operational-model.md
+++ b/docs/decisions/ADR-031-dual-forge-operational-model.md
@@ -1,0 +1,93 @@
+# ADR-031: Dual-Forge Operational Model
+
+**Status:** Accepted
+**Date:** 2026-03-08
+**Supersedes:** None
+
+## Context
+
+Samverk originally targeted GitHub as the only issue tracker and forge.
+Three operational concerns drove the need for a second forge:
+
+1. **Autonomy risk** — a dispatcher running autonomously against GitHub has
+   write access to a public-facing service. A Gitea instance on the LAN gives
+   the same issue-tracking capability with a smaller blast radius for
+   misconfigured automation.
+
+2. **Self-hosted alignment** — Samverk's design philosophy is self-hosted-first
+   (ADR-019). Operating against an external SaaS for core dispatcher state is
+   inconsistent with that principle.
+
+3. **Privacy** — development notes, draft frontmatter, and intermediate agent
+   comments that live in issues may not be suitable for a public repository
+   until they are ready for review.
+
+The goal is a dual-forge model where:
+
+- GitHub remains the public-facing, developer-visible tracker.
+- Gitea (CT 200, `gitea.herbhall.net`) is the primary runtime forge for
+  the dispatcher and agent communication during active development.
+
+## Decision
+
+Samverk supports two forges simultaneously. Key points:
+
+### Forge abstraction is the interface
+
+`forge.IssueTracker`, `forge.RepoReader`, and `forge.PullRequestManager`
+(ADR-013) remain the single interface layer. Both GitHub and Gitea are
+equal-status implementations. The dispatcher is unaware of which forge it
+is talking to.
+
+### Projects can be dual-registered
+
+`server.yaml` supports a `forge` field per project entry (`github` or `gitea`).
+A single logical repository can appear twice — once per forge — so the
+dispatcher watches both. New issues created by agents on Gitea flow back to
+GitHub via the migration script when ready.
+
+### GitHub is the public source of truth for releases
+
+`release-please` runs only on GitHub. Gitea receives tags mirrored from GitHub
+after releases are cut (B21). This keeps the changelog and semantic versioning
+tied to the public repository where external contributors can see it.
+
+### Gitea is the runtime forge for autonomous work
+
+The dispatcher preferentially operates against Gitea during the autonomous
+development phase. GitHub issues are migrated to Gitea via `migrate-issues.py`
+so the full backlog is available. Finished work is merged to GitHub via the
+normal PR flow (dual-push remote, configured in B24).
+
+### Authentication
+
+Gitea uses Bearer token auth. The token is stored in `GITEA_TOKEN` environment
+variable or per-project `gitea_token` field in `server.yaml`. The token for
+`samverk-admin` on the self-hosted instance is provisioned separately and not
+committed to the repository.
+
+## Consequences
+
+**Positive:**
+
+- Dispatcher blast radius is contained to the LAN Gitea instance.
+- GitHub remains clean and human-readable.
+- Infrastructure is portable — replacing Gitea with another forge only
+  requires implementing a new `IssueTracker` adapter.
+- `server.yaml` dual-entry model generalises to N-forge without code changes.
+
+**Negative:**
+
+- Issue state must be kept in sync across forges (manual migration or scripted).
+  Divergence is possible if sync is missed.
+- Two forges means two sets of labels, milestones, and webhooks to maintain.
+- The Gitea instance is a single point of failure for autonomous operation
+  (mitigated by fallback to GitHub mode via config change).
+
+## Related
+
+- [ADR-013: Forge Abstraction](ADR-013-forge-abstraction.md)
+- [ADR-019: Self-Hosted First](ADR-019-self-hosted-first.md)
+- [docs/gitea-migration-plan.md](../gitea-migration-plan.md)
+- [docs/gitea-actions-compatibility.md](../gitea-actions-compatibility.md)
+- [B-track issues #256–#283](https://github.com/HerbHall/samverk/milestone/5)


### PR DESCRIPTION
## Summary

- `docs/decisions/ADR-031-dual-forge-operational-model.md`: documents the dual-forge model (GitHub = public source of truth, Gitea = runtime forge for autonomous work)
- `CLAUDE.md`: adds Gitea infrastructure entry, `.gitea/workflows/` directory, ADR-031 reference, CI/CD note
- `.samverk/status.md`: reflects Window 1-2 completion state for B-track and W-track

## Test plan

- [x] `markdownlint-cli2` on all 3 files — 0 errors
- [x] Full CI (pre-push hook) — green

Closes #280
Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)