### PR TITLE
feat(#288,#324): /api/v1/metrics endpoint + fix pool shutdown panic

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/herbhall/samverk/internal/agent"
 	"github.com/herbhall/samverk/internal/api"
 	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/internal/metrics"
 	"github.com/herbhall/samverk/internal/cost"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/dispatcher"
@@ -180,7 +181,9 @@ func serveCmd() *cobra.Command {
 			}
 
 			// Wire REST API handler for dashboard.
-			cfg.APIHandler = api.New(tracker, st, costs)
+			apiHandler := api.New(tracker, st, costs)
+			apiHandler.SetMetrics(nil, nil, metrics.NewSystemCollector())
+			cfg.APIHandler = apiHandler
 			slog.Info("REST API enabled")
 
 			s := server.New(cfg)

--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -84,7 +84,20 @@ func NewPool(registry *provider.Registry, tracker forge.IssueTracker, st store.S
 
 // Submit enqueues a task for processing. Returns ErrPoolShutdown if the pool
 // has been shut down.
-func (p *Pool) Submit(task Task) error {
+//
+// There is an inherent TOCTOU window between checking p.shutdown and sending
+// on p.tasks: Shutdown can close the channel in between. We cannot hold the
+// mutex across the send because workers also acquire it (for the onComplete
+// callback), which would deadlock when the channel buffer is full. Instead
+// we recover from the resulting "send on closed channel" panic and convert
+// it to ErrPoolShutdown.
+func (p *Pool) Submit(task Task) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = ErrPoolShutdown
+		}
+	}()
+
 	p.mu.Lock()
 	if p.shutdown {
 		p.mu.Unlock()

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -322,6 +323,53 @@ func TestPool_OnCompleteCallback_ProviderFailure(t *testing.T) {
 	}
 	if results[0].Error == "" {
 		t.Errorf("expected non-empty Error on provider failure")
+	}
+}
+
+func TestPoolConcurrentSubmitAndShutdown(t *testing.T) {
+	// Regression test for #324: concurrent Submit + Shutdown must not panic
+	// with "send on closed channel". Run with -race to catch data races.
+	mp := &mockProvider{
+		chatFn: func(_ context.Context, _ provider.ChatRequest) (*provider.ChatResponse, error) {
+			time.Sleep(5 * time.Millisecond) // fast enough to avoid slow test, slow enough to create contention
+			return &provider.ChatResponse{
+				Message: provider.Message{Role: provider.RoleAssistant, Content: "ok"},
+			}, nil
+		},
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+
+	pool := newTestPool(t, 2, mp)
+
+	// Submit tasks from multiple goroutines while shutting down concurrently.
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_ = pool.Submit(Task{
+				Issue:     &forge.Issue{Number: n, Title: "race test", Body: "body"},
+				AgentType: models.AgentTypeCodeGen,
+				SessionID: fmt.Sprintf("sess-race-%d", n),
+			})
+		}(i)
+	}
+
+	// Shutdown while submits are still in-flight.
+	time.Sleep(2 * time.Millisecond)
+	pool.Shutdown()
+	wg.Wait()
+
+	// If we got here without a panic, the fix works.
+	// After shutdown, all submits must return ErrPoolShutdown.
+	err := pool.Submit(Task{
+		Issue:     &forge.Issue{Number: 999, Title: "post-shutdown", Body: "body"},
+		AgentType: models.AgentTypeCodeGen,
+		SessionID: "sess-post",
+	})
+	if !errors.Is(err, ErrPoolShutdown) {
+		t.Fatalf("expected ErrPoolShutdown after shutdown, got %v", err)
 	}
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,14 +7,33 @@ import (
 
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/internal/metrics"
 	"github.com/herbhall/samverk/internal/store"
 )
 
+// poolMetricsSource provides a snapshot of the agent pool.
+type poolMetricsSource interface {
+	Snapshot() metrics.PoolSnapshot
+}
+
+// dispatcherMetricsSource provides a snapshot of the dispatcher.
+type dispatcherMetricsSource interface {
+	Snapshot() metrics.DispatcherSnapshot
+}
+
+// systemMetricsSource provides a system-level metrics snapshot.
+type systemMetricsSource interface {
+	Collect() metrics.SystemSnapshot
+}
+
 // API provides REST endpoints for the web dashboard.
 type API struct {
-	tracker forge.IssueTracker // may be nil if no forge credentials
-	store   store.Store        // may be nil if no database
-	costs   digest.CostSource  // may be nil if no cost tracking
+	tracker    forge.IssueTracker    // may be nil if no forge credentials
+	store      store.Store           // may be nil if no database
+	costs      digest.CostSource     // may be nil if no cost tracking
+	pool       poolMetricsSource     // may be nil if pool not yet started
+	dispatcher dispatcherMetricsSource // may be nil if dispatcher not started
+	system     systemMetricsSource   // may be nil; created via SetMetrics
 }
 
 // New creates an API handler with the given dependencies.
@@ -28,6 +47,13 @@ func New(tracker forge.IssueTracker, s store.Store, costs digest.CostSource) *AP
 	}
 }
 
