### PR TITLE
feat(#313): register PC agent as a worker node with Samverk server

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -105,6 +105,7 @@ func serveCmd() *cobra.Command {
 
 			// Wire GitHub forge if credentials are available.
 			var tracker forge.IssueTracker
+			var mcpHandler *internalmcp.Handler
 			token := os.Getenv("GITHUB_TOKEN")
 			if owner == "" {
 				owner = os.Getenv("SAMVERK_GITHUB_OWNER")
@@ -128,7 +129,7 @@ func serveCmd() *cobra.Command {
 
 				// The GitHub Client implements both IssueTracker and RepoReader.
 				var repoReader forge.RepoReader = ghClient
-				mcpHandler := internalmcp.NewHandler(tracker, costs, st, policy, repoReader)
+				mcpHandler = internalmcp.NewHandler(tracker, costs, st, policy, repoReader)
 				mcpHandler.SetPRManager(ghClient)
 
 				// Wire multi-project support.
@@ -183,10 +184,6 @@ func serveCmd() *cobra.Command {
 				if st != nil {
 					mcpHandler.SetScalingEventReader(st)
 				}
-				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
-				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
-			} else {
-				slog.Info("MCP handler disabled (set GITHUB_TOKEN, owner, and repo to enable)")
 			}
 
 			// Wire REST API handler for dashboard.
@@ -194,6 +191,16 @@ func serveCmd() *cobra.Command {
 			apiHandler.SetMetrics(nil, nil, metrics.NewSystemCollector())
 			cfg.APIHandler = apiHandler
 			slog.Info("REST API enabled")
+
+			// Wire worker lister from API into MCP digest so the get_digest tool
+			// shows registered PC agent workers in the RUNTIME METRICS section.
+			if mcpHandler != nil {
+				mcpHandler.SetWorkerLister(&apiWorkerAdapter{api: apiHandler})
+				cfg.MCPHandler = internalmcp.NewHTTPHandler(mcpHandler)
+				slog.Info("MCP handler enabled", "owner", owner, "repo", repo)
+			} else {
+				slog.Info("MCP handler disabled (set GITHUB_TOKEN, owner, and repo to enable)")
+			}
 
 			s := server.New(cfg)
 			slog.Info("starting samverk server", "addr", addr)
@@ -678,6 +685,28 @@ func versionCmd() *cobra.Command {
 				version.Version, version.GitCommit, version.BuildDate)
 		},
 	}
+}
+
+// apiWorkerAdapter bridges api.WorkerRecord to mcp.WorkerInfo without
+// creating an import cycle between the api and mcp packages.
+type apiWorkerAdapter struct{ api *api.API }
+
+func (a *apiWorkerAdapter) ListWorkers() []internalmcp.WorkerInfo {
+	records := a.api.ListWorkers()
+	out := make([]internalmcp.WorkerInfo, len(records))
+	for i := range records {
+		r := &records[i]
+		out[i] = internalmcp.WorkerInfo{
+			AgentID:         r.AgentID,
+			Hostname:        r.Hostname,
+			Status:          string(r.Status),
+			CurrentTask:     r.CurrentTask,
+			ActiveWorktrees: r.ActiveWorktrees,
+			CPUPercent:      r.CPUPercent,
+			MemoryPercent:   r.MemoryPercent,
+		}
+	}
+	return out
 }
 
 // providerFactory constructs a provider.Provider from YAML config.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -34,6 +34,7 @@ type API struct {
 	pool           poolMetricsSource       // may be nil if pool not yet started
 	dispatcher     dispatcherMetricsSource // may be nil if dispatcher not started
 	system         systemMetricsSource     // may be nil; created via SetMetrics
+	workers        *workerRegistry         // in-memory registry of PC agent workers
 	scalingEnabled bool                    // true when autoscaler was configured
 	scalingMin     int
 	scalingMax     int
@@ -47,6 +48,7 @@ func New(tracker forge.IssueTracker, s store.Store, costs digest.CostSource) *AP
 		tracker: tracker,
 		store:   s,
 		costs:   costs,
+		workers: newWorkerRegistry(),
 	}
 }
 
