### PR TITLE
fix(forge): query check runs API for GitHub Actions CI status

### DIFF
--- a/internal/forge/github/pulls.go
+++ b/internal/forge/github/pulls.go
@@ -85,7 +85,10 @@ func (c *Client) MergePullRequest(ctx context.Context, number int, method forge.
 	return nil
 }
 
-// GetPRChecks returns the combined commit status checks for a pull request's head.
+// GetPRChecks returns CI status for a pull request's head by querying both the
+// legacy commit status API and the check runs API (used by GitHub Actions).
+// Results from both sources are merged; check runs take precedence over
+// commit statuses with the same name.
 func (c *Client) GetPRChecks(ctx context.Context, number int) ([]forge.Check, error) {
 	pr, _, err := c.gh.PullRequests.Get(ctx, c.owner, c.repo, number)
 	if err != nil {
@@ -97,27 +100,67 @@ func (c *Client) GetPRChecks(ctx context.Context, number int) ([]forge.Check, er
 		return nil, nil
 	}
 
+	// Collect checks by name; check runs overwrite legacy statuses.
+	byName := make(map[string]forge.Check)
+
+	// Legacy commit status API (external CI systems, older integrations).
 	status, _, err := c.gh.Repositories.GetCombinedStatus(ctx, c.owner, c.repo, ref, nil)
 	if err != nil {
 		return nil, fmt.Errorf("github: get combined status for %s: %w", ref, err)
 	}
-
-	checks := make([]forge.Check, 0, len(status.Statuses))
 	for _, s := range status.Statuses {
-		cs := forge.CheckStatusPending
-		switch s.GetState() {
-		case "success":
-			cs = forge.CheckStatusSuccess
-		case "failure", "error":
-			cs = forge.CheckStatusFailure
-		}
-		checks = append(checks, forge.Check{
+		byName[s.GetContext()] = forge.Check{
 			Name:   s.GetContext(),
-			Status: cs,
-		})
+			Status: mapCommitStatus(s.GetState()),
+		}
+	}
+
+	// Check runs API (GitHub Actions, GitHub Apps).
+	runs, _, err := c.gh.Checks.ListCheckRunsForRef(ctx, c.owner, c.repo, ref, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github: list check runs for %s: %w", ref, err)
+	}
+	for _, run := range runs.CheckRuns {
+		byName[run.GetName()] = forge.Check{
+			Name:   run.GetName(),
+			Status: mapCheckRunStatus(run.GetStatus(), run.GetConclusion()),
+		}
+	}
+
+	checks := make([]forge.Check, 0, len(byName))
+	for _, ch := range byName {
+		checks = append(checks, ch)
 	}
 
 	return checks, nil
+}
+
+// mapCommitStatus converts a legacy commit status state to forge.CheckStatus.
+func mapCommitStatus(state string) forge.CheckStatus {
+	switch state {
+	case "success":
+		return forge.CheckStatusSuccess
+	case "failure", "error":
+		return forge.CheckStatusFailure
+	default:
+		return forge.CheckStatusPending
+	}
+}
+
+// mapCheckRunStatus converts GitHub check run status + conclusion to forge.CheckStatus.
+// A check run with status "completed" uses its conclusion; otherwise it is pending.
+func mapCheckRunStatus(status, conclusion string) forge.CheckStatus {
+	if status != "completed" {
+		return forge.CheckStatusPending
+	}
+	switch conclusion {
+	case "success", "neutral", "skipped":
+		return forge.CheckStatusSuccess
+	case "failure", "cancelled", "timed_out", "action_required":
+		return forge.CheckStatusFailure
+	default:
+		return forge.CheckStatusPending
+	}
 }
 
 // ListReviewComments returns all review comments on a pull request.

--- a/internal/forge/github/pulls_test.go
+++ b/internal/forge/github/pulls_test.go
@@ -166,6 +166,225 @@ func TestMergePullRequest(t *testing.T) {
 	}
 }
 
