### PR TITLE
fix(forge): add pagination to label cache, issue listing, and comments

### DIFF
--- a/internal/forge/gitea/gitea.go
+++ b/internal/forge/gitea/gitea.go
@@ -163,19 +163,24 @@ func (c *Client) AddComment(ctx context.Context, number int, body string) (comme
 }
 
 // ListComments returns all comments on the given issue.
-func (c *Client) ListComments(ctx context.Context, number int) (comments []*forge.Comment, err error) {
-	gc, _, err := c.gt.ListIssueComments(c.owner, c.repo, int64(number), gogitea.ListIssueCommentOptions{
-		ListOptions: gogitea.ListOptions{PageSize: 50},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("gitea: list comments on #%d: %w", number, err)
+func (c *Client) ListComments(ctx context.Context, number int) ([]*forge.Comment, error) {
+	var result []*forge.Comment
+	page := 1
+	for {
+		gc, _, err := c.gt.ListIssueComments(c.owner, c.repo, int64(number), gogitea.ListIssueCommentOptions{
+			ListOptions: gogitea.ListOptions{Page: page, PageSize: 50},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("gitea: list comments on #%d: %w", number, err)
+		}
+		for i := range gc {
+			result = append(result, convertComment(gc[i]))
+		}
+		if len(gc) < 50 {
+			break
+		}
+		page++
 	}
-
-	result := make([]*forge.Comment, 0, len(gc))
-	for i := range gc {
-		result = append(result, convertComment(gc[i]))
-	}
-
 	return result, nil
 }
 
@@ -284,6 +289,28 @@ func (c *Client) Unassign(ctx context.Context, number int, assignee string) erro
 	return nil
 }
 
+// listAllOpenIssues fetches all open issues, paginating automatically.
+func (c *Client) listAllOpenIssues(ctx context.Context) ([]*forge.Issue, error) {
+	var all []*forge.Issue
+	page := 1
+	for {
+		batch, err := c.ListIssues(ctx, &forge.ListOptions{
+			State:   forge.StateOpen,
+			Page:    page,
+			PerPage: 50,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, batch...)
+		if len(batch) < 50 {
+			break
+		}
+		page++
+	}
+	return all, nil
+}
+
 // Watch polls the Gitea API for issue changes and calls handler for each detected event.
 // It blocks until the context is cancelled. The initial poll establishes baseline state;
 // subsequent polls emit events for changes.
@@ -292,7 +319,7 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 	var mu sync.Mutex
 
 	// Initial load.
-	issues, err := c.ListIssues(ctx, &forge.ListOptions{State: forge.StateOpen, PerPage: 50})
+	issues, err := c.listAllOpenIssues(ctx)
 	if err != nil {
 		return fmt.Errorf("gitea: watch initial load: %w", err)
 	}
@@ -300,6 +327,21 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 	mu.Lock()
 	for _, iss := range issues {
 		known[iss.Number] = iss
+	}
+	// Emit events for pre-existing queued issues so the dispatcher
+	// routes them on startup, not only when new issues appear.
+	for _, iss := range issues {
+		for _, label := range iss.Labels {
+			if label == "status:queued" {
+				handler(forge.Event{
+					Type:          forge.EventIssueOpened,
+					IssueNumber:   iss.Number,
+					Issue:         iss,
+					IsPullRequest: iss.IsPullRequest,
+				})
+				break
+			}
+		}
 	}
 	mu.Unlock()
 
@@ -311,7 +353,7 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			current, pollErr := c.ListIssues(ctx, &forge.ListOptions{State: forge.StateOpen, PerPage: 50})
+			current, pollErr := c.listAllOpenIssues(ctx)
 			if pollErr != nil {
 				continue // transient errors are retried on next tick
 			}
@@ -386,20 +428,25 @@ func diffAndEmit(known map[int]*forge.Issue, current []*forge.Issue, handler fun
 	}
 }
 
-// ensureLabelCache populates the label name-to-ID cache from the repo's labels.
 func (c *Client) ensureLabelCache() error {
 	c.labelOnce.Do(func() {
-		labels, _, err := c.gt.ListRepoLabels(c.owner, c.repo, gogitea.ListLabelsOptions{
-			ListOptions: gogitea.ListOptions{PageSize: 50},
-		})
-		if err != nil {
-			c.labelErr = fmt.Errorf("fetch repo labels: %w", err)
-			return
-		}
-
-		c.labelCache = make(map[string]int64, len(labels))
-		for i := range labels {
-			c.labelCache[labels[i].Name] = labels[i].ID
+		c.labelCache = make(map[string]int64)
+		page := 1
+		for {
+			labels, _, err := c.gt.ListRepoLabels(c.owner, c.repo, gogitea.ListLabelsOptions{
+				ListOptions: gogitea.ListOptions{Page: page, PageSize: 50},
+			})
+			if err != nil {
+				c.labelErr = fmt.Errorf("fetch repo labels: %w", err)
+				return
+			}
+			for i := range labels {
+				c.labelCache[labels[i].Name] = labels[i].ID
+			}
+			if len(labels) < 50 {
+				break
+			}
+			page++
 		}
 	})
 

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -154,18 +154,23 @@ func (c *Client) AddComment(ctx context.Context, number int, body string) (*forg
 
 // ListComments returns all comments on the given issue.
 func (c *Client) ListComments(ctx context.Context, number int) ([]*forge.Comment, error) {
-	comments, _, err := c.gh.Issues.ListComments(ctx, c.owner, c.repo, number, &gogithub.IssueListCommentsOptions{
-		ListOptions: gogithub.ListOptions{PerPage: 100},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("github: list comments on #%d: %w", number, err)
+	var result []*forge.Comment
+	page := 1
+	for {
+		comments, _, err := c.gh.Issues.ListComments(ctx, c.owner, c.repo, number, &gogithub.IssueListCommentsOptions{
+			ListOptions: gogithub.ListOptions{Page: page, PerPage: 100},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("github: list comments on #%d: %w", number, err)
+		}
+		for i := range comments {
+			result = append(result, convertComment(comments[i]))
+		}
+		if len(comments) < 100 {
+			break
+		}
+		page++
 	}
-
-	result := make([]*forge.Comment, 0, len(comments))
-	for i := range comments {
-		result = append(result, convertComment(comments[i]))
-	}
-
 	return result, nil
 }
 
@@ -224,6 +229,28 @@ func (c *Client) Unassign(ctx context.Context, number int, assignee string) erro
 	return nil
 }
 
+// listAllOpenIssues fetches all open issues, paginating automatically.
+func (c *Client) listAllOpenIssues(ctx context.Context) ([]*forge.Issue, error) {
+	var all []*forge.Issue
+	page := 1
+	for {
+		batch, err := c.ListIssues(ctx, &forge.ListOptions{
+			State:   forge.StateOpen,
+			Page:    page,
+			PerPage: 100,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, batch...)
+		if len(batch) < 100 {
+			break
+		}
+		page++
+	}
+	return all, nil
+}
+
 // Watch polls the GitHub API for issue changes and calls handler for each detected event.
 // It blocks until the context is cancelled. The initial poll establishes baseline state;
 // subsequent polls emit events for changes.
@@ -232,7 +259,7 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 	var mu sync.Mutex
 
 	// Initial load.
-	issues, err := c.ListIssues(ctx, &forge.ListOptions{State: forge.StateOpen, PerPage: 100})
+	issues, err := c.listAllOpenIssues(ctx)
 	if err != nil {
 		return fmt.Errorf("github: watch initial load: %w", err)
 	}
@@ -240,6 +267,21 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 	mu.Lock()
 	for _, iss := range issues {
 		known[iss.Number] = iss
+	}
+	// Emit events for pre-existing queued issues so the dispatcher
+	// routes them on startup, not only when new issues appear.
+	for _, iss := range issues {
+		for _, label := range iss.Labels {
+			if label == "status:queued" {
+				handler(forge.Event{
+					Type:          forge.EventIssueOpened,
+					IssueNumber:   iss.Number,
+					Issue:         iss,
+					IsPullRequest: iss.IsPullRequest,
+				})
+				break
+			}
+		}
 	}
 	mu.Unlock()
 
@@ -251,7 +293,7 @@ func (c *Client) Watch(ctx context.Context, handler func(forge.Event)) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			current, err := c.ListIssues(ctx, &forge.ListOptions{State: forge.StateOpen, PerPage: 100})
+			current, err := c.listAllOpenIssues(ctx)
 			if err != nil {
 				continue // transient errors are retried on next tick
 			}


### PR DESCRIPTION
## Summary

- **ensureLabelCache** (Gitea): paginate beyond 50 labels — prevents "unknown label" errors
- **Watch startup** (both forges): emit `EventIssueOpened` for pre-existing `status:queued` issues so the dispatcher routes them immediately on restart
- **Watch poll** (both forges): use `listAllOpenIssues()` helper that paginates — catches issues beyond page 1 (50 Gitea / 100 GitHub)
- **ListComments** (both forges): paginate — prevents silently dropped comments on busy issues

Supersedes #396. Fixes #394.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all forge tests green)
- [x] `golangci-lint` clean
- [x] Pre-push hook passes (build + test + lint + markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)