@@ -79,6 +81,9 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/scaling/pause", a.handleScalingPause)
 	mux.HandleFunc("POST /api/v1/scaling/resume", a.handleScalingResume)
 	mux.HandleFunc("POST /api/v1/scaling/set", a.handleScalingSet)
+	mux.HandleFunc("GET /api/v1/workers", a.handleListWorkers)
+	mux.HandleFunc("POST /api/v1/workers/register", a.handleRegisterWorker)
+	mux.HandleFunc("POST /api/v1/workers/heartbeat", a.handleWorkerHeartbeat)
 }
 
 // errorResponse is the JSON body returned for error responses.

--- a/internal/api/workers.go
+++ b/internal/api/workers.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// workerStaleThreshold is the maximum time between heartbeats before a worker
+// is considered offline.
+const workerStaleThreshold = 5 * time.Minute
+
+// WorkerStatus represents the operational state of a PC agent worker.
+type WorkerStatus string
+
+const (
+	WorkerStatusIdle    WorkerStatus = "idle"
+	WorkerStatusBusy    WorkerStatus = "busy"
+	WorkerStatusOffline WorkerStatus = "offline"
+)
+
+// WorkerRecord holds registration and heartbeat state for a single PC agent.
+type WorkerRecord struct {
+	AgentID         string       `json:"agent_id"`
+	Hostname        string       `json:"hostname"`
+	Capabilities    []string     `json:"capabilities"`
+	MaxConcurrent   int          `json:"max_concurrent"`
+	WorkspaceRoot   string       `json:"workspace_root"`
+	Status          WorkerStatus `json:"status"`
+	CurrentTask     *int         `json:"current_task,omitempty"`
+	CPUPercent      float64      `json:"cpu_percent"`
+	MemoryPercent   float64      `json:"memory_percent"`
+	ActiveWorktrees int          `json:"active_worktrees"`
+	RegisteredAt    time.Time    `json:"registered_at"`
+	LastHeartbeat   time.Time    `json:"last_heartbeat"`
+}
+
+// workerRegistry stores registered PC agent workers in memory.
+type workerRegistry struct {
+	mu      sync.RWMutex
+	workers map[string]*WorkerRecord
+}
+
+func newWorkerRegistry() *workerRegistry {
+	return &workerRegistry{
+		workers: make(map[string]*WorkerRecord),
+	}
+}
+
+// register adds or refreshes a worker record.
+func (r *workerRegistry) register(req registerRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	if existing, ok := r.workers[req.AgentID]; ok {
+		existing.Hostname = req.Hostname
+		existing.Capabilities = req.Capabilities
+		existing.MaxConcurrent = req.MaxConcurrent
+		existing.WorkspaceRoot = req.WorkspaceRoot
+		existing.Status = WorkerStatusIdle
+		existing.LastHeartbeat = now
+		return
+	}
+	r.workers[req.AgentID] = &WorkerRecord{
+		AgentID:       req.AgentID,
+		Hostname:      req.Hostname,
+		Capabilities:  req.Capabilities,
+		MaxConcurrent: req.MaxConcurrent,
+		WorkspaceRoot: req.WorkspaceRoot,
+		Status:        WorkerStatusIdle,
+		RegisteredAt:  now,
+		LastHeartbeat: now,
+	}
+}
+
+// heartbeat updates an existing worker's live metrics.
+// Returns false if the agent_id is unknown.
+func (r *workerRegistry) heartbeat(req heartbeatRequest) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rec, ok := r.workers[req.AgentID]
+	if !ok {
+		return false
+	}
+	rec.Status = req.Status
+	rec.CurrentTask = req.CurrentTask
+	rec.CPUPercent = req.CPUPercent
+	rec.MemoryPercent = req.MemoryPercent
+	rec.ActiveWorktrees = req.ActiveWorktrees
+	rec.LastHeartbeat = time.Now()
+	return true
+}
+
+// list returns a snapshot of all workers. Workers that have not sent a heartbeat
+// within workerStaleThreshold are reported as offline.
+func (r *workerRegistry) list() []WorkerRecord {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]WorkerRecord, 0, len(r.workers))
+	cutoff := time.Now().Add(-workerStaleThreshold)
+	for _, rec := range r.workers {
+		snap := *rec
+		if rec.LastHeartbeat.Before(cutoff) {
+			snap.Status = WorkerStatusOffline
+		}
+		result = append(result, snap)
+	}
+	return result
+}
+
+// --- Request types ---
+
+type registerRequest struct {
+	AgentID       string   `json:"agent_id"`
+	Hostname      string   `json:"hostname"`
+	Capabilities  []string `json:"capabilities"`
+	MaxConcurrent int      `json:"max_concurrent"`
+	WorkspaceRoot string   `json:"workspace_root"`
+}
+
+type heartbeatRequest struct {
+	AgentID         string       `json:"agent_id"`
+	Status          WorkerStatus `json:"status"`
+	CurrentTask     *int         `json:"current_task"`
+	CPUPercent      float64      `json:"cpu_percent"`
+	MemoryPercent   float64      `json:"memory_percent"`
+	ActiveWorktrees int          `json:"active_worktrees"`
+}
+
+// --- HTTP handlers ---
+
+// ListWorkers returns a snapshot of all registered workers for external consumers
+// (e.g. the MCP digest). Stale workers are marked offline in the returned slice.
+func (a *API) ListWorkers() []WorkerRecord {
+	return a.workers.list()
+}
+
+// handleRegisterWorker handles POST /api/v1/workers/register.
+func (a *API) handleRegisterWorker(w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if req.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+	a.workers.register(req)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "registered"})
+}
+
+// handleWorkerHeartbeat handles POST /api/v1/workers/heartbeat.
+// Unknown agents are auto-registered to handle restart scenarios where
+// the server restarted since the agent last registered.
+func (a *API) handleWorkerHeartbeat(w http.ResponseWriter, r *http.Request) {
+	var req heartbeatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if req.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+	if !a.workers.heartbeat(req) {
+		// Auto-register: server may have restarted since the agent last registered.
+		a.workers.register(registerRequest{AgentID: req.AgentID, MaxConcurrent: 1})
+		a.workers.heartbeat(req)
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleListWorkers handles GET /api/v1/workers.
+func (a *API) handleListWorkers(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, a.workers.list())
+}

--- a/internal/api/workers_test.go
+++ b/internal/api/workers_test.go
@@ -1,0 +1,158 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// doPost is a test helper that sends a POST with a JSON body.
+func doPost(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url,
+		bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	return resp
+}
+
+// doPostBytes is a test helper that sends a POST with raw JSON bytes.
+func doPostBytes(t *testing.T, url string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url,
+		bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	return resp
+}
+
+func TestRegisterWorker(t *testing.T) {
+	ts := newTestAPI(t, nil, nil, nil)
+
+	body := `{"agent_id":"pc-worker","hostname":"HDH-NZXT","capabilities":["code-gen","test"],"max_concurrent":1,"workspace_root":"D:\\bots"}`
+	resp := doPost(t, ts.URL+"/api/v1/workers/register", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestRegisterWorkerMissingAgentID(t *testing.T) {
+	ts := newTestAPI(t, nil, nil, nil)
+
+	body := `{"hostname":"HDH-NZXT"}`
+	resp := doPost(t, ts.URL+"/api/v1/workers/register", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestWorkerHeartbeat(t *testing.T) {
+	ts := newTestAPI(t, nil, nil, nil)
+
+	// Register first.
+	reg := `{"agent_id":"pc-worker","hostname":"HDH-NZXT","capabilities":["code-gen"],"max_concurrent":1}`
+	regResp := doPost(t, ts.URL+"/api/v1/workers/register", reg)
+	_ = regResp.Body.Close()
+
+	// Send heartbeat.
+	hb := `{"agent_id":"pc-worker","status":"busy","current_task":42,"cpu_percent":35.5,"memory_percent":48.0,"active_worktrees":1}`
+	resp := doPost(t, ts.URL+"/api/v1/workers/heartbeat", hb)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestWorkerHeartbeatAutoRegister(t *testing.T) {
+	ts := newTestAPI(t, nil, nil, nil)
+
+	// Heartbeat without prior registration — should auto-register.
+	hb := `{"agent_id":"unknown-worker","status":"idle","cpu_percent":10.0,"memory_percent":20.0}`
+	resp := doPost(t, ts.URL+"/api/v1/workers/heartbeat", hb)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+
+	// Should now appear in the worker list.
+	listResp := doGet(t, ts.URL+"/api/v1/workers")
+	defer func() { _ = listResp.Body.Close() }()
+
+	var workers []map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&workers); err != nil {
+		t.Fatalf("decode workers: %v", err)
+	}
+	if len(workers) != 1 {
+		t.Errorf("want 1 worker, got %d", len(workers))
+	}
+}
+
+func TestListWorkers(t *testing.T) {
+	ts := newTestAPI(t, nil, nil, nil)
+
+	// Register two workers.
+	for _, id := range []string{"pc-worker-1", "pc-worker-2"} {
+		body, _ := json.Marshal(map[string]any{
+			"agent_id":       id,
+			"hostname":       "host-" + id,
+			"capabilities":   []string{"code-gen"},
+			"max_concurrent": 1,
+		})
+		regResp := doPostBytes(t, ts.URL+"/api/v1/workers/register", body)
+		_ = regResp.Body.Close()
+	}
+
+	resp := doGet(t, ts.URL+"/api/v1/workers")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+
+	var workers []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&workers); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(workers) != 2 {
+		t.Errorf("want 2 workers, got %d", len(workers))
+	}
+}
+
+func TestListWorkersEmpty(t *testing.T) {
+	ts := newTestAPI(t, nil, nil, nil)
+
+	resp := doGet(t, ts.URL+"/api/v1/workers")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+
+	var workers []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&workers); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(workers) != 0 {
+		t.Errorf("want 0 workers, got %d", len(workers))
+	}
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -29,6 +29,7 @@ type Handler struct {
 	dispM         dispatcherMetricsSource // may be nil (dispatcher not running here)
 	sysM          systemMetricsSource     // may be nil
 	scalingEvents scalingEventReader      // may be nil (reads from store)
+	workersM      workerLister            // may be nil (no PC agent workers registered)
 }
 
 // NewHandler creates a new MCP tool handler with its dependencies.
@@ -58,6 +59,11 @@ func (h *Handler) SetPRManager(prm forge.PullRequestManager) {
 // When set, tools resolve tracker and repo through the active project.
 func (h *Handler) SetProjects(reg *ProjectRegistry) {
 	h.projects = reg
+}
+
+// SetWorkerLister attaches a worker lister so the digest includes PC agent status.
+func (h *Handler) SetWorkerLister(wl workerLister) {
+	h.workersM = wl
 }
 
 // activeTracker returns the IssueTracker to use for the current context.

--- a/internal/mcp/metrics.go
+++ b/internal/mcp/metrics.go
@@ -30,6 +30,23 @@ type scalingEventReader interface {
 	ListScalingEvents(ctx context.Context, limit int) ([]*models.ScalingEvent, error)
 }
 
+// WorkerInfo is a summary of a registered PC agent worker for digest output.
+type WorkerInfo struct {
+	AgentID         string
+	Hostname        string
+	Status          string
+	CurrentTask     *int
+	ActiveWorktrees int
+	CPUPercent      float64
+	MemoryPercent   float64
+}
+
+// workerLister provides registered worker snapshots for the digest.
+// api.API satisfies this interface via ListWorkers.
+type workerLister interface {
+	ListWorkers() []WorkerInfo
+}
+
 // SetMetrics attaches runtime metrics sources to the handler.
 // Sources may be nil; only non-nil sources appear in the digest.
 func (h *Handler) SetMetrics(pool poolMetricsSource, disp dispatcherMetricsSource, sys systemMetricsSource) {
@@ -46,7 +63,7 @@ func (h *Handler) SetScalingEventReader(r scalingEventReader) {
 
 // formatMetricsSection renders a brief METRICS block appended to the digest text.
 func (h *Handler) formatMetricsSection() string {
-	if h.poolM == nil && h.dispM == nil && h.sysM == nil && h.scalingEvents == nil {
+	if h.poolM == nil && h.dispM == nil && h.sysM == nil && h.scalingEvents == nil && h.workersM == nil {
 		return ""
 	}
 
@@ -96,6 +113,25 @@ func (h *Handler) formatMetricsSection() string {
 					e.Reason,
 					e.Confidence*100,
 				)
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	if h.workersM != nil {
+		workers := h.workersM.ListWorkers()
+		if len(workers) > 0 {
+			b.WriteString("PC Workers:")
+			for _, w := range workers {
+				task := "idle"
+				if w.CurrentTask != nil {
+					task = fmt.Sprintf("issue #%d", *w.CurrentTask)
+				}
+				fmt.Fprintf(&b, "\n  %s (%s) — %s | worktrees: %d | cpu: %.0f%% mem: %.0f%%",
+					w.AgentID, w.Hostname, task, w.ActiveWorktrees, w.CPUPercent, w.MemoryPercent)
+				if w.Status == "offline" {
+					b.WriteString(" [OFFLINE]")
+				}
 			}
 			b.WriteString("\n")
 		}

--- a/scripts/pc-agent/agent-loop.ps1
+++ b/scripts/pc-agent/agent-loop.ps1
@@ -77,12 +77,14 @@ Import-Module (Join-Path $script:ModuleDir 'forge.psm1')      -Force
 Import-Module (Join-Path $script:ModuleDir 'launcher.psm1')   -Force
 Import-Module (Join-Path $script:ModuleDir 'post-task.psm1')  -Force
 Import-Module (Join-Path $script:ModuleDir 'autonomy.psm1')   -Force
+Import-Module (Join-Path $script:ModuleDir 'registration.psm1') -Force
 
 # ---------------------------------------------------------------------------
 # Graceful shutdown
 # ---------------------------------------------------------------------------
 
 $script:StopRequested = $false
+$script:CurrentTask   = $null  # Shared with heartbeat thread: issue number or $null
 
 # Trap Ctrl-C so the loop can finish the current task before exiting.
 $null = [Console]::TreatControlCAsInput = $false
@@ -169,7 +171,9 @@ function Invoke-PollCycle {
 
     # 5. Run CC in an isolated worktree.
     Write-AgentLog "Launching CC task for issue #$($issue.Number)..."
+    $script:CurrentTask = $issue.Number
     $ccResult = Invoke-CCTask -Issue $issue -WorkspaceConfig $WorkspaceConfig
+    $script:CurrentTask = $null
 
     $durationStr = '{0:N0}m {1:N0}s' -f `
         [Math]::Floor($ccResult.Duration.TotalMinutes), ($ccResult.Duration.Seconds % 60)
@@ -220,6 +224,15 @@ $forgeConfig    = Get-ForgeConfig
 
 $iterationCount = 0
 
+# Register with Samverk server and start background heartbeat.
+try {
+    Register-PCAgent -WorkspaceRoot $wsConfig.Root
+    Start-HeartbeatLoop -WorkspaceRoot $wsConfig.Root
+} catch {
+    Write-AgentLog "Could not register with Samverk server: $($_.Exception.Message)" 'WARN'
+    Write-AgentLog 'Continuing without server registration -- PC workers section in digest will be empty.' 'WARN'
+}
+
 while (-not $script:StopRequested) {
     $iterationCount++
     Write-AgentLog "--- Poll cycle #$iterationCount ---"
@@ -252,4 +265,5 @@ while (-not $script:StopRequested) {
 }
 
 Write-AgentLog 'Stop requested -- exiting cleanly.'
+Stop-HeartbeatLoop
 exit 0

--- a/scripts/pc-agent/registration.psm1
+++ b/scripts/pc-agent/registration.psm1
@@ -1,0 +1,316 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    PC Agent registration and heartbeat -- keeps the Samverk server aware of this
+    worker node and its live metrics.
+
+.DESCRIPTION
+    Provides three public functions:
+
+        Register-PCAgent       -- POST /api/v1/workers/register on startup
+        Send-Heartbeat         -- POST /api/v1/workers/heartbeat with live metrics
+        Start-HeartbeatLoop    -- Starts a background thread that calls Send-Heartbeat
+                                  every HeartbeatIntervalSeconds (default 150s) until
+                                  Stop-HeartbeatLoop is called
+        Stop-HeartbeatLoop     -- Stops the background heartbeat thread
+
+    Configuration via environment variables:
+
+        SAMVERK_SERVER_URL     Base URL of the Samverk server  (default: http://localhost:8080)
+        SAMVERK_AUTH_TOKEN     Bearer token for API auth       (optional)
+
+    The agent_id is derived from the machine hostname. It must be stable across
+    restarts so the server can correlate heartbeats with the registration record.
+#>
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+$script:HeartbeatJob = $null
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+function Get-ServerURL {
+    $url = $env:SAMVERK_SERVER_URL
+    if (-not $url) { $url = 'http://localhost:8080' }
+    return $url.TrimEnd('/')
+}
+
+function Get-AuthHeaders {
+    $headers = @{ 'Content-Type' = 'application/json' }
+    if ($env:SAMVERK_AUTH_TOKEN) {
+        $headers['Authorization'] = "Bearer $($env:SAMVERK_AUTH_TOKEN)"
+    }
+    return $headers
+}
+
+function Get-AgentID {
+    # Use the machine hostname as a stable, human-readable agent identifier.
+    return $env:COMPUTERNAME.ToLower()
+}
+
+function Get-CPUPercent {
+    try {
+        $sample = Get-CimInstance Win32_Processor -ErrorAction SilentlyContinue |
+            Measure-Object -Property LoadPercentage -Average
+        if ($null -ne $sample -and $null -ne $sample.Average) {
+            return [double]$sample.Average
+        }
+    } catch {
+        # Non-fatal -- return 0 on error.
+    }
+    return 0.0
+}
+
+function Get-MemoryPercent {
+    try {
+        $os = Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue
+        if ($os -and $os.TotalVisibleMemorySize -gt 0) {
+            $used = $os.TotalVisibleMemorySize - $os.FreePhysicalMemory
+            return [Math]::Round(($used / $os.TotalVisibleMemorySize) * 100.0, 1)
+        }
+    } catch {
+        # Non-fatal.
+    }
+    return 0.0
+}
+
+function Get-ActiveWorktreeCount {
+    param([string]$WorkspaceRoot = 'D:\bots')
+    try {
+        $count = (Get-ChildItem -Path $WorkspaceRoot -Directory -Filter 'worker-*' -ErrorAction SilentlyContinue).Count
+        return [int]$count
+    } catch {
+        return 0
+    }
+}
+
+function Invoke-RegistrationRequest {
+    param(
+        [string]$Path,
+        [hashtable]$Body
+    )
+    $url     = (Get-ServerURL) + $Path
+    $headers = Get-AuthHeaders
+    $json    = $Body | ConvertTo-Json -Compress -Depth 5
+    $bytes   = [System.Text.Encoding]::UTF8.GetBytes($json)
+
+    try {
+        $resp = Invoke-WebRequest -Uri $url -Method POST -Headers $headers `
+            -Body $bytes -ContentType 'application/json' `
+            -TimeoutSec 10 -UseBasicParsing -ErrorAction Stop
+        return $resp.StatusCode
+    } catch [System.Net.WebException] {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+        throw "HTTP $statusCode from $url : $($_.Exception.Message)"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+function Register-PCAgent {
+    <#
+    .SYNOPSIS
+        Registers this PC agent with the Samverk server. Call once on startup.
+
+    .PARAMETER Capabilities
+        List of capability tags sent to the server (e.g. 'codegen', 'go', 'react').
+        Defaults to a generic set.
+
+    .PARAMETER MaxConcurrent
+        Maximum number of concurrent tasks this agent supports. Default: 1.
+
+    .PARAMETER WorkspaceRoot
+        Root directory containing worker-* worktrees. Default: D:\bots.
+    #>
+    [CmdletBinding()]
+    param(
+        [string[]]$Capabilities = @('codegen', 'go', 'react', 'windows'),
+        [int]$MaxConcurrent = 1,
+        [string]$WorkspaceRoot = 'D:\bots'
+    )
+
+    $body = @{
+        agent_id       = Get-AgentID
+        hostname       = $env:COMPUTERNAME
+        capabilities   = $Capabilities
+        max_concurrent = $MaxConcurrent
+        workspace_root = $WorkspaceRoot
+    }
+
+    $status = Invoke-RegistrationRequest -Path '/api/v1/workers/register' -Body $body
+    Write-Host "[registration] Registered with Samverk server (HTTP $status). agent_id=$(Get-AgentID)"
+}
+
+function Send-Heartbeat {
+    <#
+    .SYNOPSIS
+        Sends a single heartbeat to the Samverk server with live worker metrics.
+
+    .PARAMETER CurrentTask
+        Issue number of the task currently being processed. Omit when idle.
+
+    .PARAMETER Status
+        Worker status string: 'idle' or 'busy'. Defaults to 'idle'.
+
+    .PARAMETER WorkspaceRoot
+        Root directory containing worker-* worktrees. Default: D:\bots.
+    #>
+    [CmdletBinding()]
+    param(
+        [Nullable[int]]$CurrentTask = $null,
+        [string]$Status = 'idle',
+        [string]$WorkspaceRoot = 'D:\bots'
+    )
+
+    $body = @{
+        agent_id         = Get-AgentID
+        status           = $Status
+        cpu_percent      = Get-CPUPercent
+        memory_percent   = Get-MemoryPercent
+        active_worktrees = Get-ActiveWorktreeCount -WorkspaceRoot $WorkspaceRoot
+    }
+
+    if ($null -ne $CurrentTask) {
+        $body['current_task'] = $CurrentTask
+    }
+
+    Invoke-RegistrationRequest -Path '/api/v1/workers/heartbeat' -Body $body | Out-Null
+}
+
+function Start-HeartbeatLoop {
+    <#
+    .SYNOPSIS
+        Starts a background thread that sends heartbeats on a fixed interval.
+
+    .DESCRIPTION
+        Runs a thread job (Start-ThreadJob) that calls Send-Heartbeat every
+        HeartbeatIntervalSeconds. The thread is stored in $script:HeartbeatJob.
+        Call Stop-HeartbeatLoop to terminate it cleanly.
+
+        The shared variable $script:CurrentTask should be set by the main loop
+        before each task and cleared (set to $null) after the task completes.
+        The heartbeat thread reads this value on each cycle.
+
+    .PARAMETER HeartbeatIntervalSeconds
+        Seconds between heartbeat calls. Default: 150 (2.5 minutes), which is
+        safely within the 5-minute server-side stale threshold.
+
+    .PARAMETER WorkspaceRoot
+        Root directory containing worker-* worktrees. Default: D:\bots.
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$HeartbeatIntervalSeconds = 150,
+        [string]$WorkspaceRoot = 'D:\bots'
+    )
+
+    if ($script:HeartbeatJob -and $script:HeartbeatJob.State -eq 'Running') {
+        Write-Host "[registration] Heartbeat loop already running."
+        return
+    }
+
+    # Capture values for the thread closure.
+    $interval      = $HeartbeatIntervalSeconds
+    $wsRoot        = $WorkspaceRoot
+    $serverURL     = Get-ServerURL
+    $authToken     = $env:SAMVERK_AUTH_TOKEN
+    $agentID       = Get-AgentID
+    $hostname      = $env:COMPUTERNAME
+
+    $script:HeartbeatJob = Start-ThreadJob -ScriptBlock {
+        param($interval, $wsRoot, $serverURL, $authToken, $agentID, $hostname)
+
+        function hb-cpu {
+            try {
+                $s = Get-CimInstance Win32_Processor -ErrorAction SilentlyContinue |
+                    Measure-Object -Property LoadPercentage -Average
+                if ($s -and $s.Average) { return [double]$s.Average }
+            } catch {}
+            return 0.0
+        }
+
+        function hb-mem {
+            try {
+                $os = Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue
+                if ($os -and $os.TotalVisibleMemorySize -gt 0) {
+                    $used = $os.TotalVisibleMemorySize - $os.FreePhysicalMemory
+                    return [Math]::Round(($used / $os.TotalVisibleMemorySize) * 100.0, 1)
+                }
+            } catch {}
+            return 0.0
+        }
+
+        function hb-worktrees {
+            try {
+                return [int](Get-ChildItem -Path $wsRoot -Directory -Filter 'worker-*' -ErrorAction SilentlyContinue).Count
+            } catch { return 0 }
+        }
+
+        function hb-send {
+            param($status, $currentTask)
+            $body = @{
+                agent_id         = $agentID
+                status           = $status
+                cpu_percent      = hb-cpu
+                memory_percent   = hb-mem
+                active_worktrees = hb-worktrees
+            }
+            if ($null -ne $currentTask) { $body['current_task'] = $currentTask }
+
+            $json  = $body | ConvertTo-Json -Compress -Depth 3
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+            $hdrs  = @{ 'Content-Type' = 'application/json' }
+            if ($authToken) { $hdrs['Authorization'] = "Bearer $authToken" }
+
+            try {
+                $null = Invoke-WebRequest -Uri "$serverURL/api/v1/workers/heartbeat" `
+                    -Method POST -Headers $hdrs -Body $bytes `
+                    -TimeoutSec 10 -UseBasicParsing -ErrorAction Stop
+            } catch {
+                # Heartbeat failure is non-fatal -- log and continue.
+                Write-Host "[heartbeat] Warning: $($_.Exception.Message)"
+            }
+        }
+
+        while ($true) {
+            Start-Sleep -Seconds $interval
+            # Read the shared current-task variable from the parent runspace (best-effort).
+            try {
+                $ct = $using:script:CurrentTask
+                $st = if ($null -ne $ct) { 'busy' } else { 'idle' }
+                hb-send -status $st -currentTask $ct
+            } catch {
+                hb-send -status 'idle' -currentTask $null
+            }
+        }
+    } -ArgumentList $interval, $wsRoot, $serverURL, $authToken, $agentID, $hostname
+
+    Write-Host "[registration] Heartbeat loop started (interval=${interval}s)."
+}
+
+function Stop-HeartbeatLoop {
+    <#
+    .SYNOPSIS
+        Stops the background heartbeat thread started by Start-HeartbeatLoop.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if (-not $script:HeartbeatJob) { return }
+
+    Stop-Job  -Job $script:HeartbeatJob -ErrorAction SilentlyContinue
+    Remove-Job -Job $script:HeartbeatJob -Force -ErrorAction SilentlyContinue
+    $script:HeartbeatJob = $null
+    Write-Host "[registration] Heartbeat loop stopped."
+}
+
+Export-ModuleMember -Function Register-PCAgent, Send-Heartbeat, Start-HeartbeatLoop, Stop-HeartbeatLoop


### PR DESCRIPTION
## Summary

- Adds a REST worker registry (`GET/POST /api/v1/workers/*`) so PC agent instances register their presence and send periodic heartbeats to the Samverk server
- Exposes registered workers in the `get_digest` MCP tool under a new **PC Workers** section (agent ID, hostname, status, current task, CPU/memory)
- Bridges the API and MCP packages via an `apiWorkerAdapter` in `main.go` to avoid import cycles
- Adds `registration.psm1` PowerShell module (`Register-PCAgent`, `Send-Heartbeat`, `Start-HeartbeatLoop`) and wires it into `agent-loop.ps1` so the loop registers on startup and sends background heartbeats every 150 seconds

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (6 new tests in `internal/api/workers_test.go`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `markdownlint` — 0 issues
- [x] Pre-push hook green on both GitHub and Gitea

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)