### PR TITLE
feat(#292): dynamic worker scaling for agent pool

### DIFF
--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/herbhall/samverk/internal/cost"
@@ -40,20 +41,26 @@ type TaskResult struct {
 	Error       string
 }
 
-// Pool manages a fixed set of worker goroutines that process agent tasks.
+// workerQuitBuf is the maximum number of pending quit signals.
+// Generous to accommodate burst RemoveWorkers calls.
+const workerQuitBuf = 64
+
+// Pool manages a set of worker goroutines that process agent tasks.
+// Workers may be added or removed at runtime via AddWorkers/RemoveWorkers.
 type Pool struct {
 	registry   *provider.Registry
 	tracker    forge.IssueTracker
 	store      store.Store
 	costs      *cost.Tracker
-	workers    int
+	workers    int        // current target worker count (under mu)
 	tasks      chan Task
 	wg         sync.WaitGroup
 	logger     *slog.Logger
 	done       chan struct{}
 	mu         sync.Mutex
 	shutdown   bool
-	onComplete func(TaskResult) // callback to notify dispatcher of task completion
+	onComplete atomic.Pointer[func(TaskResult)] // callback to notify dispatcher; atomic to avoid mu deadlock
+	workerQuit chan struct{}                     // each send causes one worker to exit after its current task
 }
 
 // NewPool creates a pool with the given number of worker goroutines and starts
@@ -64,14 +71,15 @@ func NewPool(registry *provider.Registry, tracker forge.IssueTracker, st store.S
 	}
 
 	p := &Pool{
-		registry: registry,
-		tracker:  tracker,
-		store:    st,
-		costs:    costs,
-		workers:  workers,
-		tasks:    make(chan Task, workers*2),
-		logger:   slog.Default(),
-		done:     make(chan struct{}),
+		registry:   registry,
+		tracker:    tracker,
+		store:      st,
+		costs:      costs,
+		workers:    workers,
+		tasks:      make(chan Task, workers*2),
+		logger:     slog.Default(),
+		done:       make(chan struct{}),
+		workerQuit: make(chan struct{}, workerQuitBuf),
 	}
 
 	p.wg.Add(workers)
@@ -82,16 +90,87 @@ func NewPool(registry *provider.Registry, tracker forge.IssueTracker, st store.S
 	return p
 }
 
-// Submit enqueues a task for processing. Returns ErrPoolShutdown if the pool
-// has been shut down.
-func (p *Pool) Submit(task Task) error {
+// AddWorkers starts n additional worker goroutines. Returns ErrPoolShutdown if
+// the pool has already been shut down. No-op if n <= 0.
+func (p *Pool) AddWorkers(n int) error {
+	if n <= 0 {
+		return nil
+	}
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	if p.shutdown {
-		p.mu.Unlock()
 		return ErrPoolShutdown
 	}
+	p.workers += n
+	p.wg.Add(n)
+	for range n {
+		go p.worker()
+	}
+	p.logger.Info("agent pool scaled up", slog.Int("added", n), slog.Int("workers", p.workers))
+	return nil
+}
+
+// RemoveWorkers signals n workers to exit after completing their current task.
+// To protect liveness, at least one worker is always kept running; the actual
+// number removed may be less than n. Returns the number of quit signals sent.
+func (p *Pool) RemoveWorkers(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	p.mu.Lock()
+	// Keep at least one worker alive.
+	available := p.workers - 1
+	if available <= 0 {
+		p.mu.Unlock()
+		return 0
+	}
+	if n > available {
+		n = available
+	}
+	p.workers -= n
 	p.mu.Unlock()
 
+	sent := 0
+sendLoop:
+	for range n {
+		select {
+		case p.workerQuit <- struct{}{}:
+			sent++
+		default:
+			// Buffer full; stop here. Remaining workers stay alive.
+			p.mu.Lock()
+			p.workers += (n - sent)
+			p.mu.Unlock()
+			break sendLoop
+		}
+	}
+	if sent > 0 {
+		p.logger.Info("agent pool scaled down", slog.Int("removed", sent), slog.Int("workers", p.Workers()))
+	}
+	return sent
+}
+
+// Workers returns the current target worker count.
+func (p *Pool) Workers() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.workers
+}
+
+// Submit enqueues a task for processing. Returns ErrPoolShutdown if the pool
+// has been shut down.
+//
+// The lock is held across the channel send to prevent a TOCTOU race with
+// Shutdown: without it, Shutdown can close the channel between the flag
+// check and the send, causing a panic. The channel is buffered (workers×2)
+// so the send is almost always non-blocking. In the rare case the buffer
+// is full, workers will drain it without acquiring mu, so no deadlock.
+func (p *Pool) Submit(task Task) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.shutdown {
+		return ErrPoolShutdown
+	}
 	p.tasks <- task
 	return nil
 }
