### PR TITLE
feat(#300,#301): samverk scale CLI, REST API, and MCP scaling tools

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -43,6 +46,7 @@ func main() {
 
 	root.AddCommand(serveCmd())
 	root.AddCommand(dispatchCmd())
+	root.AddCommand(scaleCmd())
 	root.AddCommand(digestCmd())
 	root.AddCommand(keyCmd())
 	root.AddCommand(versionCmd())
@@ -303,6 +307,7 @@ func dispatchCmd() *cobra.Command {
 				autoscaler := scaling.NewAutoscaler(scalingPol, pool, metrics.NewSystemCollector())
 				if st != nil {
 					autoscaler.SetPersister(st)
+				autoscaler.SetControlReader(st)
 				}
 				g.Go(func() error {
 					err := autoscaler.Run(gctx)
@@ -345,6 +350,142 @@ func dispatchCmd() *cobra.Command {
 	cmd.Flags().IntVar(&scalingMax, "scaling-max", 0, "Override max workers from scaling config (0 = use config value)")
 
 	return cmd
+}
+
+func scaleCmd() *cobra.Command {
+	var serverURL, token string
+
+	cmd := &cobra.Command{
+		Use:   "scale",
+		Short: "Inspect and control adaptive worker scaling",
+		Long:  "Commands for viewing scaling state and issuing manual override commands to a running samverk serve process.",
+	}
+
+	// Shared flags on the parent.
+	cmd.PersistentFlags().StringVar(&serverURL, "server", "http://localhost:8080", "URL of the samverk serve process")
+	cmd.PersistentFlags().StringVar(&token, "token", "", "Bearer token for API authentication (or set SAMVERK_AUTH_TOKEN)")
+
+	// Helper: perform an authenticated HTTP request.
+	doScaleRequest := func(method, path string, body []byte) ([]byte, int, error) {
+		t := token
+		if t == "" {
+			t = os.Getenv("SAMVERK_AUTH_TOKEN")
+		}
+		return doHTTPRequest(method, serverURL+path, t, body)
+	}
+
+	// samverk scale status
+	cmd.AddCommand(&cobra.Command{
+		Use:   "status",
+		Short: "Show current scaling control state",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			data, _, err := doScaleRequest("GET", "/api/v1/scaling/control", nil)
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	})
+
+	// samverk scale pause
+	cmd.AddCommand(&cobra.Command{
+		Use:   "pause",
+		Short: "Pause the autoscaler (keep current worker count)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			data, _, err := doScaleRequest("POST", "/api/v1/scaling/pause", nil)
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	})
+
+	// samverk scale resume
+	cmd.AddCommand(&cobra.Command{
+		Use:   "resume",
+		Short: "Resume autonomous autoscaling",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			data, _, err := doScaleRequest("POST", "/api/v1/scaling/resume", nil)
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	})
+
+	// samverk scale set N
+	setCmd := &cobra.Command{
+		Use:   "set <workers>",
+		Short: "Force worker count to N and pause the autoscaler",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			n := 0
+			if _, err := fmt.Sscanf(args[0], "%d", &n); err != nil || n < 1 {
+				return fmt.Errorf("workers must be a positive integer, got %q", args[0])
+			}
+			body := []byte(fmt.Sprintf(`{"workers":%d}`, n))
+			data, _, err := doScaleRequest("POST", "/api/v1/scaling/set", body)
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	}
+	cmd.AddCommand(setCmd)
+
+	// samverk scale history
+	cmd.AddCommand(&cobra.Command{
+		Use:   "history",
+		Short: "Show recent scaling events",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			data, _, err := doScaleRequest("GET", "/api/v1/metrics", nil)
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	})
+
+	return cmd
+}
+
+// doHTTPRequest performs an HTTP request and returns the response body and status code.
+func doHTTPRequest(method, url, bearerToken string, body []byte) (data []byte, statusCode int, err error) {
+	var req *http.Request
+	if len(body) > 0 {
+		req, err = http.NewRequestWithContext(context.Background(), method, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, 0, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, err = http.NewRequestWithContext(context.Background(), method, url, http.NoBody)
+		if err != nil {
+			return nil, 0, fmt.Errorf("build request: %w", err)
+		}
+	}
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G107: URL comes from --server flag, not user input
+	if err != nil {
+		return nil, 0, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return data, resp.StatusCode, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(data))
+	}
+	return data, resp.StatusCode, nil
 }
 
 func digestCmd() *cobra.Command {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -75,6 +75,10 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/costs", a.handleGetCosts)
 	mux.HandleFunc("GET /api/v1/status", a.handleStatus)
 	mux.HandleFunc("GET /api/v1/metrics", a.handleMetrics)
+	mux.HandleFunc("GET /api/v1/scaling/control", a.handleGetScalingControl)
+	mux.HandleFunc("POST /api/v1/scaling/pause", a.handleScalingPause)
+	mux.HandleFunc("POST /api/v1/scaling/resume", a.handleScalingResume)
+	mux.HandleFunc("POST /api/v1/scaling/set", a.handleScalingSet)
 }
 
 // errorResponse is the JSON body returned for error responses.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -138,6 +138,14 @@ func (m *mockStore) ListScalingEvents(_ context.Context, _ int) ([]*models.Scali
 	return nil, nil
 }
 
+func (m *mockStore) GetScalingControl(_ context.Context) (*models.ScalingControl, error) {
+	return &models.ScalingControl{}, nil
+}
+
+func (m *mockStore) UpsertScalingControl(_ context.Context, _ models.ScalingControl) error {
+	return nil
+}
+
 func (m *mockStore) Close() error { return nil }
 
 // Compile-time check: mockStore implements store.Store.

--- a/internal/api/scaling.go
+++ b/internal/api/scaling.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// scalingControlDTO is the JSON-serializable form of models.ScalingControl.
+type scalingControlDTO struct {
+	Paused        bool   `json:"paused"`
+	ManualWorkers int    `json:"manual_workers"`
+	SetAt         string `json:"set_at,omitempty"`
+	Note          string `json:"note,omitempty"`
+}
+
+// scalingSetRequest is the body for POST /api/v1/scaling/set.
+type scalingSetRequest struct {
+	Workers int    `json:"workers"`
+	Note    string `json:"note,omitempty"`
+}
+
+// handleGetScalingControl handles GET /api/v1/scaling/control.
+func (a *API) handleGetScalingControl(w http.ResponseWriter, r *http.Request) {
+	if a.store == nil {
+		writeError(w, http.StatusServiceUnavailable, "database not available")
+		return
+	}
+	ctrl, err := a.store.GetScalingControl(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to read scaling control")
+		return
+	}
+	dto := scalingControlDTO{
+		Paused:        ctrl.Paused,
+		ManualWorkers: ctrl.ManualWorkers,
+		Note:          ctrl.Note,
+	}
+	if !ctrl.SetAt.IsZero() {
+		dto.SetAt = ctrl.SetAt.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, dto)
+}
+
+// handleScalingPause handles POST /api/v1/scaling/pause.
+func (a *API) handleScalingPause(w http.ResponseWriter, r *http.Request) {
+	if a.store == nil {
+		writeError(w, http.StatusServiceUnavailable, "database not available")
+		return
+	}
+	ctrl := models.ScalingControl{
+		Paused: true,
+		SetAt:  time.Now().UTC(),
+		Note:   "paused via API",
+	}
+	if err := a.store.UpsertScalingControl(r.Context(), ctrl); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update scaling control")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "paused"})
+}
+
+// handleScalingResume handles POST /api/v1/scaling/resume.
+func (a *API) handleScalingResume(w http.ResponseWriter, r *http.Request) {
+	if a.store == nil {
+		writeError(w, http.StatusServiceUnavailable, "database not available")
+		return
+	}
+	ctrl := models.ScalingControl{
+		Paused:        false,
+		ManualWorkers: 0,
+		SetAt:         time.Now().UTC(),
+		Note:          "resumed via API",
+	}
+	if err := a.store.UpsertScalingControl(r.Context(), ctrl); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update scaling control")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "resumed"})
+}
+
+// handleScalingSet handles POST /api/v1/scaling/set.
+func (a *API) handleScalingSet(w http.ResponseWriter, r *http.Request) {
+	if a.store == nil {
+		writeError(w, http.StatusServiceUnavailable, "database not available")
+		return
+	}
+	var req scalingSetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Workers < 1 {
+		writeError(w, http.StatusBadRequest, "workers must be >= 1")
+		return
+	}
+	note := req.Note
+	if note == "" {
+		note = "set via API"
+	}
+	ctrl := models.ScalingControl{
+		Paused:        true, // pause autonomous scaling while manual target is set
+		ManualWorkers: req.Workers,
+		SetAt:         time.Now().UTC(),
+		Note:          note,
+	}
+	if err := a.store.UpsertScalingControl(r.Context(), ctrl); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update scaling control")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":         "ok",
+		"manual_workers": req.Workers,
+		"note":           note,
+	})
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -138,6 +138,7 @@ func newMCPServer(h *Handler) *gosdk.Server {
 	registerRepoTools(srv, h)
 	registerProjectTools(srv, h)
 	registerPRTools(srv, h)
+	registerScalingTools(srv, h)
 	return srv
 }
 

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -279,8 +279,8 @@ func TestToolsListDiscovery(t *testing.T) {
 			t.Errorf("%s tool not found in tools/list", name)
 		}
 	}
-	if len(result.Tools) != 27 {
-		t.Errorf("expected 27 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 32 {
+		t.Errorf("expected 32 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/internal/mcp/tools_scaling.go
+++ b/internal/mcp/tools_scaling.go
@@ -1,0 +1,200 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/herbhall/samverk/internal/autonomy"
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// scaleSetInput is the typed input for the scale_set tool.
+type scaleSetInput struct {
+	Workers int    `json:"workers" jsonschema:"required,target worker count (>= 1)"`
+	Note    string `json:"note,omitempty" jsonschema:"optional reason for the manual override"`
+}
+
+// registerScalingTools registers MCP tools for scaling control and observation.
+func registerScalingTools(srv *gosdk.Server, h *Handler) {
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "scale_status",
+		Description: "Get current scaling control state (paused, manual target, autoscaler mode). Read-only.",
+	}, h.handleScaleStatus)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "scale_history",
+		Description: "List recent scaling events (scale-up, scale-down, manual-override) from durable storage.",
+	}, h.handleScaleHistory)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "scale_set",
+		Description: "Force the worker pool to a specific size and pause autonomous autoscaling. Requires Tier 2 confirmation.",
+	}, h.handleScaleSet)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "scale_pause",
+		Description: "Pause the autoscaler so it takes no autonomous scaling actions. Current workers are kept. Requires Tier 2 confirmation.",
+	}, h.handleScalePause)
+
+	gosdk.AddTool(srv, &gosdk.Tool{
+		Name:        "scale_resume",
+		Description: "Resume autonomous autoscaling and clear any manual worker target. Requires Tier 2 confirmation.",
+	}, h.handleScaleResume)
+}
+
+// handleScaleStatus returns the current scaling control state (Tier 1 - read-only).
+func (h *Handler) handleScaleStatus(
+	_ context.Context,
+	_ *gosdk.CallToolRequest,
+	_ struct{},
+) (*gosdk.CallToolResult, any, error) {
+	if h.store == nil {
+		return scaleText("scaling control not available (no database)"), nil, nil
+	}
+	ctrl, err := h.store.GetScalingControl(context.Background())
+	if err != nil {
+		return scaleText(fmt.Sprintf("error: %v", err)), nil, nil
+	}
+	out := fmt.Sprintf("Scaling control:\n  paused: %v\n  manual_workers: %d\n  note: %s\n",
+		ctrl.Paused, ctrl.ManualWorkers, ctrl.Note)
+	if !ctrl.SetAt.IsZero() {
+		out += fmt.Sprintf("  set_at: %s\n", ctrl.SetAt.UTC().Format(time.RFC3339))
+	}
+	switch {
+	case !ctrl.Paused && ctrl.ManualWorkers == 0:
+		out += "  mode: autonomous (autoscaler active)\n"
+	case ctrl.Paused && ctrl.ManualWorkers > 0:
+		out += fmt.Sprintf("  mode: manual (target=%d workers, autoscaler paused)\n", ctrl.ManualWorkers)
+	case ctrl.Paused:
+		out += "  mode: paused (autoscaler suspended, worker count unchanged)\n"
+	}
+	return scaleText(out), nil, nil
+}
+
+// handleScaleHistory lists recent scaling events (Tier 1 - read-only).
+func (h *Handler) handleScaleHistory(
+	_ context.Context,
+	_ *gosdk.CallToolRequest,
+	_ struct{},
+) (*gosdk.CallToolResult, any, error) {
+	if h.scalingEvents == nil {
+		return scaleText("scaling event history not available (no database)"), nil, nil
+	}
+	events, err := h.scalingEvents.ListScalingEvents(context.Background(), 20)
+	if err != nil {
+		return scaleText(fmt.Sprintf("error: %v", err)), nil, nil
+	}
+	if len(events) == 0 {
+		return scaleText("No scaling events recorded yet."), nil, nil
+	}
+	out := fmt.Sprintf("Recent scaling events (%d):\n", len(events))
+	for _, e := range events {
+		out += fmt.Sprintf("  [%s] %s %d→%d workers — %s (conf %.0f%%)\n",
+			e.Timestamp.UTC().Format("2006-01-02 15:04:05Z"),
+			e.Action,
+			e.FromWorkers, e.ToWorkers,
+			e.Reason,
+			e.Confidence*100,
+		)
+	}
+	return scaleText(out), nil, nil
+}
+
+// handleScaleSet forces the pool to a specific worker count (Tier 2).
+func (h *Handler) handleScaleSet(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	input scaleSetInput,
+) (*gosdk.CallToolResult, any, error) {
+	if result := h.checkTier(autonomy.ActionRunService, "scale_set", func() (*gosdk.CallToolResult, error) {
+		return h.execScaleSet(ctx, input.Workers, input.Note)
+	}); result != nil {
+		return result, nil, nil
+	}
+	r, err := h.execScaleSet(ctx, input.Workers, input.Note)
+	return r, nil, err
+}
+
+func (h *Handler) execScaleSet(ctx context.Context, workers int, note string) (*gosdk.CallToolResult, error) {
+	if h.store == nil {
+		return scaleText("scaling control not available (no database)"), nil
+	}
+	if workers < 1 {
+		return scaleText("error: workers must be >= 1"), nil
+	}
+	if note == "" {
+		note = "set via MCP"
+	}
+	ctrl := models.ScalingControl{
+		Paused:        true,
+		ManualWorkers: workers,
+		SetAt:         time.Now().UTC(),
+		Note:          note,
+	}
+	if err := h.store.UpsertScalingControl(ctx, ctrl); err != nil {
+		return scaleText(fmt.Sprintf("error: %v", err)), nil
+	}
+	return scaleText(fmt.Sprintf("OK: manual worker target set to %d, autoscaler paused. Note: %s", workers, note)), nil
+}
+
+// handleScalePause pauses the autoscaler (Tier 2).
+func (h *Handler) handleScalePause(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	_ struct{},
+) (*gosdk.CallToolResult, any, error) {
+	if result := h.checkTier(autonomy.ActionRunService, "scale_pause", func() (*gosdk.CallToolResult, error) {
+		return h.execScalePause(ctx)
+	}); result != nil {
+		return result, nil, nil
+	}
+	r, err := h.execScalePause(ctx)
+	return r, nil, err
+}
+
+func (h *Handler) execScalePause(ctx context.Context) (*gosdk.CallToolResult, error) {
+	if h.store == nil {
+		return scaleText("scaling control not available (no database)"), nil
+	}
+	ctrl := models.ScalingControl{Paused: true, SetAt: time.Now().UTC(), Note: "paused via MCP"}
+	if err := h.store.UpsertScalingControl(ctx, ctrl); err != nil {
+		return scaleText(fmt.Sprintf("error: %v", err)), nil
+	}
+	return scaleText("OK: autoscaler paused. Current worker count will be maintained."), nil
+}
+
+// handleScaleResume resumes the autoscaler (Tier 2).
+func (h *Handler) handleScaleResume(
+	ctx context.Context,
+	_ *gosdk.CallToolRequest,
+	_ struct{},
+) (*gosdk.CallToolResult, any, error) {
+	if result := h.checkTier(autonomy.ActionRunService, "scale_resume", func() (*gosdk.CallToolResult, error) {
+		return h.execScaleResume(ctx)
+	}); result != nil {
+		return result, nil, nil
+	}
+	r, err := h.execScaleResume(ctx)
+	return r, nil, err
+}
+
+func (h *Handler) execScaleResume(ctx context.Context) (*gosdk.CallToolResult, error) {
+	if h.store == nil {
+		return scaleText("scaling control not available (no database)"), nil
+	}
+	ctrl := models.ScalingControl{Paused: false, ManualWorkers: 0, SetAt: time.Now().UTC(), Note: "resumed via MCP"}
+	if err := h.store.UpsertScalingControl(ctx, ctrl); err != nil {
+		return scaleText(fmt.Sprintf("error: %v", err)), nil
+	}
+	return scaleText("OK: autoscaler resumed. Autonomous scaling is now active."), nil
+}
+
+// scaleText returns a *gosdk.CallToolResult with plain-text content.
+func scaleText(text string) *gosdk.CallToolResult {
+	return &gosdk.CallToolResult{
+		Content: []gosdk.Content{&gosdk.TextContent{Text: text}},
+	}
+}