+func TestGetPRChecks_CheckRunsOnly(t *testing.T) {
+	headSHA := "abc123def456"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/pulls/10", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.PullRequest{
+			Number: gogithub.Ptr(10),
+			Head: &gogithub.PullRequestBranch{
+				SHA: gogithub.Ptr(headSHA),
+			},
+		})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.CombinedStatus{
+			Statuses: []*gogithub.RepoStatus{}, // no legacy statuses
+		})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.ListCheckRunsResults{
+			Total: gogithub.Ptr(3),
+			CheckRuns: []*gogithub.CheckRun{
+				{Name: gogithub.Ptr("Build"), Status: gogithub.Ptr("completed"), Conclusion: gogithub.Ptr("success")},
+				{Name: gogithub.Ptr("Test"), Status: gogithub.Ptr("completed"), Conclusion: gogithub.Ptr("success")},
+				{Name: gogithub.Ptr("Lint"), Status: gogithub.Ptr("completed"), Conclusion: gogithub.Ptr("failure")},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+	checks, err := c.GetPRChecks(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetPRChecks: %v", err)
+	}
+
+	if len(checks) != 3 {
+		t.Fatalf("len(checks) = %d, want 3", len(checks))
+	}
+
+	byName := make(map[string]forge.CheckStatus, len(checks))
+	for _, ch := range checks {
+		byName[ch.Name] = ch.Status
+	}
+
+	if byName["Build"] != forge.CheckStatusSuccess {
+		t.Errorf("Build = %q, want success", byName["Build"])
+	}
+	if byName["Test"] != forge.CheckStatusSuccess {
+		t.Errorf("Test = %q, want success", byName["Test"])
+	}
+	if byName["Lint"] != forge.CheckStatusFailure {
+		t.Errorf("Lint = %q, want failure", byName["Lint"])
+	}
+}
+
+func TestGetPRChecks_MergesBothSources(t *testing.T) {
+	headSHA := "abc123def456"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/pulls/10", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.PullRequest{
+			Number: gogithub.Ptr(10),
+			Head:   &gogithub.PullRequestBranch{SHA: gogithub.Ptr(headSHA)},
+		})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.CombinedStatus{
+			Statuses: []*gogithub.RepoStatus{
+				{Context: gogithub.Ptr("external-ci"), State: gogithub.Ptr("success")},
+				{Context: gogithub.Ptr("Build"), State: gogithub.Ptr("pending")}, // will be overwritten by check run
+			},
+		})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.ListCheckRunsResults{
+			Total: gogithub.Ptr(1),
+			CheckRuns: []*gogithub.CheckRun{
+				{Name: gogithub.Ptr("Build"), Status: gogithub.Ptr("completed"), Conclusion: gogithub.Ptr("success")},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+	checks, err := c.GetPRChecks(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetPRChecks: %v", err)
+	}
+
+	if len(checks) != 2 {
+		t.Fatalf("len(checks) = %d, want 2", len(checks))
+	}
+
+	byName := make(map[string]forge.CheckStatus, len(checks))
+	for _, ch := range checks {
+		byName[ch.Name] = ch.Status
+	}
+
+	// Check run should overwrite legacy status for "Build".
+	if byName["Build"] != forge.CheckStatusSuccess {
+		t.Errorf("Build = %q, want success (check run should overwrite legacy pending)", byName["Build"])
+	}
+	if byName["external-ci"] != forge.CheckStatusSuccess {
+		t.Errorf("external-ci = %q, want success", byName["external-ci"])
+	}
+}
+
+func TestGetPRChecks_PendingCheckRun(t *testing.T) {
+	headSHA := "abc123def456"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/pulls/10", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.PullRequest{
+			Number: gogithub.Ptr(10),
+			Head:   &gogithub.PullRequestBranch{SHA: gogithub.Ptr(headSHA)},
+		})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.CombinedStatus{})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.ListCheckRunsResults{
+			Total: gogithub.Ptr(1),
+			CheckRuns: []*gogithub.CheckRun{
+				{Name: gogithub.Ptr("Build"), Status: gogithub.Ptr("in_progress"), Conclusion: gogithub.Ptr("")},
+			},
+		})
+	})
+
+	c, _ := newTestClient(t, mux)
+	checks, err := c.GetPRChecks(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetPRChecks: %v", err)
+	}
+
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	if checks[0].Status != forge.CheckStatusPending {
+		t.Errorf("Status = %q, want pending", checks[0].Status)
+	}
+}
+
+func TestGetPRChecks_NoBothSources(t *testing.T) {
+	headSHA := "abc123def456"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/owner/repo/pulls/10", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.PullRequest{
+			Number: gogithub.Ptr(10),
+			Head:   &gogithub.PullRequestBranch{SHA: gogithub.Ptr(headSHA)},
+		})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.CombinedStatus{})
+	})
+	mux.HandleFunc("GET /repos/owner/repo/commits/"+headSHA+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, http.StatusOK, &gogithub.ListCheckRunsResults{Total: gogithub.Ptr(0)})
+	})
+
+	c, _ := newTestClient(t, mux)
+	checks, err := c.GetPRChecks(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetPRChecks: %v", err)
+	}
+
+	if len(checks) != 0 {
+		t.Fatalf("len(checks) = %d, want 0", len(checks))
+	}
+}
+
+func TestMapCheckRunStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		conclusion string
+		want       forge.CheckStatus
+	}{
+		{"completed success", "completed", "success", forge.CheckStatusSuccess},
+		{"completed failure", "completed", "failure", forge.CheckStatusFailure},
+		{"completed neutral", "completed", "neutral", forge.CheckStatusSuccess},
+		{"completed skipped", "completed", "skipped", forge.CheckStatusSuccess},
+		{"completed cancelled", "completed", "cancelled", forge.CheckStatusFailure},
+		{"completed timed_out", "completed", "timed_out", forge.CheckStatusFailure},
+		{"completed action_required", "completed", "action_required", forge.CheckStatusFailure},
+		{"in_progress", "in_progress", "", forge.CheckStatusPending},
+		{"queued", "queued", "", forge.CheckStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapCheckRunStatus(tt.status, tt.conclusion)
+			if got != tt.want {
+				t.Errorf("mapCheckRunStatus(%q, %q) = %q, want %q", tt.status, tt.conclusion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapCommitStatus(t *testing.T) {
+	tests := []struct {
+		state string
+		want  forge.CheckStatus
+	}{
+		{"success", forge.CheckStatusSuccess},
+		{"failure", forge.CheckStatusFailure},
+		{"error", forge.CheckStatusFailure},
+		{"pending", forge.CheckStatusPending},
+		{"unknown", forge.CheckStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			got := mapCommitStatus(tt.state)
+			if got != tt.want {
+				t.Errorf("mapCommitStatus(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestListReviewComments(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repos/owner/repo/pulls/10/comments", func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

- Query both the legacy commit status API and the check runs API in `GetPRChecks()`
- Check runs (GitHub Actions) take precedence over legacy statuses with the same name
- Extract `mapCommitStatus()` and `mapCheckRunStatus()` helpers for clarity

Closes #401

## Root Cause

`GetPRChecks()` only called `Repositories.GetCombinedStatus()` which returns legacy commit statuses. GitHub Actions uses the Check Runs API (`/repos/{owner}/{repo}/commits/{sha}/check-runs`), so all Actions-based CI was invisible -- `review_pr` always reported `ci_status: "no-ci"`.

## Changes

| File | Change |
|------|--------|
| `internal/forge/github/pulls.go` | Query both APIs, merge by name (check runs win) |
| `internal/forge/github/pulls_test.go` | 6 new tests: check-runs-only, merged sources, pending, empty, status mapper, conclusion mapper |

## Test plan

- [x] `TestGetPRChecks_CheckRunsOnly` -- GitHub Actions with no legacy statuses
- [x] `TestGetPRChecks_MergesBothSources` -- check run overwrites legacy status of same name
- [x] `TestGetPRChecks_PendingCheckRun` -- in-progress check run maps to pending
- [x] `TestGetPRChecks_NoBothSources` -- no checks from either API returns empty
- [x] `TestMapCheckRunStatus` -- all conclusion values (success/failure/neutral/skipped/cancelled/timed_out/action_required)
- [x] `TestMapCommitStatus` -- legacy state mapping
- [x] golangci-lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)