### PR TITLE
feat(#240): runner heartbeat integration (Phase 0)

### DIFF
--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -27,10 +27,11 @@ const defaultWorkers = 3
 
 // Task represents a unit of work to be processed by the agent pool.
 type Task struct {
-	Issue       *forge.Issue
-	AgentType   models.AgentType
-	SessionID   string
-	ProviderKey string // routing chain key; defaults to string(AgentType) when empty
+	Issue         *forge.Issue
+	AgentType     models.AgentType
+	SessionID     string
+	ProviderKey   string // routing chain key; defaults to string(AgentType) when empty
+	HeartbeatFunc func() // called periodically while running; signals dispatcher that work is in progress; may be nil
 }
 
 // TaskResult reports the outcome of a pool task back to the dispatcher.

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -16,6 +16,12 @@ import (
 	"github.com/herbhall/samverk/pkg/models"
 )
 
+// heartbeatPulseInterval is how often the runner calls task.HeartbeatFunc
+// during the blocking provider.Chat() call to prevent the dispatcher from
+// treating the session as hung. Must be well below the dispatcher timeout
+// (HeartbeatInterval × HeartbeatTimeoutMultiplier, default 30 min).
+const heartbeatPulseInterval = 5 * time.Minute
+
 // Runner executes a single agent task: sends the issue to an AI provider,
 // records cost, and posts the response as an issue comment or opens a PR.
 type Runner struct {
@@ -99,7 +105,25 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		},
 	}
 
-	// Step 4: Call provider.
+	// Step 4: Call provider (with heartbeat ticker to keep dispatcher informed).
+	if task.HeartbeatFunc != nil {
+		task.HeartbeatFunc() // fire immediately before blocking call
+		stop := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(heartbeatPulseInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					task.HeartbeatFunc()
+				case <-stop:
+					return
+				}
+			}
+		}()
+		defer close(stop)
+	}
+
 	resp, err := r.provider.Chat(ctx, req)
 	if err != nil {
 		r.failTask(ctx, task, fmt.Sprintf("provider error: %v", err))

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -282,5 +282,74 @@ func TestRunnerTrackerError(t *testing.T) {
 	}
 }
 