+// SetMetrics attaches metrics sources to the API handler. Call before serving.
+func (a *API) SetMetrics(pool poolMetricsSource, disp dispatcherMetricsSource, sys systemMetricsSource) {
+	a.pool = pool
+	a.dispatcher = disp
+	a.system = sys
+}
+
 // RegisterRoutes registers all API endpoints on the given mux.
 // Routes use Go 1.22+ method+path patterns.
 func (a *API) RegisterRoutes(mux *http.ServeMux) {
@@ -36,6 +62,7 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/sessions", a.handleListSessions)
 	mux.HandleFunc("GET /api/v1/costs", a.handleGetCosts)
 	mux.HandleFunc("GET /api/v1/status", a.handleStatus)
+	mux.HandleFunc("GET /api/v1/metrics", a.handleMetrics)
 }
 
 // errorResponse is the JSON body returned for error responses.

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"net/http"
+	"time"
+)
+
+// metricsResponse is the JSON body returned by GET /api/v1/metrics.
+type metricsResponse struct {
+	Pool       *poolMetricsDTO       `json:"pool"`
+	Dispatcher *dispatcherMetricsDTO `json:"dispatcher"`
+	System     *systemMetricsDTO     `json:"system"`
+}
+
+// poolMetricsDTO is the JSON-serializable form of metrics.PoolSnapshot.
+// Duration fields are expressed in milliseconds for dashboard readability.
+type poolMetricsDTO struct {
+	CollectedAt       string  `json:"collected_at"`
+	TotalWorkers      int     `json:"total_workers"`
+	ActiveWorkers     int     `json:"active_workers"`
+	IdleWorkers       int     `json:"idle_workers"`
+	QueueDepth        int     `json:"queue_depth"`
+	TasksCompleted    int64   `json:"tasks_completed"`
+	TasksFailed       int64   `json:"tasks_failed"`
+	AvgTaskDurationMs float64 `json:"avg_task_duration_ms"`
+	P95TaskDurationMs float64 `json:"p95_task_duration_ms"`
+}
+
+// dispatcherMetricsDTO is the JSON-serializable form of metrics.DispatcherSnapshot.
+type dispatcherMetricsDTO struct {
+	CollectedAt          string  `json:"collected_at"`
+	ClaimedCount         int     `json:"claimed_count"`
+	TotalRouted          int64   `json:"total_routed"`
+	TotalRequeued        int64   `json:"total_requeued"`
+	TotalEventsProcessed int64   `json:"total_events_processed"`
+	AvgPollLatencyMs     float64 `json:"avg_poll_latency_ms"`
+	LastPollAt           string  `json:"last_poll_at"`
+}
+
+// systemMetricsDTO is the JSON-serializable form of metrics.SystemSnapshot.
+type systemMetricsDTO struct {
+	CollectedAt    string `json:"collected_at"`
+	Goroutines     int    `json:"goroutines"`
+	HeapAllocBytes uint64 `json:"heap_alloc_bytes"`
+	SysBytesTotal  uint64 `json:"sys_bytes_total"`
+	GCCycles       uint32 `json:"gc_cycles"`
+	NextGCBytes    uint64 `json:"next_gc_bytes"`
+}
+
+// handleMetrics serves GET /api/v1/metrics.
+// Returns 200 with a JSON body. Any source that is nil contributes a null field.
+func (a *API) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	resp := metricsResponse{}
+
+	if a.pool != nil {
+		snap := a.pool.Snapshot()
+		resp.Pool = &poolMetricsDTO{
+			CollectedAt:       snap.CollectedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			TotalWorkers:      snap.TotalWorkers,
+			ActiveWorkers:     snap.ActiveWorkers,
+			IdleWorkers:       snap.IdleWorkers,
+			QueueDepth:        snap.QueueDepth,
+			TasksCompleted:    snap.TasksCompleted,
+			TasksFailed:       snap.TasksFailed,
+			AvgTaskDurationMs: durationToMs(snap.AvgTaskDuration),
+			P95TaskDurationMs: durationToMs(snap.P95TaskDuration),
+		}
+	}
+
+	if a.dispatcher != nil {
+		snap := a.dispatcher.Snapshot()
+		resp.Dispatcher = &dispatcherMetricsDTO{
+			CollectedAt:          snap.CollectedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			ClaimedCount:         snap.ClaimedCount,
+			TotalRouted:          snap.TotalRouted,
+			TotalRequeued:        snap.TotalRequeued,
+			TotalEventsProcessed: snap.TotalEventsProcessed,
+			AvgPollLatencyMs:     durationToMs(snap.AvgPollLatency),
+			LastPollAt:           snap.LastPollAt.UTC().Format("2006-01-02T15:04:05Z"),
+		}
+	}
+
+	if a.system != nil {
+		snap := a.system.Collect()
+		resp.System = &systemMetricsDTO{
+			CollectedAt:    snap.CollectedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			Goroutines:     snap.Goroutines,
+			HeapAllocBytes: snap.HeapAllocBytes,
+			SysBytesTotal:  snap.SysBytesTotal,
+			GCCycles:       snap.GCCycles,
+			NextGCBytes:    snap.NextGCBytes,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// durationToMs converts a time.Duration to milliseconds as a float64.
+func durationToMs(d time.Duration) float64 {
+	return float64(d.Nanoseconds()) / 1e6
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -1,0 +1,262 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/herbhall/samverk/internal/api"
+	"github.com/herbhall/samverk/internal/metrics"
+)
+
+// makeMetricsServer creates an httptest.Server for an already-configured API.
+func makeMetricsServer(t *testing.T, a *api.API) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	a.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestHandleMetrics_AllNil(t *testing.T) {
+	// Do not call SetMetrics -- all three sources are nil interfaces by default.
+	a := api.New(nil, nil, nil)
+	ts := makeMetricsServer(t, a)
+
+	resp := doGet(t, ts.URL+"/api/v1/metrics")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var body map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	for _, field := range []string{"pool", "dispatcher", "system"} {
+		val := string(body[field])
+		if val != "null" {
+			t.Errorf("%s = %s, want null", field, val)
+		}
+	}
+}
+
+func TestHandleMetrics_Pool(t *testing.T) {
+	pm := metrics.NewPoolMetrics(4)
+	// Simulate a completed task so avg duration is non-zero.
+	pm.WorkerStarted()
+	pm.WorkerFinished(50_000_000, metrics.TaskResultSuccess) // 50ms
+
+	a := api.New(nil, nil, nil)
+	a.SetMetrics(pm, nil, nil) // nil literals are untyped: safe nil interfaces
+	ts := makeMetricsServer(t, a)
+
+	resp := doGet(t, ts.URL+"/api/v1/metrics")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		Pool *struct {
+			CollectedAt       string  `json:"collected_at"`
+			TotalWorkers      int     `json:"total_workers"`
+			ActiveWorkers     int     `json:"active_workers"`
+			IdleWorkers       int     `json:"idle_workers"`
+			TasksCompleted    int64   `json:"tasks_completed"`
+			TasksFailed       int64   `json:"tasks_failed"`
+			AvgTaskDurationMs float64 `json:"avg_task_duration_ms"`
+		} `json:"pool"`
+		Dispatcher *struct{} `json:"dispatcher"`
+		System     *struct{} `json:"system"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Pool == nil {
+		t.Fatal("pool = nil, want non-nil")
+	}
+	if body.Pool.CollectedAt == "" {
+		t.Error("pool.collected_at is empty")
+	}
+	if body.Pool.TotalWorkers != 4 {
+		t.Errorf("total_workers = %d, want 4", body.Pool.TotalWorkers)
+	}
+	if body.Pool.ActiveWorkers != 0 {
+		t.Errorf("active_workers = %d, want 0", body.Pool.ActiveWorkers)
+	}
+	if body.Pool.IdleWorkers != 4 {
+		t.Errorf("idle_workers = %d, want 4", body.Pool.IdleWorkers)
+	}
+	if body.Pool.TasksCompleted != 1 {
+		t.Errorf("tasks_completed = %d, want 1", body.Pool.TasksCompleted)
+	}
+	if body.Pool.TasksFailed != 0 {
+		t.Errorf("tasks_failed = %d, want 0", body.Pool.TasksFailed)
+	}
+	// 50ms -> 50.0ms
+	if body.Pool.AvgTaskDurationMs < 49 || body.Pool.AvgTaskDurationMs > 51 {
+		t.Errorf("avg_task_duration_ms = %v, want ~50", body.Pool.AvgTaskDurationMs)
+	}
+	if body.Dispatcher != nil {
+		t.Error("dispatcher = non-nil, want null")
+	}
+	if body.System != nil {
+		t.Error("system = non-nil, want null")
+	}
+}
+
+func TestHandleMetrics_Dispatcher(t *testing.T) {
+	dm := metrics.NewDispatcherMetrics()
+	dm.IssueRouted()
+	dm.IssueRouted()
+	dm.IssueRequeued()
+	dm.EventProcessed()
+	dm.PollCompleted(10_000_000) // 10ms
+
+	a := api.New(nil, nil, nil)
+	a.SetMetrics(nil, dm, nil) // nil literals are untyped: safe nil interfaces
+	ts := makeMetricsServer(t, a)
+
+	resp := doGet(t, ts.URL+"/api/v1/metrics")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		Pool       *struct{} `json:"pool"`
+		Dispatcher *struct {
+			CollectedAt          string  `json:"collected_at"`
+			TotalRouted          int64   `json:"total_routed"`
+			TotalRequeued        int64   `json:"total_requeued"`
+			TotalEventsProcessed int64   `json:"total_events_processed"`
+			AvgPollLatencyMs     float64 `json:"avg_poll_latency_ms"`
+			LastPollAt           string  `json:"last_poll_at"`
+		} `json:"dispatcher"`
+		System *struct{} `json:"system"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Pool != nil {
+		t.Error("pool = non-nil, want null")
+	}
+	if body.Dispatcher == nil {
+		t.Fatal("dispatcher = nil, want non-nil")
+	}
+	if body.Dispatcher.TotalRouted != 2 {
+		t.Errorf("total_routed = %d, want 2", body.Dispatcher.TotalRouted)
+	}
+	if body.Dispatcher.TotalRequeued != 1 {
+		t.Errorf("total_requeued = %d, want 1", body.Dispatcher.TotalRequeued)
+	}
+	if body.Dispatcher.TotalEventsProcessed != 1 {
+		t.Errorf("total_events_processed = %d, want 1", body.Dispatcher.TotalEventsProcessed)
+	}
+	// 10ms -> 10.0ms
+	if body.Dispatcher.AvgPollLatencyMs < 9 || body.Dispatcher.AvgPollLatencyMs > 11 {
+		t.Errorf("avg_poll_latency_ms = %v, want ~10", body.Dispatcher.AvgPollLatencyMs)
+	}
+	if body.System != nil {
+		t.Error("system = non-nil, want null")
+	}
+}
+
+func TestHandleMetrics_System(t *testing.T) {
+	sc := metrics.NewSystemCollector()
+
+	a := api.New(nil, nil, nil)
+	a.SetMetrics(nil, nil, sc) // nil literals are untyped: safe nil interfaces
+	ts := makeMetricsServer(t, a)
+
+	resp := doGet(t, ts.URL+"/api/v1/metrics")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		Pool       *struct{} `json:"pool"`
+		Dispatcher *struct{} `json:"dispatcher"`
+		System     *struct {
+			CollectedAt    string `json:"collected_at"`
+			Goroutines     int    `json:"goroutines"`
+			HeapAllocBytes uint64 `json:"heap_alloc_bytes"`
+			SysBytesTotal  uint64 `json:"sys_bytes_total"`
+		} `json:"system"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Pool != nil {
+		t.Error("pool = non-nil, want null")
+	}
+	if body.Dispatcher != nil {
+		t.Error("dispatcher = non-nil, want null")
+	}
+	if body.System == nil {
+		t.Fatal("system = nil, want non-nil")
+	}
+	if body.System.CollectedAt == "" {
+		t.Error("system.collected_at is empty")
+	}
+	if body.System.Goroutines <= 0 {
+		t.Errorf("goroutines = %d, want > 0", body.System.Goroutines)
+	}
+	if body.System.HeapAllocBytes == 0 {
+		t.Error("heap_alloc_bytes = 0, want > 0")
+	}
+	if body.System.SysBytesTotal == 0 {
+		t.Error("sys_bytes_total = 0, want > 0")
+	}
+}
+
+func TestHandleMetrics_AllSources(t *testing.T) {
+	pm := metrics.NewPoolMetrics(2)
+	dm := metrics.NewDispatcherMetrics()
+	sc := metrics.NewSystemCollector()
+
+	a := api.New(nil, nil, nil)
+	a.SetMetrics(pm, dm, sc)
+	ts := makeMetricsServer(t, a)
+
+	resp := doGet(t, ts.URL+"/api/v1/metrics")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		Pool       *json.RawMessage `json:"pool"`
+		Dispatcher *json.RawMessage `json:"dispatcher"`
+		System     *json.RawMessage `json:"system"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Pool == nil {
+		t.Error("pool = null, want non-null")
+	}
+	if body.Dispatcher == nil {
+		t.Error("dispatcher = null, want non-null")
+	}
+	if body.System == nil {
+		t.Error("system = null, want non-null")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/metrics` REST endpoint that exposes pool, dispatcher, and system metrics as JSON (W05 #288)
- Wires `SystemCollector` into `samverk serve` so system metrics (goroutines, heap, GC) are always live
- Pool and dispatcher metrics fields return `null` when the component is not running in that process (nil-safe by design)
- Fixes #324: `pool.Submit` panicked with "send on closed channel" during concurrent `Shutdown` due to a TOCTOU race — fixed by recovering the panic and returning `ErrPoolShutdown`
- 5 new API tests, 1 new agent regression test (`TestPoolConcurrentSubmitAndShutdown`)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — 20 packages pass
- [x] `golangci-lint` — 0 issues
- [x] `markdownlint` — 0 issues
- [x] Pre-push hook: all checks passed

Closes #288, Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)