### PR TITLE
feat(#277): ErrNotSupported for Gitea search_code + MCP friendly message

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -8,8 +8,14 @@ package forge
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrNotSupported is returned by forge operations that are not available on
+// the current platform (e.g. code search on Gitea). Callers can check with
+// errors.Is to present a user-friendly "not available on this forge" message.
+var ErrNotSupported = errors.New("forge: operation not supported on this platform")
 
 // State represents the open/closed state of an issue.
 type State string

--- a/internal/forge/gitea/gitea.go
+++ b/internal/forge/gitea/gitea.go
@@ -485,9 +485,9 @@ func extractAssigneeLogins(users []*gogitea.User) []string {
 	return result
 }
 
-// ErrNotImplemented is returned by Gitea methods that are not yet implemented.
-// Currently used by SearchCode, which has no equivalent in Gitea SDK v0.23.2.
-var ErrNotImplemented = fmt.Errorf("gitea: not implemented")
+// errNotImplemented is an internal alias for forge.ErrNotSupported used by
+// Gitea methods that have no equivalent in Gitea SDK v0.23.2 (e.g. SearchCode).
+var errNotImplemented = forge.ErrNotSupported
 
 // stringSliceEqual reports whether two string slices have the same elements.
 func stringSliceEqual(a, b []string) bool {

--- a/internal/forge/gitea/repo.go
+++ b/internal/forge/gitea/repo.go
@@ -130,9 +130,9 @@ func (c *Client) GetCommitLog(_ context.Context, branch string, limit int) ([]fo
 }
 
 // SearchCode is not supported by the Gitea SDK v0.23.2 at the repo scope.
-// It always returns ErrNotImplemented.
+// It returns forge.ErrNotSupported so callers can surface a friendly message.
 func (c *Client) SearchCode(_ context.Context, _ string) ([]forge.SearchResult, error) {
-	return []forge.SearchResult{}, ErrNotImplemented
+	return []forge.SearchResult{}, errNotImplemented
 }
 
 // CreateBranch creates a new branch from "main" HEAD.

--- a/internal/forge/gitea/repo_test.go
+++ b/internal/forge/gitea/repo_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	gogitea "code.gitea.io/sdk/gitea"
+
+	"github.com/herbhall/samverk/internal/forge"
 )
 
 func TestCreateBranch(t *testing.T) {
@@ -368,8 +370,8 @@ func TestSearchCode_NotImplemented(t *testing.T) {
 	c, _ := newTestClient(t, handler)
 
 	results, err := c.SearchCode(context.Background(), "some query")
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("err = %v, want ErrNotImplemented", err)
+	if !errors.Is(err, forge.ErrNotSupported) {
+		t.Errorf("err = %v, want forge.ErrNotSupported", err)
 	}
 	if results == nil {
 		t.Error("expected non-nil empty slice, got nil")

--- a/internal/mcp/tools_repo.go
+++ b/internal/mcp/tools_repo.go
@@ -3,10 +3,13 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/herbhall/samverk/internal/forge"
 )
 
 // listFilesInput is the typed input for the list_files tool.
@@ -286,6 +289,13 @@ func (h *Handler) handleSearchCode(
 
 	results, err := h.activeReader().SearchCode(ctx, input.Query)
 	if err != nil {
+		if errors.Is(err, forge.ErrNotSupported) {
+			return &gosdk.CallToolResult{
+				Content: []gosdk.Content{
+					&gosdk.TextContent{Text: "search_code is not available on this forge platform (Gitea does not expose repo-scoped code search via its SDK)"},
+				},
+			}, nil, nil
+		}
 		return nil, nil, fmt.Errorf("searching code: %w", err)
 	}
 

--- a/internal/mcp/tools_repo_test.go
+++ b/internal/mcp/tools_repo_test.go
@@ -14,12 +14,13 @@ import (
 
 // mockRepoReader implements forge.RepoReader for testing.
 type mockRepoReader struct {
-	files    []forge.FileEntry
-	fileData []byte
-	diff     string
-	branches []forge.Branch
-	commits  []forge.Commit
-	search   []forge.SearchResult
+	files     []forge.FileEntry
+	fileData  []byte
+	diff      string
+	branches  []forge.Branch
+	commits   []forge.Commit
+	search    []forge.SearchResult
+	searchErr error // if set, SearchCode returns this error
 }
 
 func (m *mockRepoReader) ListFiles(_ context.Context, _, _ string) ([]forge.FileEntry, error) {
@@ -43,7 +44,7 @@ func (m *mockRepoReader) GetCommitLog(_ context.Context, _ string, _ int) ([]for
 }
 
 func (m *mockRepoReader) SearchCode(_ context.Context, _ string) ([]forge.SearchResult, error) {
-	return m.search, nil
+	return m.search, m.searchErr
 }
 
 // newTestMCPServerWithRepo sets up an httptest.Server with a RepoReader.
@@ -446,6 +447,48 @@ func TestSearchCode_EmptyQuery(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Error("expected isError=true for empty query")
+	}
+}
+
+func TestSearchCode_NotSupported(t *testing.T) {
+	// When the forge returns ErrNotSupported (e.g. Gitea), search_code should
+	// return a user-friendly message rather than a protocol-level error.
+	repo := &mockRepoReader{searchErr: forge.ErrNotSupported}
+	ts := newTestMCPServerWithRepo(t, &mockTracker{}, repo)
+
+	respBody := postJSON(t, ts.URL, jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      11,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "search_code",
+			"arguments": map[string]any{
+				"query": "something",
+			},
+		},
+	})
+
+	var resp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, respBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected protocol error: %s", resp.Error)
+	}
+	var result callToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.IsError {
+		t.Error("expected isError=false (friendly message, not tool error)")
+	}
+	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "not available") {
+		t.Errorf("expected 'not available' message, got %q", func() string {
+			if len(result.Content) > 0 {
+				return result.Content[0].Text
+			}
+			return "<empty>"
+		}())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `forge.ErrNotSupported` sentinel to `internal/forge` package — callers can now detect unsupported platform operations without importing `forge/gitea`
- Gitea's `SearchCode` returns `forge.ErrNotSupported` instead of a package-local error
- MCP `search_code` handler detects this sentinel and returns a user-friendly text response rather than a protocol-level tool error
- Adds `TestSearchCode_NotSupported` to verify the friendly-message path

## What was already working

The exploration confirmed all other MCP tools work correctly against Gitea via the existing `ProjectRegistry` pattern:
- `set_project` switches the active forge — all subsequent calls use the Gitea adapter
- `list_issues`, `create_issue`, `get_issue` — fully implemented in Gitea adapter
- `list_files`, `read_file`, `get_diff`, `list_branches`, `get_commit_log` — fully implemented
- `create_pr`, `list_prs`, `merge_pr` — fully implemented (compile-time interface guards in place)

The only gap was `search_code` surfacing a confusing internal error rather than a clear "not available on this platform" message.

## Test plan

- [x] `go test ./internal/forge/... ./internal/mcp/...` passes
- [x] `TestSearchCode_NotSupported` verifies friendly message path
- [x] `TestSearchCode_NotImplemented` (gitea package) updated to use `forge.ErrNotSupported`

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)