### PR TITLE
feat(#293): scaling policy engine with configurable thresholds

### DIFF
--- a/internal/scaling/policy.go
+++ b/internal/scaling/policy.go
@@ -1,0 +1,264 @@
+// Package scaling provides the policy engine for adaptive worker scaling.
+// The policy evaluates system and pool metrics and produces scaling decisions;
+// it does not execute them. Separation keeps the logic testable in isolation.
+package scaling
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/herbhall/samverk/internal/metrics"
+)
+
+// Action represents a scaling decision type.
+type Action int
+
+const (
+	// Hold means no change to worker count.
+	Hold Action = iota
+	// ScaleUp means add workers.
+	ScaleUp
+	// ScaleDown means remove workers.
+	ScaleDown
+)
+
+// String returns a human-readable name for the action.
+func (a Action) String() string {
+	switch a {
+	case Hold:
+		return "hold"
+	case ScaleUp:
+		return "scale-up"
+	case ScaleDown:
+		return "scale-down"
+	default:
+		return "unknown"
+	}
+}
+
+// Decision is the output of a policy evaluation.
+type Decision struct {
+	// Action is the recommended scaling action.
+	Action Action
+	// Delta is the number of workers to add (ScaleUp) or remove (ScaleDown).
+	// Zero for Hold decisions.
+	Delta int
+	// Reason is a human-readable explanation suitable for logs and the dashboard.
+	Reason string
+	// Confidence is a 0–1 score reflecting how many signals agree.
+	// Higher means more signals agree; lower means ambiguous.
+	Confidence float64
+}
+
+// Policy evaluates metrics and returns a scaling Decision.
+type Policy interface {
+	Evaluate(pool metrics.PoolSnapshot, sys metrics.SystemSnapshot) Decision
+}
+
+// ScaleUpConfig holds scale-up thresholds.
+type ScaleUpConfig struct {
+	// MemoryThreshold is the maximum memory-usage percentage (heap/sys*100) below
+	// which scale-up is permitted. Protects against scaling under memory pressure.
+	MemoryThreshold int `yaml:"memory_threshold"`
+	// QueueDepthTrigger is the minimum queue depth that triggers a scale-up check.
+	QueueDepthTrigger int `yaml:"queue_depth_trigger"`
+	// AllWorkersBusy, when true, requires all workers to be active before scaling up.
+	AllWorkersBusy bool `yaml:"all_workers_busy"`
+}
+
+// ScaleDownConfig holds scale-down thresholds.
+type ScaleDownConfig struct {
+	// IdleWorkerThreshold is the minimum number of idle workers required to consider
+	// scaling down.
+	IdleWorkerThreshold int `yaml:"idle_worker_threshold"`
+	// IdleDuration is how long idle workers must exceed IdleWorkerThreshold before
+	// scale-down is triggered. Prevents premature scale-down during brief lulls.
+	IdleDuration time.Duration `yaml:"idle_duration"`
+}
+
+// PolicyConfig holds all configurable thresholds for ThresholdPolicy.
+type PolicyConfig struct {
+	// Enabled controls whether the policy produces non-Hold decisions.
+	// When false, Evaluate always returns Hold.
+	Enabled bool `yaml:"enabled"`
+	// MinWorkers is the minimum worker count the policy will recommend.
+	MinWorkers int `yaml:"min_workers"`
+	// MaxWorkers is the maximum worker count the policy will recommend.
+	MaxWorkers int `yaml:"max_workers"`
+	// EvaluationInterval is a hint for the autoscaler loop; not enforced here.
+	EvaluationInterval time.Duration `yaml:"evaluation_interval"`
+	// CooldownAfterScale is the minimum time between consecutive scale events.
+	// Prevents oscillation.
+	CooldownAfterScale time.Duration `yaml:"cooldown_after_scale"`
+	// ScaleUp holds the scale-up thresholds.
+	ScaleUp ScaleUpConfig `yaml:"scale_up"`
+	// ScaleDown holds the scale-down thresholds.
+	ScaleDown ScaleDownConfig `yaml:"scale_down"`
+}
+
+// DefaultPolicyConfig returns a conservative default configuration.
+func DefaultPolicyConfig() PolicyConfig {
+	return PolicyConfig{
+		Enabled:            true,
+		MinWorkers:         1,
+		MaxWorkers:         8,
+		EvaluationInterval: 30 * time.Second,
+		CooldownAfterScale: 2 * time.Minute,
+		ScaleUp: ScaleUpConfig{
+			MemoryThreshold:   80,
+			QueueDepthTrigger: 2,
+			AllWorkersBusy:    true,
+		},
+		ScaleDown: ScaleDownConfig{
+			IdleWorkerThreshold: 2,
+			IdleDuration:        2 * time.Minute,
+		},
+	}
+}
+
+// ThresholdPolicy is a Policy implementation driven by configurable thresholds.
+// It is safe for concurrent use.
+type ThresholdPolicy struct {
+	config       PolicyConfig
+	mu           sync.Mutex
+	lastScale    time.Time // time of the most recent scale event
+	idleStart    time.Time // when idle-worker count first exceeded the threshold
+	hasIdleStart bool      // true if idleStart is valid
+}
+
+// NewThresholdPolicy creates a ThresholdPolicy with the given configuration.
+// Invalid values are silently clamped to safe defaults (min/max bounds).
+func NewThresholdPolicy(cfg PolicyConfig) *ThresholdPolicy {
+	if cfg.MinWorkers <= 0 {
+		cfg.MinWorkers = 1
+	}
+	if cfg.MaxWorkers <= 0 {
+		cfg.MaxWorkers = 8
+	}
+	if cfg.MinWorkers > cfg.MaxWorkers {
+		cfg.MaxWorkers = cfg.MinWorkers
+	}
+	return &ThresholdPolicy{config: cfg}
+}
+
+// NotifyScaled records the time of a scale event for cooldown tracking.
+// The autoscaler calls this after it applies a decision.
+func (p *ThresholdPolicy) NotifyScaled() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastScale = time.Now()
+}
+
+// Evaluate returns the recommended scaling decision given current metrics.
+// It considers queue depth, worker utilisation, memory pressure, idle duration,
+// and the cooldown period.
+func (p *ThresholdPolicy) Evaluate(pool metrics.PoolSnapshot, sys metrics.SystemSnapshot) Decision {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.config.Enabled {
+		return Decision{Action: Hold, Reason: "scaling disabled", Confidence: 1.0}
+	}
+
+	now := pool.CollectedAt
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	// Cooldown: do nothing if we scaled recently.
+	if !p.lastScale.IsZero() && now.Sub(p.lastScale) < p.config.CooldownAfterScale {
+		remaining := p.config.CooldownAfterScale - now.Sub(p.lastScale)
+		return Decision{
+			Action:     Hold,
+			Reason:     fmt.Sprintf("cooldown active, %s remaining", remaining.Truncate(time.Second)),
+			Confidence: 1.0,
+		}
+	}
+
+	memPct := memoryPct(sys)
+	currentWorkers := pool.TotalWorkers
+
+	// --- Scale-up evaluation ---
+	if currentWorkers < p.config.MaxWorkers {
+		upSignals := 0
+		totalUpSignals := 3
+
+		queueTriggered := pool.QueueDepth >= p.config.ScaleUp.QueueDepthTrigger
+		if queueTriggered {
+			upSignals++
+		}
+		allBusy := pool.IdleWorkers == 0
+		if !p.config.ScaleUp.AllWorkersBusy || allBusy {
+			upSignals++
+		}
+		memOK := memPct < float64(p.config.ScaleUp.MemoryThreshold)
+		if memOK {
+			upSignals++
+		}
+
+		if queueTriggered && memOK && (!p.config.ScaleUp.AllWorkersBusy || allBusy) {
+			// Reset idle tracking since we're scaling up.
+			p.hasIdleStart = false
+			confidence := float64(upSignals) / float64(totalUpSignals)
+			return Decision{
+				Action:     ScaleUp,
+				Delta:      1,
+				Reason:     fmt.Sprintf("queue depth %d >= %d, all-busy=%v, memory %.0f%% < %d%%", pool.QueueDepth, p.config.ScaleUp.QueueDepthTrigger, allBusy, memPct, p.config.ScaleUp.MemoryThreshold),
+				Confidence: confidence,
+			}
+		}
+	}
+
+	// --- Scale-down evaluation ---
+	if currentWorkers > p.config.MinWorkers {
+		idleAboveThreshold := pool.IdleWorkers >= p.config.ScaleDown.IdleWorkerThreshold
+		if idleAboveThreshold {
+			if !p.hasIdleStart {
+				p.idleStart = now
+				p.hasIdleStart = true
+			}
+			idleFor := now.Sub(p.idleStart)
+			if idleFor >= p.config.ScaleDown.IdleDuration {
+				p.hasIdleStart = false // reset for next cycle
+				signals := 2          // idle count + duration met
+				if pool.QueueDepth == 0 {
+					signals++
+				}
+				confidence := float64(signals) / 3.0
+				return Decision{
+					Action:     ScaleDown,
+					Delta:      1,
+					Reason:     fmt.Sprintf("%d idle workers (>= %d) for %s (>= %s), queue=%d", pool.IdleWorkers, p.config.ScaleDown.IdleWorkerThreshold, idleFor.Truncate(time.Second), p.config.ScaleDown.IdleDuration, pool.QueueDepth),
+					Confidence: confidence,
+				}
+			}
+			// Idle threshold met but not for long enough yet.
+			remaining := p.config.ScaleDown.IdleDuration - idleFor
+			return Decision{
+				Action:     Hold,
+				Reason:     fmt.Sprintf("%d idle workers, waiting %s more before scale-down", pool.IdleWorkers, remaining.Truncate(time.Second)),
+				Confidence: 0.5,
+			}
+		}
+	}
+
+	// Reset idle tracking since we're below the threshold.
+	p.hasIdleStart = false
+
+	return Decision{
+		Action:     Hold,
+		Reason:     "conditions stable",
+		Confidence: 0.8,
+	}
+}
+
+// memoryPct computes heap allocation as a percentage of total system memory
+// obtained by the Go runtime. This is a conservative proxy for memory pressure:
+// a high ratio indicates GC is working hard and adding more workers may worsen it.
+func memoryPct(sys metrics.SystemSnapshot) float64 {
+	if sys.SysBytesTotal == 0 {
+		return 0
+	}
+	return float64(sys.HeapAllocBytes) / float64(sys.SysBytesTotal) * 100
+}

