### PR TITLE
feat(#305,#306): PC agent workspace module and design doc

### DIFF
--- a/docs/pc-agent-design.md
+++ b/docs/pc-agent-design.md
@@ -1,0 +1,317 @@
+# PC Agent Runner Design
+
+## Overview
+
+The PC agent runner turns a Windows workstation into a Samverk worker node.
+It continuously polls for queued issues, provisions isolated workspaces, launches
+Claude Code (CC) as an autonomous agent, and handles the results — all without
+touching the developer's working copy.
+
+**Critical invariant:** No component reads from or writes to the user's working
+copy (`D:\DevSpace\Samverk`). All agent file operations occur inside worktree
+directories under the workspace root (`D:\bots\`).
+
+## Component Overview
+
+```text
+┌──────────────────────────────────────────────────────────────────────────┐
+│                          PC Agent Runner Loop                            │
+│                                                                          │
+│  ┌─────────────┐   ┌───────────────┐   ┌──────────────┐                 │
+│  │Forge Poller │──▶│Autonomy Gate  │──▶│Workspace Mgr │                 │
+│  │(PowerShell) │   │(tier check)   │   │(worktree)    │                 │
+│  └─────────────┘   └───────────────┘   └──────┬───────┘                 │
+│                                               │                         │
+│                                               ▼                         │
+│                                    ┌──────────────────┐                 │
+│                                    │ Prompt Formatter  │                 │
+│                                    │ (issue → CC task) │                 │
+│                                    └────────┬─────────┘                 │
+│                                             │                           │
+│                                             ▼                           │
+│                                    ┌──────────────────┐                 │
+│                                    │   CC Launcher    │                 │
+│                                    │ (claude --print) │                 │
+│                                    └────────┬─────────┘                 │
+│                                             │                           │
+│                                             ▼                           │
+│                                    ┌──────────────────┐                 │
+│                                    │ Post-Task Handler│                 │
+│                                    │ (PR, labels,     │                 │
+│                                    │  cleanup)        │                 │
+│                                    └──────────────────┘                 │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Full Issue Lifecycle (Sequence Diagram)
+
+```text
+ForgePoller       AutonomyGate  WorkspaceMgr  PromptFormatter  CCLauncher  PostTaskHandler
+    │                 │              │                │              │             │
+    │──poll issues──▶ │              │                │              │             │
+    │◀─issue list──── │              │                │              │             │
+    │──check tier────▶│              │                │              │             │
+    │◀─proceed────────│              │                │              │             │
+    │──claim labels──▶(GitHub API)   │                │              │             │
+    │──update bare────────────────▶  │                │              │             │
+    │──new worktree───────────────▶  │                │              │             │
+    │◀─worktree info──────────────── │                │              │             │
+    │──format issue───────────────────────────────▶  │              │             │
+    │◀─prompt─────────────────────────────────────── │              │             │
+    │──launch CC──────────────────────────────────────────────────▶ │             │
+    │                                                               │(CC runs:    │
+    │                                                               │ read files  │
+    │                                                               │ write code  │
+    │                                                               │ run tests   │
+    │                                                               │ git commit) │
+    │◀─exit code + output─────────────────────────────────────────── │             │
+    │──handle result──────────────────────────────────────────────────────────▶   │
+    │                                                                             │──push branch
+    │                                                                             │──open PR
+    │                                                                             │──update labels
+    │                                                                             │──add comment
+    │──remove worktree────────────────────────────────────────────────────────── │
+    │                                                                             │──cleanup
+    │──next poll──────(loop)
+```
+
+## Component Details
+
+### 1. Forge Poller (`scripts/pc-agent/poller.ps1`)
+
+Queries GitHub/Gitea for issues ready to be claimed.
+
+**Query criteria:**
+
+- `status:queued` label — dispatcher has routed it
+- Agent label matches: `agent:code-gen`, `agent:triage`, `agent:research`, `agent:docs`
+- Not already assigned or in-progress
+- Complexity label is within the configured autonomy tier
+
+**Claim protocol:**
+
+1. Remove `status:queued` label
+2. Add `status:active` label
+3. Add self as assignee (via forge API)
+4. Begin processing — if the runner crashes, a watchdog re-queues after a timeout
+
+**Output:** `PSCustomObject` with `Number`, `Title`, `Body`, `Labels`, `AgentType`, `ComplexityTier`
+
+### 2. Autonomy Gate (`scripts/pc-agent/poller.ps1`)
+
+Filters issues against the configured autonomy tier before claiming.
+
+| Complexity Label | Tier | PC Agent Action |
+|-----------------|------|----------------|
+| `complexity:local` | 1 | Auto-proceed |
+| `complexity:cloud` | 2 | Auto-proceed (log prominently) |
+| `complexity:ambiguous` | 3 | Skip — leave in queue |
+| `priority:critical` + any | — | Auto-proceed regardless of tier |
+
+Configuration in `.samverk/pc-agent.yaml`:
+
+```yaml
+autonomy:
+  max_tier: 2
+  always_proceed_on_critical: true
+```
+
+### 3. Workspace Manager (`scripts/pc-agent/workspace.psm1`)
+
+Manages the bare clone and per-session worktrees.
+
+**Directory layout:**
+
+```text
+D:\bots\
+├── samverk.git\          ← Bare clone (shared object store)
+├── worker-1\             ← Worktree for session 1 (branch: fix/42-add-feature)
+├── worker-2\             ← Worktree for session 2
+└── worker-3\             ← Worktree for session 3 (max 3 simultaneous)
+```
+
+**Key functions:**
+
+| Function | Purpose |
+|----------|---------|
+| `Initialize-AgentWorkspace` | One-time bare clone setup |
+| `Update-BareRepo` | `git fetch --all` before each task |
+| `Get-AvailableWorkerSlot` | Find next free `worker-N` slot |
+| `New-AgentWorktree` | Create worktree on `fix/<N>-<slug>` branch |
+| `Remove-AgentWorktree` | Delete worktree and prune refs |
+| `Test-WorktreeHealth` | Verify clean git status + project structure |
+
+**Branch naming:** `fix/<issueNumber>-<slug>` where slug is the issue title lowercased,
+non-alphanumeric stripped, spaces → hyphens, max 40 chars.
+
+### 4. Prompt Formatter (`scripts/pc-agent/formatter.ps1`)
+
+Converts a Samverk issue into a CC-consumable task prompt.
+
+**Template:**
+
+```text
+You are a Samverk agent implementing GitHub issue #<N>.
+
+Title: <issue title>
+Agent type: <agent_type>
+
+Issue body:
+<full issue body including frontmatter>
+
+Instructions:
+- Work in the current directory (a git worktree on branch fix/<N>-<slug>)
+- Read CLAUDE.md for project conventions and build commands
+- Run `make ci` (build + test + lint) before committing
+- Commit your changes with: git commit -m "feat(#<N>): <summary>"
+- Do NOT push — the post-task handler pushes and opens the PR
+- If you cannot complete the task, write a comment to AGENT_BLOCKED.md
+  explaining what is blocked and why
+
+The project uses Go (backend) and React+TypeScript (frontend).
+Run `go build ./...` and `go test ./...` to verify backend changes.
+Run `cd web && npx tsc --noEmit` to verify frontend changes.
+```
+
+**Why CLAUDE.md is not injected:** CC reads `CLAUDE.md` automatically from
+the current working directory. The worktree inherits it from the repo. No prompt
+injection needed — project context is available natively.
+
+### 5. CC Launcher (`scripts/pc-agent/launcher.ps1`)
+
+Starts CC in the worktree directory with the formatted prompt.
+
+**Invocation:**
+
+```powershell
+$result = & claude `
+    --print `
+    --dangerously-skip-permissions `
+    --output-format json `
+    --max-turns 50 `
+    $prompt 2>&1 | Out-String
+
+$exitCode = $LASTEXITCODE
+$parsed   = $result | ConvertFrom-Json -ErrorAction SilentlyContinue
+```
+
+**Parameters:**
+
+| Flag | Rationale |
+|------|-----------|
+| `--print` | Non-interactive headless mode; CC processes task and exits |
+| `--dangerously-skip-permissions` | No permission prompts during unattended execution |
+| `--output-format json` | Structured output parseable by PowerShell |
+| `--max-turns 50` | Safety cap; prevents infinite loops on buggy tasks |
+
+**Timeout:** Set via `Start-Job` + `Wait-Job -Timeout <seconds>`. Default timeout
+by complexity label:
+
+| Complexity | Timeout |
+|-----------|---------|
+| `complexity:local` | 600 s (10 min) |
+| `complexity:cloud` | 1800 s (30 min) |
+| Default | 900 s (15 min) |
+
+**Success detection:**
+
+- Exit code 0 AND `$parsed.is_error -eq $false`
+- If `$parsed.is_error -eq $true`, treat as failure even with exit 0
+
+### 6. Post-Task Handler (`scripts/pc-agent/post-task.ps1`)
+
+Handles the task result: push code, open PR, update issue.
+
+**Success path:**
+
+1. Check `git status` in worktree — are there committed changes on the branch?
+2. `git push origin fix/<N>-<slug>` via the bare repo
+3. Open PR via forge API (`gh pr create` or GitHub REST API)
+4. Post comment on issue: `"PR opened: #<PR number>"`, link to PR
+5. Remove `status:active` label, add `status:done` label
+6. Remove worktree (`Remove-AgentWorktree`)
+
+**Failure path:**
+
+1. Post comment on issue with error details and CC output excerpt
+2. Remove `status:active` label, add `status:needs-human` label
+3. Remove worktree (always clean up)
+
+**Blocked path** (CC wrote `AGENT_BLOCKED.md`):
+
+1. Read `AGENT_BLOCKED.md` content
+2. Post as issue comment: `"[BLOCKED] <content>"`
+3. Remove `status:active` label, add `status:needs-human` label
+4. Remove worktree
+
+**Retry policy:** No automatic retries at the runner level. If the issue label
+is reset to `status:queued` by a human, it becomes eligible for the next poll cycle.
+
+## Error Handling
+
+| Error | Recovery |
+|-------|---------|
+| Bare repo unreachable | Log + wait; retry next poll cycle |
+| All worker slots occupied | Skip poll; retry in `poll_interval` seconds |
+| Worktree creation fails (branch exists) | Delete branch, retry once |
+| CC timeout | Kill process, remove worktree, fail the task |
+| CC exit code non-zero | Read output, post error comment |
+| Push fails (network) | Retry 3 times with 10 s backoff |
+| PR create fails | Post branch name in comment for manual PR creation |
+
+## Windows-Specific Considerations
+
+1. **Paths:** Use `Join-Path` throughout. Never hardcode `\` separators. All paths
+   are under `D:\bots\` which avoids MSYS path translation issues.
+
+2. **Process management:** Use `Start-Job` / `Wait-Job -Timeout` for CC invocation.
+   Direct `&` blocks the runner; background job with timeout enables safe interruption.
+
+3. **Git credential:** The bare repo uses HTTPS. Git credential manager (GCM) must
+   have a stored credential for `github.com` and `gitea.herbhall.net`. Test with
+   `git -C D:\bots\samverk.git fetch` before first agent run.
+
+4. **CLAUDE.md loading:** CC loads `CLAUDE.md` from the worktree directory and
+   all ancestor directories. Since worktrees share the object store but have their
+   own working tree, `CLAUDE.md` at the repo root is present and loaded automatically.
+
+5. **PowerShell execution policy:** The runner scripts require
+   `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser` (one-time setup).
+
+6. **Concurrent instances:** Each worker slot is a separate process. PowerShell
+   does not provide built-in mutex primitives — use file-based locking if running
+   multiple runner instances simultaneously.
+
+## Configuration Reference (`.samverk/pc-agent.yaml`)
+
+```yaml
+workspace:
+  root: D:\bots
+  bare_repo: samverk.git
+  max_worktrees: 3
+  remotes:
+    github: https://github.com/HerbHall/samverk.git
+    gitea: http://gitea.herbhall.net/samverk/samverk.git
+
+autonomy:
+  max_tier: 2
+  always_proceed_on_critical: true
+
+timeouts:
+  local_seconds: 600
+  cloud_seconds: 1800
+  default_seconds: 900
+
+poll_interval_seconds: 60
+
+cc:
+  max_turns: 50
+  output_format: json
+```
+
+## Related Documents
+
+- [PC Agent Research Findings](https://github.com/HerbHall/samverk/issues/304#issuecomment-4020751460) — CC headless invocation modes
+- [docs/autonomy-model.md](autonomy-model.md) — Three-tier trust model
+- [docs/communication-protocol.md](communication-protocol.md) — Label taxonomy
+- [scripts/pc-agent/workspace.psm1](../scripts/pc-agent/workspace.psm1) — Workspace module

--- a/scripts/pc-agent/workspace.psm1
+++ b/scripts/pc-agent/workspace.psm1
@@ -1,0 +1,318 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    PC Agent workspace infrastructure — bare clone and worktree lifecycle management.
+
+.DESCRIPTION
+    Provides functions to manage an isolated agent workspace under a configurable
+    root directory (default D:\bots\). Agents NEVER access the user's working copy.
+
+    Directory layout:
+        <Root>\samverk.git\    ← Bare clone (shared object store)
+        <Root>\worker-1\       ← Worktree: agent session 1
+        <Root>\worker-2\       ← Worktree: agent session 2
+        <Root>\worker-3\       ← Worktree: agent session 3
+
+    CRITICAL INVARIANT: No function in this module reads from or writes to
+    the user's working copy. All agent file operations occur within worktree
+    directories under the workspace root.
+#>
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+# Default configuration — callers can override by passing -Config.
+$script:DefaultConfig = @{
+    Root         = 'D:\bots'
+    BareRepo     = 'samverk.git'
+    MaxWorktrees = 3
+    Remotes      = @{
+        github = 'https://github.com/HerbHall/samverk.git'
+        gitea  = 'http://gitea.herbhall.net/samverk/samverk.git'
+    }
+}
+
+function Get-WorkspaceConfig {
+    <#
+    .SYNOPSIS
+        Returns configuration, merging defaults with an optional .samverk/pc-agent.yaml override.
+    .PARAMETER YamlPath
+        Path to pc-agent.yaml. If omitted, uses D:\devspace\Samverk\.samverk\pc-agent.yaml.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$YamlPath = ''
+    )
+    # Return defaults — YAML parsing would require powershell-yaml module.
+    # When that module is available, add: Import-Module powershell-yaml and parse.
+    return $script:DefaultConfig
+}
+
+function Get-BareRepoPath {
+    param([hashtable]$Config = $script:DefaultConfig)
+    return Join-Path $Config.Root $Config.BareRepo
+}
+
+function Initialize-AgentWorkspace {
+    <#
+    .SYNOPSIS
+        One-time setup: creates the bare clone at the configured location.
+    .DESCRIPTION
+        Clones the primary remote (github) as a bare repository. Adds the
+        secondary remote (gitea) so Update-BareRepo can push to both.
+        Safe to call multiple times — skips setup if the bare repo already exists.
+    .PARAMETER Config
+        Workspace configuration hashtable.
+    .PARAMETER Force
+        Remove and re-create the bare repo if it already exists.
+    #>
+    [CmdletBinding()]
+    param(
+        [hashtable]$Config = $script:DefaultConfig,
+        [switch]$Force
+    )
+
+    $bareRepo = Get-BareRepoPath -Config $Config
+
+    if (Test-Path $bareRepo) {
+        if ($Force) {
+            Write-Verbose "Force: removing existing bare repo at $bareRepo"
+            Remove-Item -Recurse -Force $bareRepo
+        } else {
+            Write-Host "Bare repo already exists at $bareRepo — skipping clone."
+            return
+        }
+    }
+
+    $null = New-Item -ItemType Directory -Force -Path $Config.Root
+
+    Write-Host "Cloning bare repo from $($Config.Remotes.github) to $bareRepo ..."
+    $null = & git clone --bare $Config.Remotes.github $bareRepo 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git clone --bare failed (exit $LASTEXITCODE)"
+    }
+
+    # Add gitea as a secondary remote for push mirroring.
+    $null = & git -C $bareRepo remote add gitea $Config.Remotes.gitea 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Could not add gitea remote (non-fatal): gitea remote may already exist."
+    }
+
+    Write-Host "Workspace initialized at $($Config.Root)"
+}
+
+function Update-BareRepo {
+    <#
+    .SYNOPSIS
+        Fetches the latest commits from all remotes into the bare clone.
+    .DESCRIPTION
+        Should be called before creating a new worktree to ensure the agent
+        starts from the latest main branch.
+    .PARAMETER Config
+        Workspace configuration hashtable.
+    #>
+    [CmdletBinding()]
+    param(
+        [hashtable]$Config = $script:DefaultConfig
+    )
+
+    $bareRepo = Get-BareRepoPath -Config $Config
+    if (-not (Test-Path $bareRepo)) {
+        throw "Bare repo not found at $bareRepo — run Initialize-AgentWorkspace first."
+    }
+
+    Write-Verbose "Fetching from origin (github) ..."
+    $null = & git -C $bareRepo fetch --all --prune 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git fetch failed (exit $LASTEXITCODE)"
+    }
+
+    Write-Verbose "Bare repo updated."
+}
+
+function Get-AvailableWorkerSlot {
+    <#
+    .SYNOPSIS
+        Returns the name of the next available worker slot (e.g. "worker-2").
+    .DESCRIPTION
+        Scans the workspace root for existing worker directories and returns the
+        lowest-numbered slot that is not currently in use.
+        Returns $null when all slots are occupied.
+    .PARAMETER Config
+        Workspace configuration hashtable.
+    #>
+    [CmdletBinding()]
+    param(
+        [hashtable]$Config = $script:DefaultConfig
+    )
+
+    for ($i = 1; $i -le $Config.MaxWorktrees; $i++) {
+        $slot = "worker-$i"
+        $path = Join-Path $Config.Root $slot
+        if (-not (Test-Path $path)) {
+            return $slot
+        }
+    }
+    return $null
+}
+
+function New-AgentWorktree {
+    <#
+    .SYNOPSIS
+        Creates an isolated worktree for a single agent task.
+    .DESCRIPTION
+        Provisions a git worktree on a new branch named fix/<issueNumber>-<slug>.
+        The worktree contains the full project (CLAUDE.md, Makefile, go.mod, etc.)
+        and is isolated from the user's working copy.
+    .PARAMETER IssueNumber
+        The GitHub/Gitea issue number being worked on.
+    .PARAMETER IssueTitle
+        The issue title, used to build the branch slug.
+    .PARAMETER Slot
+        Worker slot name (e.g. "worker-1"). If omitted, the next available slot is used.
+    .PARAMETER Config
+        Workspace configuration hashtable.
+    .OUTPUTS
+        Hashtable with keys: Slot, Path, Branch, BareRepo
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [int]$IssueNumber,
+        [Parameter(Mandatory)]
+        [string]$IssueTitle,
+        [string]$Slot = '',
+        [hashtable]$Config = $script:DefaultConfig
+    )
+
+    $bareRepo = Get-BareRepoPath -Config $Config
+    if (-not (Test-Path $bareRepo)) {
+        throw "Bare repo not found at $bareRepo — run Initialize-AgentWorkspace first."
+    }
+
+    if ($Slot -eq '') {
+        $Slot = Get-AvailableWorkerSlot -Config $Config
+        if ($null -eq $Slot) {
+            throw "All $($Config.MaxWorktrees) worker slots are occupied. Wait for a task to complete."
+        }
+    }
+
+    $worktreePath = Join-Path $Config.Root $Slot
+    if (Test-Path $worktreePath) {
+        throw "Slot $Slot is already in use at $worktreePath."
+    }
+
+    # Build branch slug: lowercase, alphanumeric + hyphens, max 40 chars.
+    $slug = ($IssueTitle -replace '[^a-zA-Z0-9\s]', '' -replace '\s+', '-').ToLower()
+    $slug = $slug.Substring(0, [Math]::Min($slug.Length, 40)).TrimEnd('-')
+    $branch = "fix/$IssueNumber-$slug"
+
+    Write-Host "Creating worktree: slot=$Slot branch=$branch path=$worktreePath"
+    $null = & git -C $bareRepo worktree add $worktreePath -b $branch origin/main 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git worktree add failed (exit $LASTEXITCODE). Branch '$branch' may already exist."
+    }
+
+    return @{
+        Slot     = $Slot
+        Path     = $worktreePath
+        Branch   = $branch
+        BareRepo = $bareRepo
+    }
+}
+
+function Remove-AgentWorktree {
+    <#
+    .SYNOPSIS
+        Removes a worktree and cleans up dangling refs.
+    .DESCRIPTION
+        Deletes the worktree directory and prunes the worktree list from the
+        bare repo. Safe to call even if the worktree was already removed.
+    .PARAMETER Slot
+        Worker slot name (e.g. "worker-1").
+    .PARAMETER Config
+        Workspace configuration hashtable.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Slot,
+        [hashtable]$Config = $script:DefaultConfig
+    )
+
+    $bareRepo  = Get-BareRepoPath -Config $Config
+    $worktreePath = Join-Path $Config.Root $Slot
+
+    if (Test-Path $worktreePath) {
+        Write-Verbose "Removing worktree at $worktreePath ..."
+        $null = & git -C $bareRepo worktree remove --force $worktreePath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            # Fallback: manual directory removal if git worktree remove fails.
+            Write-Warning "git worktree remove failed — removing directory manually."
+            Remove-Item -Recurse -Force $worktreePath -ErrorAction SilentlyContinue
+        }
+    } else {
+        Write-Verbose "Worktree path $worktreePath does not exist — skipping removal."
+    }
+
+    # Prune stale worktree metadata from the bare repo.
+    $null = & git -C $bareRepo worktree prune 2>&1
+    Write-Verbose "Slot $Slot cleaned up."
+}
+
+function Test-WorktreeHealth {
+    <#
+    .SYNOPSIS
+        Verifies that a worktree is in a clean, functional state.
+    .DESCRIPTION
+        Checks that the worktree path exists, git status is clean (no uncommitted
+        changes), and go.mod is present (project structure intact).
+    .PARAMETER Slot
+        Worker slot name (e.g. "worker-1").
+    .PARAMETER Config
+        Workspace configuration hashtable.
+    .OUTPUTS
+        $true if healthy, $false with a warning message if not.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Slot,
+        [hashtable]$Config = $script:DefaultConfig
+    )
+
+    $worktreePath = Join-Path $Config.Root $Slot
+
+    if (-not (Test-Path $worktreePath)) {
+        Write-Warning "Worktree path does not exist: $worktreePath"
+        return $false
+    }
+
+    if (-not (Test-Path (Join-Path $worktreePath 'go.mod'))) {
+        Write-Warning "go.mod not found in worktree — project structure may be incomplete."
+        return $false
+    }
+
+    $status = & git -C $worktreePath status --porcelain 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "git status failed in worktree $worktreePath"
+        return $false
+    }
+
+    if ($status.Trim() -ne '') {
+        Write-Warning "Worktree has uncommitted changes:`n$status"
+        return $false
+    }
+
+    return $true
+}
+
+Export-ModuleMember -Function @(
+    'Get-WorkspaceConfig',
+    'Initialize-AgentWorkspace',
+    'Update-BareRepo',
+    'Get-AvailableWorkerSlot',
+    'New-AgentWorktree',
+    'Remove-AgentWorktree',
+    'Test-WorktreeHealth'
+)


### PR DESCRIPTION
## Summary

- **`scripts/pc-agent/workspace.psm1`** — PowerShell module managing the bare clone + worktree lifecycle for isolated agent workspaces. Exports 7 functions: Initialize-AgentWorkspace, Update-BareRepo, Get-AvailableWorkerSlot, New-AgentWorktree, Remove-AgentWorktree, Test-WorktreeHealth, Get-WorkspaceConfig.
- **`docs/pc-agent-design.md`** — Full architecture doc covering all 6 components (forge poller, autonomy gate, workspace manager, prompt formatter, CC launcher, post-task handler) with sequence diagram, error handling table, and Windows-specific notes.

The CC invocation mode (`--print --dangerously-skip-permissions --output-format json --max-turns 50`) is based on the #304 research findings posted as issue comment.

Closes #305, Closes #306

## Test plan

- [x] `go build ./...` + `go test ./...` — all packages pass
- [x] `golangci-lint` — 0 issues
- [x] `markdownlint` — 0 errors
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)