### PR TITLE
feat(#290): add runtime metrics to get_digest MCP tool output

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/herbhall/samverk/internal/agent"
 	"github.com/herbhall/samverk/internal/api"
 	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/internal/metrics"
 	"github.com/herbhall/samverk/internal/cost"
 	"github.com/herbhall/samverk/internal/digest"
 	"github.com/herbhall/samverk/internal/dispatcher"
@@ -173,8 +174,9 @@ func serveCmd() *cobra.Command {
 				}
 
 				mcpHandler.SetProjects(registry)
-				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
-				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
+			mcpHandler.SetMetrics(nil, nil, metrics.NewSystemCollector())
+			cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
+			slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
 			} else {
 				slog.Info("MCP handler disabled (set GITHUB_TOKEN, owner, and repo to enable)")
 			}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -25,6 +25,9 @@ type Handler struct {
 	repo      forge.RepoReader            // may be nil (no repo browsing)
 	prManager forge.PullRequestManager    // may be nil (no PR operations)
 	projects  *ProjectRegistry            // may be nil (single-project mode)
+	poolM     poolMetricsSource           // may be nil (pool not running here)
+	dispM     dispatcherMetricsSource     // may be nil (dispatcher not running here)
+	sysM      systemMetricsSource         // may be nil
 }
 
 // NewHandler creates a new MCP tool handler with its dependencies.

--- a/internal/mcp/metrics.go
+++ b/internal/mcp/metrics.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/herbhall/samverk/internal/metrics"
+)
+
+// poolMetricsSource provides pool stats for the digest.
+type poolMetricsSource interface {
+	Snapshot() metrics.PoolSnapshot
+}
+
+// dispatcherMetricsSource provides dispatcher stats for the digest.
+type dispatcherMetricsSource interface {
+	Snapshot() metrics.DispatcherSnapshot
+}
+
+// systemMetricsSource provides system stats for the digest.
+type systemMetricsSource interface {
+	Collect() metrics.SystemSnapshot
+}
+
+// SetMetrics attaches runtime metrics sources to the handler.
+// Sources may be nil; only non-nil sources appear in the digest.
+func (h *Handler) SetMetrics(pool poolMetricsSource, disp dispatcherMetricsSource, sys systemMetricsSource) {
+	h.poolM = pool
+	h.dispM = disp
+	h.sysM = sys
+}
+
+// formatMetricsSection renders a brief METRICS block appended to the digest text.
+func (h *Handler) formatMetricsSection() string {
+	if h.poolM == nil && h.dispM == nil && h.sysM == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n--- RUNTIME METRICS ---\n\n")
+
+	if h.poolM != nil {
+		snap := h.poolM.Snapshot()
+		fmt.Fprintf(&b, "Pool: %d workers (%d active, %d idle) | queue: %d | completed: %d | failed: %d\n",
+			snap.TotalWorkers, snap.ActiveWorkers, snap.IdleWorkers,
+			snap.QueueDepth, snap.TasksCompleted, snap.TasksFailed)
+		if snap.AvgTaskDuration > 0 {
+			fmt.Fprintf(&b, "  Avg task: %dms | P95: %dms\n",
+				snap.AvgTaskDuration.Milliseconds(), snap.P95TaskDuration.Milliseconds())
+		}
+	} else {
+		b.WriteString("Pool: not running in this process\n")
+	}
+
+	if h.dispM != nil {
+		snap := h.dispM.Snapshot()
+		fmt.Fprintf(&b, "Dispatcher: %d claimed | %d routed | %d requeued | %d events",
+			snap.ClaimedCount, snap.TotalRouted, snap.TotalRequeued, snap.TotalEventsProcessed)
+		if snap.AvgPollLatency > 0 {
+			fmt.Fprintf(&b, " | poll latency: %dms", snap.AvgPollLatency.Milliseconds())
+		}
+		b.WriteString("\n")
+	} else {
+		b.WriteString("Dispatcher: not running in this process\n")
+	}
+
+	if h.sysM != nil {
+		snap := h.sysM.Collect()
+		fmt.Fprintf(&b, "System: %d goroutines | heap: %s | GC cycles: %d\n",
+			snap.Goroutines, formatBytes(snap.HeapAllocBytes), snap.GCCycles)
+	}
+
+	return b.String()
+}
+
+// formatBytes returns a human-readable byte count.
+func formatBytes(b uint64) string {
+	switch {
+	case b >= 1_073_741_824:
+		return fmt.Sprintf("%.1f GB", float64(b)/1_073_741_824)
+	case b >= 1_048_576:
+		return fmt.Sprintf("%.1f MB", float64(b)/1_048_576)
+	case b >= 1_024:
+		return fmt.Sprintf("%.1f KB", float64(b)/1_024)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -198,7 +198,7 @@ func (h *Handler) handleGetDigest(
 		return nil, nil, fmt.Errorf("building digest: %w", err)
 	}
 
-	text := digest.FormatDigest(data)
+	text := digest.FormatDigest(data) + h.formatMetricsSection()
 
 	return &gosdk.CallToolResult{
 		Content: []gosdk.Content{


### PR DESCRIPTION
## Summary

- Appends a `--- RUNTIME METRICS ---` section to `get_digest` output showing pool, dispatcher, and system stats
- Each component degrades gracefully when not running in the current process ("not running in this process" message)
- Wires `SystemCollector` into the serve command's MCP handler so system metrics (goroutines, heap, GC cycles) always appear in digests
- Adds `Handler.SetMetrics()` for future wiring when serve and dispatch are co-located

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] Pre-push hook: all CI checks passed

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)