--- a/internal/scaling/autoscaler.go
+++ b/internal/scaling/autoscaler.go
@@ -15,6 +15,13 @@ type PoolScaler interface {
 	Snapshot() metrics.PoolSnapshot
 	AddWorkers(n int) error
 	RemoveWorkers(n int) int
+	Workers() int
+}
+
+// ScalingControlReader reads the current manual scaling override.
+// store.Store satisfies this interface.
+type ScalingControlReader interface {
+	GetScalingControl(ctx context.Context) (*models.ScalingControl, error)
 }
 
 // SystemCollector provides runtime system snapshots.
@@ -27,13 +34,14 @@ type SystemCollector interface {
 // policy and applies the resulting decision to the pool.
 // Start it with Run(ctx) and cancel the context to shut it down.
 type Autoscaler struct {
-	policy    *ThresholdPolicy
-	pool      PoolScaler
-	collector SystemCollector
-	interval  time.Duration
-	logger    *slog.Logger
-	events    *EventBuffer
-	persister EventPersister // optional; nil means no durable storage
+	policy        *ThresholdPolicy
+	pool          PoolScaler
+	collector     SystemCollector
+	interval      time.Duration
+	logger        *slog.Logger
+	events        *EventBuffer
+	persister     EventPersister      // optional; nil means no durable storage
+	controlReader ScalingControlReader // optional; nil means no override support
 }
 
 // NewAutoscaler creates an Autoscaler wired to the given policy, pool, and
@@ -60,6 +68,12 @@ func NewAutoscaler(policy *ThresholdPolicy, pool PoolScaler, collector SystemCol
 // survive process restarts and are visible to other processes (e.g. serve).
 func (a *Autoscaler) SetPersister(p EventPersister) {
 	a.persister = p
+}
+
+// SetControlReader attaches an optional store for reading manual scaling overrides.
+// When set, the autoscaler checks for pause/set commands before each evaluation.
+func (a *Autoscaler) SetControlReader(r ScalingControlReader) {
+	a.controlReader = r
 }
 
 // Events returns recent scaling events from the in-memory buffer, newest first.
@@ -92,6 +106,23 @@ func (a *Autoscaler) Run(ctx context.Context) error {
 
 // evaluate runs one policy cycle and applies the decision.
 func (a *Autoscaler) evaluate() {
+	// Check for manual override before running the policy.
+	if a.controlReader != nil {
+		ctrl, ctrlErr := a.controlReader.GetScalingControl(context.Background())
+		if ctrlErr != nil {
+			a.logger.Warn("autoscaler: failed to read scaling control", slog.String("error", ctrlErr.Error()))
+		} else if ctrl != nil {
+			if ctrl.Paused {
+				a.logger.Debug("autoscaler paused via manual override")
+				return
+			}
+			if ctrl.ManualWorkers > 0 {
+				a.applyManualOverride(ctrl.ManualWorkers, ctrl.Note)
+				return
+			}
+		}
+	}
+
 	poolSnap := a.pool.Snapshot()
 	sysSnap := a.collector.Collect()
 	decision := a.policy.Evaluate(poolSnap, sysSnap)
@@ -106,6 +137,43 @@ func (a *Autoscaler) evaluate() {
 
 	oldCount := poolSnap.TotalWorkers
 	a.apply(decision, oldCount)
+}
+
+// applyManualOverride adjusts the pool to the requested worker count.
+func (a *Autoscaler) applyManualOverride(targetWorkers int, note string) {
+	current := a.pool.Workers()
+	if current == targetWorkers {
+		return
+	}
+	delta := targetWorkers - current
+	reason := "manual override"
+	if note != "" {
+		reason = "manual override: " + note
+	}
+	if delta > 0 {
+		if err := a.pool.AddWorkers(delta); err != nil {
+			a.logger.Warn("autoscaler manual override scale-up failed", slog.String("error", err.Error()))
+			return
+		}
+	} else {
+		a.pool.RemoveWorkers(-delta)
+	}
+	newCount := a.pool.Workers()
+	a.logger.Info("autoscaler manual override applied",
+		slog.Int("old_workers", current),
+		slog.Int("new_workers", newCount),
+		slog.String("reason", reason),
+	)
+	e := models.ScalingEvent{
+		Timestamp:   time.Now(),
+		Action:      "manual-override",
+		FromWorkers: current,
+		ToWorkers:   newCount,
+		Reason:      reason,
+		Confidence:  1.0,
+	}
+	a.events.Add(e)
+	a.persist(e)
 }
 
 // persist saves e to the optional durable store. Errors are logged but not fatal.

--- a/internal/scaling/autoscaler_test.go
+++ b/internal/scaling/autoscaler_test.go
@@ -37,6 +37,7 @@ func (m *mockPool) RemoveWorkers(_ int) int {
 	m.snapshot.TotalWorkers--
 	return m.remReturn
 }
+func (m *mockPool) Workers() int { return m.snapshot.TotalWorkers }
 
 type mockCollector struct{}
 

--- a/internal/store/scaling_control.go
+++ b/internal/store/scaling_control.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// GetScalingControl returns the current scaling control record.
+// Returns a zeroed ScalingControl (no override, not paused) if no record exists.
+func (s *SQLiteStore) GetScalingControl(ctx context.Context) (*models.ScalingControl, error) {
+	var c models.ScalingControl
+	var setAtStr string
+	var paused, manualWorkers int
+
+	err := s.db.QueryRowContext(ctx,
+		`SELECT paused, manual_workers, set_at, note FROM scaling_control WHERE id = 1`,
+	).Scan(&paused, &manualWorkers, &setAtStr, &c.Note)
+
+	if err == sql.ErrNoRows {
+		return &models.ScalingControl{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	c.Paused = paused != 0
+	c.ManualWorkers = manualWorkers
+	c.SetAt, _ = time.Parse(time.RFC3339, setAtStr)
+	return &c, nil
+}
+
+// UpsertScalingControl inserts or replaces the scaling control record (single row, id=1).
+func (s *SQLiteStore) UpsertScalingControl(ctx context.Context, c models.ScalingControl) error {
+	paused := 0
+	if c.Paused {
+		paused = 1
+	}
+	setAt := c.SetAt
+	if setAt.IsZero() {
+		setAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO scaling_control (id, paused, manual_workers, set_at, note)
+VALUES (1, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    paused = excluded.paused,
+    manual_workers = excluded.manual_workers,
+    set_at = excluded.set_at,
+    note = excluded.note`,
+		paused,
+		c.ManualWorkers,
+		setAt.UTC().Format(time.RFC3339),
+		c.Note,
+	)
+	return err
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,10 @@ type Store interface {
 	SaveScalingEvent(ctx context.Context, e models.ScalingEvent) error
 	ListScalingEvents(ctx context.Context, limit int) ([]*models.ScalingEvent, error)
 
+	// Scaling control (written by serve/CLI, read by dispatch autoscaler)
+	GetScalingControl(ctx context.Context) (*models.ScalingControl, error)
+	UpsertScalingControl(ctx context.Context, c models.ScalingControl) error
+
 	Close() error
 }
 
@@ -118,6 +122,14 @@ CREATE TABLE IF NOT EXISTS scaling_events (
 );
 
 CREATE INDEX IF NOT EXISTS idx_scaling_ts ON scaling_events(timestamp DESC);
+
+CREATE TABLE IF NOT EXISTS scaling_control (
+	id             INTEGER PRIMARY KEY CHECK (id = 1),
+	paused         INTEGER NOT NULL DEFAULT 0,
+	manual_workers INTEGER NOT NULL DEFAULT 0,
+	set_at         TEXT NOT NULL,
+	note           TEXT NOT NULL DEFAULT ''
+);
 `
 	_, err := s.db.ExecContext(context.Background(), ddl)
 	return err

--- a/pkg/models/scaling.go
+++ b/pkg/models/scaling.go
@@ -6,9 +6,20 @@ import "time"
 type ScalingEvent struct {
 	ID          string
 	Timestamp   time.Time
-	Action      string // "scale_up" | "scale_down"
+	Action      string // "scale-up" | "scale-down" | "manual-override"
 	FromWorkers int
 	ToWorkers   int
 	Reason      string
 	Confidence  float64
+}
+
+// ScalingControl is a single-row record that holds manual override state written
+// by the REST API or CLI and consumed by the autoscaler on each evaluation cycle.
+// ManualWorkers == 0 means no manual target is set.
+// Paused == true means the autoscaler should hold (take no autonomous action).
+type ScalingControl struct {
+	Paused        bool
+	ManualWorkers int
+	SetAt         time.Time
+	Note          string
 }


### PR DESCRIPTION
## Summary

- **REST API** (`/api/v1/scaling/pause|resume|set|control`): read/write the single-row `scaling_control` SQLite record that cross-process signals the autoscaler
- **SQLite persistence**: `GetScalingControl`/`UpsertScalingControl` on the `Store` interface; new `scaling_control` table with DDL migration
- **Autoscaler control reader**: `ScalingControlReader` interface and `SetControlReader()` hook; each evaluation cycle checks for pause/manual-override before running policy
- **`samverk scale` CLI**: `status`, `pause`, `resume`, `set <N>`, `history` subcommands; `--server` and `--token` flags; `doHTTPRequest` helper
- **MCP tools**: `scale_status`, `scale_history` (Tier 1); `scale_set`, `scale_pause`, `scale_resume` (Tier 2, `ActionRunService`); wired in `newMCPServer` (tool count 27 → 32)

Closes #300, Closes #301

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 23 packages)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `markdownlint` — 0 errors
- [x] Pre-push hooks pass (both GitHub and Gitea)

🤖 Generated with [Claude Code](https://claude.com/claude-code)