@@ -121,17 +200,21 @@ func (p *Pool) Done() <-chan struct{} {
 
 // SetOnComplete registers a callback invoked after each task finishes.
 func (p *Pool) SetOnComplete(fn func(TaskResult)) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.onComplete = fn
+	p.onComplete.Store(&fn)
 }
 
 // worker is the main loop for a single worker goroutine.
+// After each task it checks workerQuit; if a signal is pending, it exits.
 func (p *Pool) worker() {
 	defer p.wg.Done()
 
 	for task := range p.tasks {
 		p.processTask(task)
+		select {
+		case <-p.workerQuit:
+			return
+		default:
+		}
 	}
 }
 
@@ -165,11 +248,8 @@ func (p *Pool) processTask(task Task) {
 		logger.Error("no healthy provider", slog.String("error", err.Error()))
 		p.failSession(ctx, task.SessionID, fmt.Sprintf("no healthy provider: %v", err))
 		// Notify dispatcher even on provider failure.
-		p.mu.Lock()
-		cb := p.onComplete
-		p.mu.Unlock()
-		if cb != nil {
-			cb(TaskResult{
+		if cbPtr := p.onComplete.Load(); cbPtr != nil {
+			(*cbPtr)(TaskResult{
 				IssueNumber: task.Issue.Number,
 				SessionID:   task.SessionID,
 				AgentType:   task.AgentType,
@@ -197,11 +277,8 @@ func (p *Pool) processTask(task Task) {
 		logger.Info("task completed")
 	}
 
-	p.mu.Lock()
-	cb := p.onComplete
-	p.mu.Unlock()
-	if cb != nil {
-		cb(result)
+	if cbPtr := p.onComplete.Load(); cbPtr != nil {
+		(*cbPtr)(result)
 	}
 }
 

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -325,6 +325,58 @@ func TestPool_OnCompleteCallback_ProviderFailure(t *testing.T) {
 	}
 }
 
+func TestPool_ConcurrentSubmitAndShutdown(t *testing.T) {
+	// This test verifies that concurrent Submit and Shutdown calls do not
+	// panic with "send on closed channel". Before the fix in #324,
+	// Submit released the lock before the channel send, creating a
+	// TOCTOU race where Shutdown could close the channel in between.
+	mp := &mockProvider{
+		chatFn: func(_ context.Context, _ provider.ChatRequest) (*provider.ChatResponse, error) {
+			return &provider.ChatResponse{
+				Message: provider.Message{Role: provider.RoleAssistant, Content: "done"},
+			}, nil
+		},
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+
+	// Run multiple iterations to increase the chance of hitting the race.
+	for iter := range 50 {
+		pool := newTestPool(t, 2, mp)
+
+		var wg sync.WaitGroup
+
+		// Goroutines that submit tasks as fast as possible.
+		for g := range 4 {
+			wg.Add(1)
+			go func(g int) {
+				defer wg.Done()
+				for i := range 5 {
+					err := pool.Submit(Task{
+						Issue:     &forge.Issue{Number: iter*100 + g*10 + i, Title: "Race", Body: "body"},
+						AgentType: models.AgentTypeCodeGen,
+						SessionID: "sess-race",
+					})
+					if errors.Is(err, ErrPoolShutdown) {
+						return
+					}
+				}
+			}(g)
+		}
+
+		// Shut down concurrently — no delay, maximum race pressure.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pool.Shutdown()
+		}()
+
+		wg.Wait()
+		_ = iter // suppress unused warning
+	}
+	// If we get here without panicking, the fix works.
+}
+
 func TestPoolDefaultWorkers(t *testing.T) {
 	mp := &mockProvider{
 		healthyFn: func(_ context.Context) bool { return true },
@@ -336,6 +388,180 @@ func TestPoolDefaultWorkers(t *testing.T) {
 
 	if pool.workers != defaultWorkers {
 		t.Errorf("workers = %d, want %d", pool.workers, defaultWorkers)
+	}
+}
+
+func TestWorkers(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	pool := newTestPool(t, 3, mp)
+	defer pool.Shutdown()
+
+	if got := pool.Workers(); got != 3 {
+		t.Errorf("Workers() = %d, want 3", got)
+	}
+}
+
+func TestAddWorkers(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	pool := newTestPool(t, 2, mp)
+	defer pool.Shutdown()
+
+	if err := pool.AddWorkers(3); err != nil {
+		t.Fatalf("AddWorkers returned error: %v", err)
+	}
+	if got := pool.Workers(); got != 5 {
+		t.Errorf("Workers() = %d, want 5 after adding 3", got)
+	}
+}
+
+func TestAddWorkers_Noop(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	pool := newTestPool(t, 2, mp)
+	defer pool.Shutdown()
+
+	if err := pool.AddWorkers(0); err != nil {
+		t.Fatalf("AddWorkers(0) returned error: %v", err)
+	}
+	if err := pool.AddWorkers(-1); err != nil {
+		t.Fatalf("AddWorkers(-1) returned error: %v", err)
+	}
+	if got := pool.Workers(); got != 2 {
+		t.Errorf("Workers() = %d, want 2 after noop adds", got)
+	}
+}
+
+func TestAddWorkers_AfterShutdown(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	pool := newTestPool(t, 1, mp)
+	pool.Shutdown()
+
+	if err := pool.AddWorkers(2); !errors.Is(err, ErrPoolShutdown) {
+		t.Errorf("AddWorkers after Shutdown: got %v, want ErrPoolShutdown", err)
+	}
+}
+
+func TestAddWorkers_NewWorkersProcessTasks(t *testing.T) {
+	var processed atomic.Int32
+	// Gate blocks all workers until we explicitly release them.
+	ready := make(chan struct{})
+	mp := &mockProvider{
+		chatFn: func(_ context.Context, _ provider.ChatRequest) (*provider.ChatResponse, error) {
+			<-ready
+			processed.Add(1)
+			return &provider.ChatResponse{
+				Message: provider.Message{Role: provider.RoleAssistant, Content: "ok"},
+			}, nil
+		},
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+
+	// Start with 1 worker, then scale up to handle 3 concurrent tasks.
+	pool := newTestPool(t, 1, mp)
+
+	for i := range 3 {
+		if err := pool.Submit(Task{
+			Issue:     &forge.Issue{Number: i + 1, Title: "t", Body: "b"},
+			AgentType: models.AgentTypeCodeGen,
+			SessionID: "sess-" + string(rune('a'+i)),
+		}); err != nil {
+			t.Fatalf("Submit %d: %v", i, err)
+		}
+	}
+
+	if err := pool.AddWorkers(2); err != nil {
+		t.Fatalf("AddWorkers: %v", err)
+	}
+
+	// Release all workers and wait for all tasks to complete.
+	close(ready)
+	pool.Shutdown()
+
+	if got := processed.Load(); got != 3 {
+		t.Errorf("processed = %d, want 3", got)
+	}
+}
+
+func TestRemoveWorkers_ReducesCount(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	pool := newTestPool(t, 4, mp)
+	defer pool.Shutdown()
+
+	removed := pool.RemoveWorkers(2)
+	if removed != 2 {
+		t.Errorf("RemoveWorkers(2) = %d, want 2", removed)
+	}
+	if got := pool.Workers(); got != 2 {
+		t.Errorf("Workers() = %d, want 2 after removing 2", got)
+	}
+}
+
+func TestRemoveWorkers_MinimumOne(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	pool := newTestPool(t, 1, mp)
+	defer pool.Shutdown()
+
+	removed := pool.RemoveWorkers(5)
+	if removed != 0 {
+		t.Errorf("RemoveWorkers(5) on single-worker pool = %d, want 0", removed)
+	}
+	if got := pool.Workers(); got != 1 {
+		t.Errorf("Workers() = %d, want 1 (minimum preserved)", got)
+	}
+}
+
+func TestRemoveWorkers_Noop(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	pool := newTestPool(t, 3, mp)
+	defer pool.Shutdown()
+
+	if removed := pool.RemoveWorkers(0); removed != 0 {
+		t.Errorf("RemoveWorkers(0) = %d, want 0", removed)
+	}
+	if removed := pool.RemoveWorkers(-1); removed != 0 {
+		t.Errorf("RemoveWorkers(-1) = %d, want 0", removed)
+	}
+	if got := pool.Workers(); got != 3 {
+		t.Errorf("Workers() = %d, want 3 after noop removes", got)
+	}
+}
+
+func TestRemoveWorkers_ClampsToMinimum(t *testing.T) {
+	mp := &mockProvider{
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test" },
+	}
+	// 3 workers; remove 10 — only 2 can be removed (minimum 1 preserved).
+	pool := newTestPool(t, 3, mp)
+	defer pool.Shutdown()
+
+	removed := pool.RemoveWorkers(10)
+	if removed != 2 {
+		t.Errorf("RemoveWorkers(10) on 3-worker pool = %d, want 2", removed)
+	}
+	if got := pool.Workers(); got != 1 {
+		t.Errorf("Workers() = %d, want 1 after clamped remove", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `AddWorkers(n int) error` and `RemoveWorkers(n int) int` to scale the pool at runtime without restarting
- Adds `Workers() int` to query current target worker count
- Workers exit gracefully after completing their current task via a buffered `workerQuit` channel
- `RemoveWorkers` preserves minimum one worker to maintain liveness
- Fixes latent deadlock in `processTask`: `onComplete` callback was read under `p.mu`, which deadlocked when `Submit` held `p.mu` during a blocking channel send. Fixed by storing `onComplete` in `sync/atomic.Pointer`, removing the lock from the read path entirely

## Test plan

- [x] `TestWorkers` — initial count returned correctly
- [x] `TestAddWorkers` — worker count increases; new workers process tasks
- [x] `TestAddWorkers_Noop` — n ≤ 0 is a no-op
- [x] `TestAddWorkers_AfterShutdown` — returns `ErrPoolShutdown`
- [x] `TestAddWorkers_NewWorkersProcessTasks` — scaled workers drain queued tasks via Shutdown
- [x] `TestRemoveWorkers_ReducesCount` — count decreases by requested amount
- [x] `TestRemoveWorkers_MinimumOne` — single-worker pool: removes 0, count stays 1
- [x] `TestRemoveWorkers_Noop` — n ≤ 0 returns 0, count unchanged
- [x] `TestRemoveWorkers_ClampsToMinimum` — excess removes clamped to keep 1 worker
- [x] `TestPool_ConcurrentSubmitAndShutdown` — deadlock now fixed, races cleanly

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)