### PR TITLE
fix(forge): emit events for pre-existing queued issues on Watch() startup (#394)

### DIFF
--- a/internal/forge/gitea/gitea.go
+++ b/internal/forge/gitea/gitea.go
@@ -301,6 +301,21 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 	for _, iss := range issues {
 		known[iss.Number] = iss
 	}
+	// Emit events for pre-existing queued issues so the dispatcher
+	// routes them on startup, not only when new issues appear.
+	for _, iss := range issues {
+		for _, label := range iss.Labels {
+			if label == "status:queued" {
+				handler(forge.Event{
+					Type:          forge.EventIssueOpened,
+					IssueNumber:   iss.Number,
+					Issue:         iss,
+					IsPullRequest: iss.IsPullRequest,
+				})
+				break
+			}
+		}
+	}
 	mu.Unlock()
 
 	ticker := time.NewTicker(c.pollInterval)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -241,6 +241,21 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 	for _, iss := range issues {
 		known[iss.Number] = iss
 	}
+	// Emit events for pre-existing queued issues so the dispatcher
+	// routes them on startup, not only when new issues appear.
+	for _, iss := range issues {
+		for _, label := range iss.Labels {
+			if label == "status:queued" {
+				handler(forge.Event{
+					Type:          forge.EventIssueOpened,
+					IssueNumber:   iss.Number,
+					Issue:         iss,
+					IsPullRequest: iss.IsPullRequest,
+				})
+				break
+			}
+		}
+	}
 	mu.Unlock()
 
 	ticker := time.NewTicker(c.pollInterval)


### PR DESCRIPTION
Both GitHub and Gitea Watch() implementations silently ignored all pre-existing issues during initial load. The known map was populated but the event handler was never called, so the dispatcher never routed any issues that existed before it started.

Now emits EventIssueOpened for every issue with status:queued label during the initial load.

Also created missing status:needs-human label on Gitea samverk/samverk repo.

Fixes #394

Deployed and validated on CT 202 — dispatcher now fires events on startup.