### PR TITLE
feat(#289): add Metrics page to SPA dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router'
 import { Layout } from './components/Layout'
 import { Dashboard } from './pages/Dashboard'
 import { Issues } from './pages/Issues'
+import { Metrics } from './pages/Metrics'
 
 export function App() {
   return (
@@ -9,6 +10,7 @@ export function App() {
       <Route element={<Layout />}>
         <Route index element={<Dashboard />} />
         <Route path="issues" element={<Issues />} />
+        <Route path="metrics" element={<Metrics />} />
       </Route>
     </Routes>
   )

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -23,6 +23,14 @@ export function Layout() {
           >
             Issues
           </NavLink>
+          <NavLink
+            to="/metrics"
+            className={({ isActive }) =>
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+            }
+          >
+            Metrics
+          </NavLink>
         </nav>
       </aside>
       <main className="flex-1 overflow-auto p-6">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -52,6 +52,43 @@ export interface SystemStatus {
   tool_count: number
 }
 
+export interface PoolMetrics {
+  collected_at: string
+  total_workers: number
+  active_workers: number
+  idle_workers: number
+  queue_depth: number
+  tasks_completed: number
+  tasks_failed: number
+  avg_task_duration_ms: number
+  p95_task_duration_ms: number
+}
+
+export interface DispatcherMetrics {
+  collected_at: string
+  claimed_count: number
+  total_routed: number
+  total_requeued: number
+  total_events_processed: number
+  avg_poll_latency_ms: number
+  last_poll_at: string
+}
+
+export interface SystemMetrics {
+  collected_at: string
+  goroutines: number
+  heap_alloc_bytes: number
+  sys_bytes_total: number
+  gc_cycles: number
+  next_gc_bytes: number
+}
+
+export interface MetricsResponse {
+  pool: PoolMetrics | null
+  dispatcher: DispatcherMetrics | null
+  system: SystemMetrics | null
+}
+
 export const api = {
   listIssues: (params?: { state?: string; page?: number }) =>
     fetchJSON<Issue[]>(`/issues${params ? '?' + new URLSearchParams(params as Record<string, string>).toString() : ''}`),
@@ -67,4 +104,7 @@ export const api = {
 
   getStatus: () =>
     fetchJSON<SystemStatus>('/status'),
+
+  getMetrics: () =>
+    fetchJSON<MetricsResponse>('/metrics'),
 }

--- a/web/src/pages/Metrics.tsx
+++ b/web/src/pages/Metrics.tsx
@@ -1,0 +1,143 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../lib/api'
+import type { PoolMetrics, DispatcherMetrics, SystemMetrics } from '../lib/api'
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`
+  if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(1)} KB`
+  return `${bytes} B`
+}
+
+function formatMs(ms: number): string {
+  if (ms === 0) return '—'
+  if (ms >= 1_000) return `${(ms / 1_000).toFixed(2)}s`
+  return `${ms.toFixed(1)}ms`
+}
+
+function MetricRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between py-2 border-b last:border-b-0">
+      <span className="text-sm text-gray-600">{label}</span>
+      <span className="text-sm font-medium text-gray-900 font-mono">{value}</span>
+    </div>
+  )
+}
+
+function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border bg-white">
+      <div className="px-4 py-3 border-b bg-gray-50">
+        <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
+      </div>
+      <div className="px-4 py-2">{children}</div>
+    </div>
+  )
+}
+
+function NullSection({ title }: { title: string }) {
+  return (
+    <div className="rounded-lg border bg-white">
+      <div className="px-4 py-3 border-b bg-gray-50">
+        <h3 className="text-sm font-semibold text-gray-400">{title}</h3>
+      </div>
+      <div className="px-4 py-6 text-center text-sm text-gray-400">Not running</div>
+    </div>
+  )
+}
+
+function PoolSection({ pool }: { pool: PoolMetrics | null }) {
+  if (pool == null) return <NullSection title="Agent Pool" />
+
+  const utilization =
+    pool.total_workers > 0 ? Math.round((pool.active_workers / pool.total_workers) * 100) : 0
+
+  return (
+    <SectionCard title="Agent Pool">
+      <MetricRow label="Total Workers" value={pool.total_workers.toString()} />
+      <MetricRow label="Active Workers" value={pool.active_workers.toString()} />
+      <MetricRow label="Idle Workers" value={pool.idle_workers.toString()} />
+      <MetricRow label="Utilization" value={`${utilization}%`} />
+      <MetricRow label="Queue Depth" value={pool.queue_depth.toString()} />
+      <MetricRow label="Tasks Completed" value={pool.tasks_completed.toLocaleString()} />
+      <MetricRow label="Tasks Failed" value={pool.tasks_failed.toLocaleString()} />
+      <MetricRow label="Avg Task Duration" value={formatMs(pool.avg_task_duration_ms)} />
+      <MetricRow label="P95 Task Duration" value={formatMs(pool.p95_task_duration_ms)} />
+    </SectionCard>
+  )
+}
+
+function DispatcherSection({ dispatcher }: { dispatcher: DispatcherMetrics | null }) {
+  if (dispatcher == null) return <NullSection title="Dispatcher" />
+
+  const lastPoll =
+    dispatcher.last_poll_at === '0001-01-01T00:00:00Z'
+      ? 'Never'
+      : new Date(dispatcher.last_poll_at).toLocaleString()
+
+  return (
+    <SectionCard title="Dispatcher">
+      <MetricRow label="Claimed Issues" value={dispatcher.claimed_count.toString()} />
+      <MetricRow label="Total Routed" value={dispatcher.total_routed.toLocaleString()} />
+      <MetricRow label="Total Requeued" value={dispatcher.total_requeued.toLocaleString()} />
+      <MetricRow
+        label="Events Processed"
+        value={dispatcher.total_events_processed.toLocaleString()}
+      />
+      <MetricRow label="Avg Poll Latency" value={formatMs(dispatcher.avg_poll_latency_ms)} />
+      <MetricRow label="Last Poll" value={lastPoll} />
+    </SectionCard>
+  )
+}
+
+function SystemSection({ system }: { system: SystemMetrics | null }) {
+  if (system == null) return <NullSection title="System" />
+
+  return (
+    <SectionCard title="System">
+      <MetricRow label="Goroutines" value={system.goroutines.toString()} />
+      <MetricRow label="Heap Allocated" value={formatBytes(system.heap_alloc_bytes)} />
+      <MetricRow label="OS Memory" value={formatBytes(system.sys_bytes_total)} />
+      <MetricRow label="GC Cycles" value={system.gc_cycles.toString()} />
+      <MetricRow label="Next GC Target" value={formatBytes(system.next_gc_bytes)} />
+    </SectionCard>
+  )
+}
+
+export function Metrics() {
+  const metrics = useQuery({
+    queryKey: ['metrics'],
+    queryFn: api.getMetrics,
+    refetchInterval: 10_000,
+  })
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">Metrics</h2>
+        <span className="text-xs text-gray-400">Auto-refreshes every 10s</span>
+      </div>
+
+      {metrics.isLoading && (
+        <div className="flex items-center justify-center py-20">
+          <p className="text-gray-500">Loading metrics...</p>
+        </div>
+      )}
+
+      {metrics.isError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+          <p className="font-medium text-red-800">Failed to load metrics</p>
+          <p className="mt-1 text-sm text-red-600">{metrics.error?.message ?? 'Unknown error'}</p>
+        </div>
+      )}
+
+      {metrics.data != null && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <PoolSection pool={metrics.data.pool} />
+          <DispatcherSection dispatcher={metrics.data.dispatcher} />
+          <SystemSection system={metrics.data.system} />
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/metrics` route to the React SPA showing pool, dispatcher, and system metrics
- 3-column card layout — each section shows "Not running" gracefully when its source is null (pool/dispatcher run in separate process from the HTTP server)
- Auto-refreshes every 10s via TanStack Query
- Adds `PoolMetrics`, `DispatcherMetrics`, `SystemMetrics` TypeScript types and `api.getMetrics()` to `api.ts`
- Adds Metrics link to sidebar nav

## Test plan

- [x] `tsc -b && vite build` — clean build
- [x] TypeScript strict mode — no errors
- [x] `go build ./...` — clean
- [x] Pre-push hook: all CI checks passed

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)