+func TestRunnerHeartbeat(t *testing.T) {
+	var heartbeatCalls int
+
+	ms := newDefaultMockStore()
+	mp := &mockProvider{
+		chatFn: func(_ context.Context, _ provider.ChatRequest) (*provider.ChatResponse, error) {
+			return &provider.ChatResponse{
+				Message: provider.Message{
+					Role:    provider.RoleAssistant,
+					Content: "done",
+				},
+			}, nil
+		},
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test-provider" },
+	}
+	mt := &mockTracker{
+		addCommentFn: func(_ context.Context, _ int, _ string) (*forge.Comment, error) {
+			return &forge.Comment{ID: 1}, nil
+		},
+	}
+
+	runner := newTestRunner(mp, mt, ms)
+	task := newDefaultTask()
+	task.HeartbeatFunc = func() {
+		heartbeatCalls++
+	}
+
+	err := runner.Run(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	// HeartbeatFunc must be called at least once (immediately before Chat).
+	if heartbeatCalls < 1 {
+		t.Errorf("HeartbeatFunc called %d times, want >= 1", heartbeatCalls)
+	}
+}
+
+func TestRunnerHeartbeatNil(t *testing.T) {
+	// When HeartbeatFunc is nil the runner must not panic.
+	ms := newDefaultMockStore()
+	mp := &mockProvider{
+		chatFn: func(_ context.Context, _ provider.ChatRequest) (*provider.ChatResponse, error) {
+			return &provider.ChatResponse{
+				Message: provider.Message{
+					Role:    provider.RoleAssistant,
+					Content: "done",
+				},
+			}, nil
+		},
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test-provider" },
+	}
+	mt := &mockTracker{
+		addCommentFn: func(_ context.Context, _ int, _ string) (*forge.Comment, error) {
+			return &forge.Comment{ID: 1}, nil
+		},
+	}
+
+	runner := newTestRunner(mp, mt, ms)
+	task := newDefaultTask()
+	// HeartbeatFunc intentionally left nil.
+
+	if err := runner.Run(context.Background(), task); err != nil {
+		t.Fatalf("Run returned error with nil HeartbeatFunc: %v", err)
+	}
+}
+
 // Old buildSystemPrompt tests removed — replaced by prompts_test.go
 // which covers BuildSystemPrompt with per-agent-type verification.

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -200,11 +200,19 @@ func (d *Dispatcher) route(ctx context.Context, issue *forge.Issue, agentType mo
 		if err := d.store.CreateSession(ctx, session); err != nil {
 			return fmt.Errorf("create session for #%d: %w", issue.Number, err)
 		}
+		issueNum := issue.Number
 		task := agent.Task{
 			Issue:       issue,
 			AgentType:   agentType,
 			SessionID:   sessionID,
 			ProviderKey: providerKey,
+			HeartbeatFunc: func() {
+				d.mu.Lock()
+				if c, ok := d.claimed[issueNum]; ok {
+					c.LastHeartbeat = time.Now()
+				}
+				d.mu.Unlock()
+			},
 		}
 		if err := d.pool.Submit(task); err != nil {
 			return fmt.Errorf("submit agent task for #%d: %w", issue.Number, err)

--- a/internal/dispatcher/router_test.go
+++ b/internal/dispatcher/router_test.go
@@ -3,6 +3,7 @@ package dispatcher
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/pkg/models"
@@ -216,4 +217,64 @@ func TestSelectProviderKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHeartbeatFunc_UpdatesClaimedLastHeartbeat verifies the HeartbeatFunc closure
+// built inside route() correctly updates d.claimed[N].LastHeartbeat under the lock.
+// We test the closure directly to avoid the complexity of building a real agent.Pool.
+func TestHeartbeatFunc_UpdatesClaimedLastHeartbeat(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	const issueNum = 99
+	oldTime := time.Now().Add(-5 * time.Minute)
+
+	d.mu.Lock()
+	d.claimed[issueNum] = &claimedIssue{
+		AgentID:       "code-gen",
+		ClaimedAt:     oldTime,
+		LastHeartbeat: oldTime,
+	}
+	d.mu.Unlock()
+
+	// Build the same closure that route() injects into agent.Task.HeartbeatFunc.
+	heartbeatFunc := func() {
+		d.mu.Lock()
+		if c, ok := d.claimed[issueNum]; ok {
+			c.LastHeartbeat = time.Now()
+		}
+		d.mu.Unlock()
+	}
+
+	heartbeatFunc()
+
+	d.mu.Lock()
+	hb := d.claimed[issueNum].LastHeartbeat
+	d.mu.Unlock()
+
+	if !hb.After(oldTime) {
+		t.Errorf("LastHeartbeat not updated: got %v, want after %v", hb, oldTime)
+	}
+}
+
+// TestHeartbeatFunc_NoopWhenUnclaimed verifies the HeartbeatFunc does not panic
+// or error when the issue has already been removed from the claimed map (e.g.,
+// after dispatcher completion callback runs before the goroutine stops).
+func TestHeartbeatFunc_NoopWhenUnclaimed(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	const issueNum = 77
+	// Issue is NOT in d.claimed.
+
+	heartbeatFunc := func() {
+		d.mu.Lock()
+		if c, ok := d.claimed[issueNum]; ok {
+			c.LastHeartbeat = time.Now()
+		}
+		d.mu.Unlock()
+	}
+
+	// Must not panic.
+	heartbeatFunc()
 }


### PR DESCRIPTION
## Summary

- Adds `HeartbeatFunc func()` to `agent.Task` — a callback the runner calls periodically during the blocking `provider.Chat()` call
- Adds `heartbeatPulseInterval = 5 * time.Minute` constant (well below the 30 min dispatcher timeout threshold)
- Runner fires the callback immediately before Chat, then starts a background ticker that fires every 5 min until Chat returns
- Dispatcher's `route()` wires a closure that updates `d.claimed[N].LastHeartbeat` under the existing mutex
- Nil-safe: when `HeartbeatFunc` is nil (e.g. when pool is not wired), the runner skips the goroutine entirely

## Why

The dispatcher kills sessions that miss heartbeats for > 30 min. Before this change, runners never sent heartbeats — only HEARTBEAT comments in issue threads (which agents never post). Long AI calls would time out and restart, burning tokens and looping.

## Test plan

- `TestRunnerHeartbeat` — verifies callback is invoked at least once
- `TestRunnerHeartbeatNil` — verifies nil HeartbeatFunc does not panic
- `TestHeartbeatFunc_UpdatesClaimedLastHeartbeat` — verifies the closure updates `LastHeartbeat` in the claimed map
- `TestHeartbeatFunc_NoopWhenUnclaimed` — verifies no panic when issue leaves claimed map before goroutine stops
- All 264 tests passing

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)