--- a/internal/scaling/policy_test.go
+++ b/internal/scaling/policy_test.go
@@ -1,0 +1,338 @@
+package scaling
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/herbhall/samverk/internal/metrics"
+)
+
+// makePool builds a PoolSnapshot for testing.
+func makePool(total, active, idle, queue int) metrics.PoolSnapshot {
+	return metrics.PoolSnapshot{
+		CollectedAt:   time.Now(),
+		TotalWorkers:  total,
+		ActiveWorkers: active,
+		IdleWorkers:   idle,
+		QueueDepth:    queue,
+	}
+}
+
+// makePoolAt builds a PoolSnapshot with an explicit collection time.
+func makePoolAt(t time.Time, total, active, idle, queue int) metrics.PoolSnapshot {
+	return metrics.PoolSnapshot{
+		CollectedAt:   t,
+		TotalWorkers:  total,
+		ActiveWorkers: active,
+		IdleWorkers:   idle,
+		QueueDepth:    queue,
+	}
+}
+
+// makeSys builds a SystemSnapshot with a given heap/sys memory ratio.
+// heapPct is the desired heap-to-sys percentage (0–100).
+func makeSys(heapPct float64) metrics.SystemSnapshot {
+	const sysBytesTotal = 1_000_000_000 // 1 GB
+	heap := uint64(heapPct / 100 * sysBytesTotal)
+	return metrics.SystemSnapshot{
+		CollectedAt:    time.Now(),
+		HeapAllocBytes: heap,
+		SysBytesTotal:  sysBytesTotal,
+	}
+}
+
+// defaultPolicy creates a ThresholdPolicy with DefaultPolicyConfig values
+// tweaked for fast tests (no real-time waiting).
+func defaultPolicy() *ThresholdPolicy {
+	cfg := DefaultPolicyConfig()
+	cfg.CooldownAfterScale = 5 * time.Minute // keep cooldown out of the way
+	cfg.ScaleDown.IdleDuration = 2 * time.Minute
+	return NewThresholdPolicy(cfg)
+}
+
+// --- Disabled policy ---
+
+func TestThresholdPolicy_Disabled(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.Enabled = false
+	p := NewThresholdPolicy(cfg)
+
+	d := p.Evaluate(makePool(2, 2, 0, 5), makeSys(20))
+	if d.Action != Hold {
+		t.Errorf("disabled: got action %s, want Hold", d.Action)
+	}
+	if !strings.Contains(d.Reason, "disabled") {
+		t.Errorf("disabled reason %q should mention 'disabled'", d.Reason)
+	}
+	if d.Confidence != 1.0 {
+		t.Errorf("disabled: confidence = %.2f, want 1.0", d.Confidence)
+	}
+}
+
+// --- Scale-up cases ---
+
+func TestThresholdPolicy_ScaleUp_QueueAndAllBusy(t *testing.T) {
+	p := defaultPolicy()
+	// 2 workers, all busy, queue depth 3 (>= 2), memory 20% (< 80%).
+	d := p.Evaluate(makePool(2, 2, 0, 3), makeSys(20))
+	if d.Action != ScaleUp {
+		t.Errorf("got action %s, want ScaleUp; reason: %s", d.Action, d.Reason)
+	}
+	if d.Delta != 1 {
+		t.Errorf("delta = %d, want 1", d.Delta)
+	}
+	if d.Confidence <= 0 || d.Confidence > 1 {
+		t.Errorf("confidence = %.2f, want (0,1]", d.Confidence)
+	}
+}
+
+func TestThresholdPolicy_NoScaleUp_QueueBelowTrigger(t *testing.T) {
+	p := defaultPolicy()
+	// Queue depth 1 (< trigger 2) — should not scale up.
+	d := p.Evaluate(makePool(2, 2, 0, 1), makeSys(20))
+	if d.Action == ScaleUp {
+		t.Errorf("queue 1 < trigger 2: got ScaleUp, want Hold; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_NoScaleUp_MemoryPressure(t *testing.T) {
+	p := defaultPolicy()
+	// Memory 85% (> threshold 80%), queue full — memory pressure should block scale-up.
+	d := p.Evaluate(makePool(2, 2, 0, 5), makeSys(85))
+	if d.Action == ScaleUp {
+		t.Errorf("high memory: got ScaleUp, want Hold; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_NoScaleUp_AlreadyAtMax(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.MaxWorkers = 3
+	p := NewThresholdPolicy(cfg)
+	// At max workers — should not scale up.
+	d := p.Evaluate(makePool(3, 3, 0, 10), makeSys(10))
+	if d.Action == ScaleUp {
+		t.Errorf("at max workers: got ScaleUp, want Hold; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_NoScaleUp_NotAllWorkersBusy(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.ScaleUp.AllWorkersBusy = true
+	p := NewThresholdPolicy(cfg)
+	// Queue has work but 1 worker is idle — all_workers_busy blocks scale-up.
+	d := p.Evaluate(makePool(3, 2, 1, 5), makeSys(10))
+	if d.Action == ScaleUp {
+		t.Errorf("idle worker present: got ScaleUp, want Hold; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_ScaleUp_AllWorkersBusy_Disabled(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.ScaleUp.AllWorkersBusy = false
+	p := NewThresholdPolicy(cfg)
+	// Queue has work, 1 worker idle, but AllWorkersBusy=false so still scale up.
+	d := p.Evaluate(makePool(3, 2, 1, 5), makeSys(10))
+	if d.Action != ScaleUp {
+		t.Errorf("AllWorkersBusy=false: got %s, want ScaleUp; reason: %s", d.Action, d.Reason)
+	}
+}
+
+// --- Scale-down cases ---
+
+func TestThresholdPolicy_ScaleDown_SustainedIdle(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.ScaleDown.IdleWorkerThreshold = 2
+	cfg.ScaleDown.IdleDuration = 10 * time.Second
+	cfg.CooldownAfterScale = 0
+	p := NewThresholdPolicy(cfg)
+
+	base := time.Now()
+
+	// First eval: idle count meets threshold, start the clock.
+	p.Evaluate(makePoolAt(base, 4, 1, 3, 0), makeSys(10))
+
+	// Second eval: 15s later — idle duration exceeded.
+	d := p.Evaluate(makePoolAt(base.Add(15*time.Second), 4, 1, 3, 0), makeSys(10))
+	if d.Action != ScaleDown {
+		t.Errorf("sustained idle: got %s, want ScaleDown; reason: %s", d.Action, d.Reason)
+	}
+	if d.Delta != 1 {
+		t.Errorf("delta = %d, want 1", d.Delta)
+	}
+}
+
+func TestThresholdPolicy_NoScaleDown_IdleDurationNotMet(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.ScaleDown.IdleWorkerThreshold = 2
+	cfg.ScaleDown.IdleDuration = 60 * time.Second
+	cfg.CooldownAfterScale = 0
+	p := NewThresholdPolicy(cfg)
+
+	base := time.Now()
+	p.Evaluate(makePoolAt(base, 4, 1, 3, 0), makeSys(10))
+	// Only 5s elapsed — not enough.
+	d := p.Evaluate(makePoolAt(base.Add(5*time.Second), 4, 1, 3, 0), makeSys(10))
+	if d.Action == ScaleDown {
+		t.Errorf("idle 5s < 60s: got ScaleDown, want Hold; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_NoScaleDown_BelowIdleThreshold(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.ScaleDown.IdleWorkerThreshold = 3
+	cfg.CooldownAfterScale = 0
+	p := NewThresholdPolicy(cfg)
+	// Only 2 idle workers (< threshold 3).
+	d := p.Evaluate(makePool(4, 2, 2, 0), makeSys(10))
+	if d.Action == ScaleDown {
+		t.Errorf("2 idle < threshold 3: got ScaleDown, want Hold; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_NoScaleDown_AtMinWorkers(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.MinWorkers = 2
+	cfg.ScaleDown.IdleWorkerThreshold = 1
+	cfg.ScaleDown.IdleDuration = 0
+	cfg.CooldownAfterScale = 0
+	p := NewThresholdPolicy(cfg)
+	// At min workers — cannot scale down.
+	d := p.Evaluate(makePool(2, 0, 2, 0), makeSys(10))
+	if d.Action == ScaleDown {
+		t.Errorf("at min workers: got ScaleDown, want Hold; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_ScaleDown_IdleResetOnBusyPeriod(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.ScaleDown.IdleWorkerThreshold = 2
+	cfg.ScaleDown.IdleDuration = 30 * time.Second
+	cfg.CooldownAfterScale = 0
+	p := NewThresholdPolicy(cfg)
+
+	base := time.Now()
+	// Start idle tracking.
+	p.Evaluate(makePoolAt(base, 4, 1, 3, 0), makeSys(10))
+	// Work arrives — workers become busy, idle drops below threshold.
+	p.Evaluate(makePoolAt(base.Add(10*time.Second), 4, 4, 0, 5), makeSys(10))
+	// Idle again — but clock should have reset.
+	p.Evaluate(makePoolAt(base.Add(20*time.Second), 4, 1, 3, 0), makeSys(10))
+	// 15s from the reset — not enough yet.
+	d := p.Evaluate(makePoolAt(base.Add(35*time.Second), 4, 1, 3, 0), makeSys(10))
+	if d.Action == ScaleDown {
+		t.Errorf("idle clock should have reset: got ScaleDown; reason: %s", d.Reason)
+	}
+}
+
+// --- Cooldown ---
+
+func TestThresholdPolicy_Cooldown(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.CooldownAfterScale = 5 * time.Minute
+	p := NewThresholdPolicy(cfg)
+	p.NotifyScaled()
+
+	// Scale-up conditions are met but we're in cooldown.
+	d := p.Evaluate(makePool(2, 2, 0, 5), makeSys(10))
+	if d.Action != Hold {
+		t.Errorf("cooldown: got %s, want Hold; reason: %s", d.Action, d.Reason)
+	}
+	if !strings.Contains(d.Reason, "cooldown") {
+		t.Errorf("cooldown reason %q should mention 'cooldown'", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_CooldownExpires(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.CooldownAfterScale = 10 * time.Millisecond
+	p := NewThresholdPolicy(cfg)
+	p.NotifyScaled()
+	time.Sleep(20 * time.Millisecond)
+
+	// Cooldown should have expired — scale-up conditions met.
+	d := p.Evaluate(makePool(2, 2, 0, 5), makeSys(10))
+	if d.Action != ScaleUp {
+		t.Errorf("cooldown expired: got %s, want ScaleUp; reason: %s", d.Action, d.Reason)
+	}
+}
+
+// --- Hold cases ---
+
+func TestThresholdPolicy_Hold_QueueEmptyAllIdle(t *testing.T) {
+	p := defaultPolicy()
+	// No queue, no busy workers — nothing to do.
+	d := p.Evaluate(makePool(3, 0, 3, 0), makeSys(10))
+	if d.Action == ScaleUp {
+		t.Errorf("empty queue + all idle: got ScaleUp; reason: %s", d.Reason)
+	}
+}
+
+func TestThresholdPolicy_Hold_Stable(t *testing.T) {
+	p := defaultPolicy()
+	// Some active workers, small queue, reasonable memory — no action.
+	d := p.Evaluate(makePool(3, 2, 1, 1), makeSys(30))
+	if d.Action != Hold {
+		t.Errorf("stable: got %s, want Hold; reason: %s", d.Action, d.Reason)
+	}
+	if d.Reason == "" {
+		t.Error("reason should not be empty")
+	}
+}
+
+// --- Config validation ---
+
+func TestNewThresholdPolicy_ClampsInvalidConfig(t *testing.T) {
+	cfg := PolicyConfig{MinWorkers: -1, MaxWorkers: 0}
+	p := NewThresholdPolicy(cfg)
+	if p.config.MinWorkers != 1 {
+		t.Errorf("MinWorkers = %d, want 1", p.config.MinWorkers)
+	}
+	if p.config.MaxWorkers != 8 {
+		t.Errorf("MaxWorkers = %d, want 8", p.config.MaxWorkers)
+	}
+}
+
+func TestNewThresholdPolicy_ClampsMinGtMax(t *testing.T) {
+	cfg := PolicyConfig{MinWorkers: 5, MaxWorkers: 2}
+	p := NewThresholdPolicy(cfg)
+	if p.config.MaxWorkers < p.config.MinWorkers {
+		t.Errorf("MaxWorkers %d < MinWorkers %d after clamp", p.config.MaxWorkers, p.config.MinWorkers)
+	}
+}
+
+// --- Memory pressure ---
+
+func TestThresholdPolicy_MemoryPct_ZeroSys(t *testing.T) {
+	sys := metrics.SystemSnapshot{HeapAllocBytes: 1000, SysBytesTotal: 0}
+	if got := memoryPct(sys); got != 0 {
+		t.Errorf("memoryPct with zero SysBytes = %.2f, want 0", got)
+	}
+}
+
+func TestThresholdPolicy_NoScaleUp_ExactMemoryAtThreshold(t *testing.T) {
+	cfg := DefaultPolicyConfig()
+	cfg.ScaleUp.MemoryThreshold = 80
+	p := NewThresholdPolicy(cfg)
+	// Memory exactly at threshold (80%) — scale-up forbidden (< not <=).
+	d := p.Evaluate(makePool(2, 2, 0, 5), makeSys(80))
+	if d.Action == ScaleUp {
+		t.Errorf("memory exactly at threshold: got ScaleUp, want Hold; reason: %s", d.Reason)
+	}
+}
+
+// --- Action.String ---
+
+func TestAction_String(t *testing.T) {
+	tests := []struct{ a Action; want string }{
+		{Hold, "hold"},
+		{ScaleUp, "scale-up"},
+		{ScaleDown, "scale-down"},
+		{Action(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.a.String(); got != tt.want {
+			t.Errorf("Action(%d).String() = %q, want %q", tt.a, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/scaling` package with `ThresholdPolicy` implementing the `Policy` interface
- `Policy.Evaluate(pool, sys)` returns `Decision{Action, Delta, Reason, Confidence}`
- Scale-up when: queue depth >= trigger AND all workers busy (configurable) AND memory below ceiling
- Scale-down when: idle workers >= threshold for a sustained idle duration
- Hold when: cooldown active, conditions ambiguous, or stable
- Cooldown prevents oscillation — caller calls `NotifyScaled()` after applying a decision
- Memory pressure uses heap/sys ratio as a proxy (CPU not available from Go runtime)
- `DefaultPolicyConfig()`: max 8 workers, 2m cooldown, queue trigger 2, idle threshold 2 workers for 2m
- All thresholds configurable via YAML

## Test plan

- [x] `TestThresholdPolicy_Disabled` — disabled policy always holds
- [x] `TestThresholdPolicy_ScaleUp_QueueAndAllBusy` — scales up when queue + all busy + low memory
- [x] `TestThresholdPolicy_NoScaleUp_QueueBelowTrigger` — queue below trigger → hold
- [x] `TestThresholdPolicy_NoScaleUp_MemoryPressure` — memory above ceiling → hold
- [x] `TestThresholdPolicy_NoScaleUp_AlreadyAtMax` — at max workers → hold
- [x] `TestThresholdPolicy_NoScaleUp_NotAllWorkersBusy` — idle worker present with AllWorkersBusy=true → hold
- [x] `TestThresholdPolicy_ScaleUp_AllWorkersBusy_Disabled` — AllWorkersBusy=false → scales up even with idle
- [x] `TestThresholdPolicy_ScaleDown_SustainedIdle` — idle duration met → scale down
- [x] `TestThresholdPolicy_NoScaleDown_IdleDurationNotMet` — idle too brief → hold
- [x] `TestThresholdPolicy_NoScaleDown_BelowIdleThreshold` — not enough idle workers → hold
- [x] `TestThresholdPolicy_NoScaleDown_AtMinWorkers` — at min workers → hold
- [x] `TestThresholdPolicy_ScaleDown_IdleResetOnBusyPeriod` — idle clock resets on busy period
- [x] `TestThresholdPolicy_Cooldown` — in cooldown → hold with reason
- [x] `TestThresholdPolicy_CooldownExpires` — cooldown expired → scale up
- [x] `TestThresholdPolicy_Hold_QueueEmptyAllIdle` — no queue, all idle → hold
- [x] `TestThresholdPolicy_Hold_Stable` — balanced load → hold
- [x] Config validation and clamping tests
- [x] `memoryPct` edge case (zero sys bytes)
- [x] `Action.String()` enumeration

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)