### PR TITLE
feat(#243): streaming progress detection with heartbeat reset on active output

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -108,7 +108,15 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		},
 	}
 
-	// Step 4: Call provider (with heartbeat ticker to keep dispatcher informed).
+	// Step 4: Call provider (with heartbeat and streaming activity detection).
+	//
+	// Two heartbeat mechanisms work together:
+	//   a) Ticker-based: fires every heartbeatPulseInterval as a fallback for
+	//      providers that don't support ActivityNotifier.
+	//   b) Activity-based: if the provider implements provider.ActivityNotifier,
+	//      the callback fires on every chunk of output, resetting the heartbeat
+	//      timer immediately. This prevents false timeout kills during long but
+	//      active streaming sessions.
 	if task.HeartbeatFunc != nil {
 		task.HeartbeatFunc() // fire immediately before blocking call
 		stop := make(chan struct{})
@@ -125,6 +133,17 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 			}
 		}()
 		defer close(stop)
+	}
+
+	// Wire streaming activity detection if the provider supports it.
+	if notifier, ok := r.provider.(provider.ActivityNotifier); ok {
+		notifier.SetOnActivity(func() {
+			if task.HeartbeatFunc != nil {
+				task.HeartbeatFunc()
+			}
+		})
+		// Clear the callback after Chat returns to avoid stale references.
+		defer notifier.SetOnActivity(nil)
 	}
 
 	resp, err := r.provider.Chat(ctx, req)

--- a/internal/provider/claudecli/claudecli.go
+++ b/internal/provider/claudecli/claudecli.go
@@ -6,9 +6,11 @@ package claudecli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/herbhall/samverk/internal/provider"
@@ -22,13 +24,21 @@ const (
 	// maxErrOutputBytes caps the CLI output included in error messages to prevent
 	// oversized GitHub issue comments and avoid leaking unrelated terminal output.
 	maxErrOutputBytes = 2048
+
+	// staleOutputTimeout is how long Chat waits for new bytes before treating
+	// the process as hung. Must be shorter than the dispatcher heartbeat timeout.
+	staleOutputTimeout = 3 * time.Minute
+
+	// streamBufSize is the read buffer for pipe-based streaming.
+	streamBufSize = 4096
 )
 
 // Client invokes the claude CLI binary for chat completions.
 type Client struct {
-	claudeBin string
-	model     string
-	timeout   time.Duration
+	claudeBin  string
+	model      string
+	timeout    time.Duration
+	onActivity func() // called when output bytes arrive; may be nil
 }
 
 // New creates a claude-cli provider with the default timeout.
@@ -47,8 +57,19 @@ func NewWithTimeout(model string, timeout time.Duration) *Client {
 	}
 }
 
+// SetOnActivity registers a callback invoked whenever the CLI process
+// produces output bytes. The runner uses this to reset the dispatcher
+// heartbeat timer, proving the session is actively producing tokens.
+func (c *Client) SetOnActivity(fn func()) {
+	c.onActivity = fn
+}
+
 // Chat builds a prompt from the request messages, invokes `claude --print`,
 // and returns the CLI output as the assistant response.
+//
+// Output is read incrementally via pipes instead of CombinedOutput so that
+// the onActivity callback fires as bytes arrive and hung processes are
+// detected early (no output for staleOutputTimeout → cancel).
 //
 // IMPORTANT: The prompt MUST be sent via stdin, not as a CLI argument.
 // Passing the prompt as an argument causes the CLI to hang indefinitely.
@@ -92,23 +113,119 @@ func (c *Client) Chat(ctx context.Context, req provider.ChatRequest) (*provider.
 	}
 	cmd.Env = env
 
-	out, err := cmd.CombinedOutput()
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		snippet := out
+		return nil, fmt.Errorf("claude-cli: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("claude-cli: stderr pipe: %w", err)
+	}
+
+	if err = cmd.Start(); err != nil {
+		return nil, fmt.Errorf("claude-cli: start: %w", err)
+	}
+
+	// Read stdout and stderr concurrently, merging into a single buffer.
+	var output strings.Builder
+	streamErr := c.streamOutput(ctx, cancel, &output, stdout, stderr)
+
+	// Wait for the process to exit after pipes are drained.
+	waitErr := cmd.Wait()
+
+	// Prefer stream errors (hung detection) over wait errors.
+	if streamErr != nil {
+		snippet := output.String()
 		if len(snippet) > maxErrOutputBytes {
-			// Keep the tail — the final lines are usually the most relevant.
 			snippet = snippet[len(snippet)-maxErrOutputBytes:]
 		}
-		return nil, fmt.Errorf("claude-cli: exec: %w: output: %s", err, strings.TrimSpace(string(snippet)))
+		return nil, fmt.Errorf("claude-cli: %w: output: %s", streamErr, strings.TrimSpace(snippet))
+	}
+	if waitErr != nil {
+		snippet := output.String()
+		if len(snippet) > maxErrOutputBytes {
+			snippet = snippet[len(snippet)-maxErrOutputBytes:]
+		}
+		return nil, fmt.Errorf("claude-cli: exec: %w: output: %s", waitErr, strings.TrimSpace(snippet))
 	}
 
 	return &provider.ChatResponse{
 		Model: c.model,
 		Message: provider.Message{
 			Role:    provider.RoleAssistant,
-			Content: strings.TrimSpace(string(out)),
+			Content: strings.TrimSpace(output.String()),
 		},
 	}, nil
+}
+
+// streamOutput reads from stdout and stderr concurrently, writing to output.
+// It fires onActivity on each read and cancels the context if no bytes arrive
+// within staleOutputTimeout (hung detection).
+func (c *Client) streamOutput(ctx context.Context, cancel context.CancelFunc, output *strings.Builder, stdout, stderr io.ReadCloser) error {
+	// Merge stdout and stderr via a pipe so we can read from a single source.
+	pr, pw := io.Pipe()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(pw, stdout)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(pw, stderr)
+	}()
+	go func() {
+		wg.Wait()
+		_ = pw.Close()
+	}()
+
+	buf := make([]byte, streamBufSize)
+	staleTimer := time.NewTimer(staleOutputTimeout)
+	defer staleTimer.Stop()
+
+	for {
+		// Use a channel to make Read interruptible by the stale timer.
+		type readResult struct {
+			n   int
+			err error
+		}
+		ch := make(chan readResult, 1)
+		go func() {
+			n, readErr := pr.Read(buf)
+			ch <- readResult{n, readErr}
+		}()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-staleTimer.C:
+			cancel() // kill the subprocess
+			return fmt.Errorf("hung: no output for %v", staleOutputTimeout)
+		case res := <-ch:
+			if res.n > 0 {
+				output.Write(buf[:res.n])
+				// Reset stale timer — process is alive.
+				if !staleTimer.Stop() {
+					select {
+					case <-staleTimer.C:
+					default:
+					}
+				}
+				staleTimer.Reset(staleOutputTimeout)
+				// Signal activity to the dispatcher heartbeat.
+				if c.onActivity != nil {
+					c.onActivity()
+				}
+			}
+			if res.err != nil {
+				if res.err == io.EOF {
+					return nil
+				}
+				return fmt.Errorf("read output: %w", res.err)
+			}
+		}
+	}
 }
 
 // Healthy returns true if the claude binary is found and responds to --version.

--- a/internal/provider/claudecli/claudecli_test.go
+++ b/internal/provider/claudecli/claudecli_test.go
@@ -2,7 +2,9 @@ package claudecli
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/herbhall/samverk/internal/provider"
 )
@@ -99,5 +101,67 @@ func TestChatExecError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Chat() should return error for missing binary")
+	}
+}
+
+// TestActivityNotifierInterface verifies Client implements provider.ActivityNotifier.
+func TestActivityNotifierInterface(t *testing.T) {
+	var _ provider.ActivityNotifier = (*Client)(nil)
+}
+
+// TestSetOnActivity verifies the callback is stored and can be cleared.
+func TestSetOnActivity(t *testing.T) {
+	c := New("")
+	if c.onActivity != nil {
+		t.Fatal("onActivity should be nil initially")
+	}
+
+	called := false
+	c.SetOnActivity(func() { called = true })
+	if c.onActivity == nil {
+		t.Fatal("onActivity should be set after SetOnActivity")
+	}
+	c.onActivity()
+	if !called {
+		t.Error("onActivity callback was not invoked")
+	}
+
+	c.SetOnActivity(nil)
+	if c.onActivity != nil {
+		t.Error("onActivity should be nil after SetOnActivity(nil)")
+	}
+}
+
+// TestChatFiresOnActivity verifies the onActivity callback fires during
+// streaming output from a subprocess. Uses `echo` which produces output
+// that should trigger at least one callback invocation.
+func TestChatFiresOnActivity(t *testing.T) {
+	var calls atomic.Int32
+	c := &Client{
+		claudeBin:  "echo",
+		model:      "",
+		timeout:    10 * time.Second,
+		onActivity: func() { calls.Add(1) },
+	}
+
+	_, err := c.Chat(context.Background(), provider.ChatRequest{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "hello world"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if calls.Load() == 0 {
+		t.Error("onActivity was never called during streaming output")
+	}
+}
+
+// TestNewWithTimeout verifies custom timeout is applied.
+func TestNewWithTimeout(t *testing.T) {
+	c := NewWithTimeout("model", 42*time.Second)
+	if c.timeout != 42*time.Second {
+		t.Errorf("timeout = %v, want 42s", c.timeout)
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -36,6 +36,14 @@ type ChatResponse struct {
 	CompletionTokens int `json:"eval_count,omitempty"`
 }
 
+// ActivityNotifier is an optional interface that providers may implement to
+// support streaming progress detection. When a provider supports this, the
+// runner sets a callback that fires whenever the provider produces output
+// bytes, allowing the dispatcher heartbeat to reset on active output.
+type ActivityNotifier interface {
+	SetOnActivity(fn func())
+}
+
 // Provider is the interface for AI model inference backends.
 // Implementations exist for Ollama (local), Claude, and OpenAI (cloud).
 type Provider interface {

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -28,8 +28,8 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO sessions (id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO sessions (id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sess.ID,
 		sess.IssueNumber,
 		sess.AgentType,
@@ -39,6 +39,7 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 		sess.StartedAt.Format(time.RFC3339),
 		finishedAt,
 		sess.Error,
+		sess.PartialOutput,
 		sess.CreatedAt.Format(time.RFC3339),
 		sess.UpdatedAt.Format(time.RFC3339),
 	)
@@ -51,7 +52,7 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 // GetSession retrieves a session by ID. Returns ErrNotFound if no row matches.
 func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Session, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, created_at, updated_at
+		`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id)
 
 	sess, err := scanSession(row)
@@ -71,7 +72,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, sess *models.Session) e
 	}
 
 	result, err := s.db.ExecContext(ctx,
-		`UPDATE sessions SET issue_number=?, agent_type=?, provider=?, model=?, status=?, started_at=?, finished_at=?, error=?, updated_at=?
+		`UPDATE sessions SET issue_number=?, agent_type=?, provider=?, model=?, status=?, started_at=?, finished_at=?, error=?, partial_output=?, updated_at=?
 		 WHERE id=?`,
 		sess.IssueNumber,
 		sess.AgentType,
@@ -81,6 +82,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, sess *models.Session) e
 		sess.StartedAt.Format(time.RFC3339),
 		finishedAt,
 		sess.Error,
+		sess.PartialOutput,
 		sess.UpdatedAt.Format(time.RFC3339),
 		sess.ID,
 	)
@@ -108,11 +110,11 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, status models.SessionSta
 
 	if status != "" {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, created_at, updated_at
+			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at
 			 FROM sessions WHERE status = ? ORDER BY created_at DESC`, string(status))
 	} else {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, created_at, updated_at
+			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at
 			 FROM sessions ORDER BY created_at DESC`)
 	}
 	if err != nil {
@@ -144,7 +146,7 @@ func scanSession(row *sql.Row) (*models.Session, error) {
 
 	err := row.Scan(
 		&sess.ID, &sess.IssueNumber, &sess.AgentType, &sess.Provider, &sess.Model,
-		&status, &startedAt, &finishedAt, &sess.Error, &createdAt, &updatedAt,
+		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &createdAt, &updatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
@@ -186,7 +188,7 @@ func scanSessionRows(rows *sql.Rows) (*models.Session, error) {
 
 	err := rows.Scan(
 		&sess.ID, &sess.IssueNumber, &sess.AgentType, &sess.Provider, &sess.Model,
-		&status, &startedAt, &finishedAt, &sess.Error, &createdAt, &updatedAt,
+		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &createdAt, &updatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("scan session row: %w", err)

--- a/internal/store/session_test.go
+++ b/internal/store/session_test.go
@@ -162,3 +162,57 @@ func TestListSessionsEmpty(t *testing.T) {
 		t.Errorf("sessions count = %d, want 0", len(sessions))
 	}
 }
+
+func TestPartialOutputRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	sess := &models.Session{
+		IssueNumber: 99,
+		AgentType:   "code-gen",
+		Provider:    "claude-cli",
+		Model:       "opus-4",
+		Status:      models.SessionStatusActive,
+		StartedAt:   now,
+	}
+
+	if err := s.CreateSession(ctx, sess); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Initially empty.
+	got, err := s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.PartialOutput != "" {
+		t.Errorf("initial partial_output = %q, want empty", got.PartialOutput)
+	}
+
+	// Update with partial output checkpoint.
+	sess.PartialOutput = "streaming output chunk 1..."
+	if err := s.UpdateSession(ctx, sess); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, err = s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if got.PartialOutput != "streaming output chunk 1..." {
+		t.Errorf("partial_output = %q, want %q", got.PartialOutput, "streaming output chunk 1...")
+	}
+
+	// Verify it appears in list results too.
+	sessions, err := s.ListSessions(ctx, models.SessionStatusActive)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions count = %d, want 1", len(sessions))
+	}
+	if sessions[0].PartialOutput != "streaming output chunk 1..." {
+		t.Errorf("list partial_output = %q, want %q", sessions[0].PartialOutput, "streaming output chunk 1...")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/herbhall/samverk/pkg/models"
@@ -89,17 +90,18 @@ func (s *SQLiteStore) Close() error {
 func (s *SQLiteStore) migrate() error {
 	const ddl = `
 CREATE TABLE IF NOT EXISTS sessions (
-	id          TEXT PRIMARY KEY,
-	issue_number INTEGER NOT NULL,
-	agent_type  TEXT NOT NULL,
-	provider    TEXT NOT NULL,
-	model       TEXT NOT NULL,
-	status      TEXT NOT NULL,
-	started_at  TEXT NOT NULL,
-	finished_at TEXT,
-	error       TEXT,
-	created_at  TEXT NOT NULL,
-	updated_at  TEXT NOT NULL
+	id             TEXT PRIMARY KEY,
+	issue_number   INTEGER NOT NULL,
+	agent_type     TEXT NOT NULL,
+	provider       TEXT NOT NULL,
+	model          TEXT NOT NULL,
+	status         TEXT NOT NULL,
+	started_at     TEXT NOT NULL,
+	finished_at    TEXT,
+	error          TEXT,
+	partial_output TEXT NOT NULL DEFAULT '',
+	created_at     TEXT NOT NULL,
+	updated_at     TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS cost_records (
@@ -148,8 +150,25 @@ CREATE TABLE IF NOT EXISTS task_profiles (
 	PRIMARY KEY (agent_type, provider)
 );
 `
-	_, err := s.db.ExecContext(context.Background(), ddl)
-	return err
+	if _, err := s.db.ExecContext(context.Background(), ddl); err != nil {
+		return err
+	}
+
+	// Incremental migrations for existing databases.
+	// SQLite silently ignores duplicate ADD COLUMN when using IF NOT EXISTS
+	// is not available, so we detect and skip manually.
+	migrations := []string{
+		`ALTER TABLE sessions ADD COLUMN partial_output TEXT NOT NULL DEFAULT ''`,
+	}
+	for _, m := range migrations {
+		if _, err := s.db.ExecContext(context.Background(), m); err != nil {
+			// "duplicate column name" means the column already exists — skip.
+			if !isDuplicateColumn(err) {
+				return fmt.Errorf("migration: %w", err)
+			}
+		}
+	}
+	return nil
 }
 
 // generateID produces a random hex-encoded identifier.
@@ -160,4 +179,10 @@ func generateID() string {
 		return fmt.Sprintf("%d", time.Now().UnixNano())
 	}
 	return hex.EncodeToString(b)
+}
+
+// isDuplicateColumn returns true if the error indicates an ALTER TABLE ADD COLUMN
+// failed because the column already exists. SQLite returns "duplicate column name: X".
+func isDuplicateColumn(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "duplicate column name")
 }

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -15,15 +15,16 @@ const (
 
 // Session represents a unit of agent work on an issue.
 type Session struct {
-	ID          string        `json:"id"`
-	IssueNumber int           `json:"issue_number"`
-	AgentType   string        `json:"agent_type"` // e.g., "code-gen", "qc", "research"
-	Provider    string        `json:"provider"`   // e.g., "ollama", "claude", "openai"
-	Model       string        `json:"model"`      // e.g., "qwen2.5-coder:7b"
-	Status      SessionStatus `json:"status"`
-	StartedAt   time.Time     `json:"started_at"`
-	FinishedAt  *time.Time    `json:"finished_at,omitempty"`
-	Error       string        `json:"error,omitempty"`
-	CreatedAt   time.Time     `json:"created_at"`
-	UpdatedAt   time.Time     `json:"updated_at"`
+	ID            string        `json:"id"`
+	IssueNumber   int           `json:"issue_number"`
+	AgentType     string        `json:"agent_type"` // e.g., "code-gen", "qc", "research"
+	Provider      string        `json:"provider"`   // e.g., "ollama", "claude", "openai"
+	Model         string        `json:"model"`      // e.g., "qwen2.5-coder:7b"
+	Status        SessionStatus `json:"status"`
+	StartedAt     time.Time     `json:"started_at"`
+	FinishedAt    *time.Time    `json:"finished_at,omitempty"`
+	Error         string        `json:"error,omitempty"`
+	PartialOutput string        `json:"partial_output,omitempty"` // last checkpoint of streaming output
+	CreatedAt     time.Time     `json:"created_at"`
+	UpdatedAt     time.Time     `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary

- Replace `CombinedOutput()` with pipe-based streaming in claude-cli provider for real-time output detection
- Add `ActivityNotifier` interface so the runner can wire heartbeat resets to streaming output events
- Add `PartialOutput` field to Session model for checkpoint persistence (schema migration included)
- Stale output timer (3 min no-output) detects hung processes and cancels context

## How it works

Together with #242 (dynamic timeout), this solves the timeout problem from both ends:
- **#242** sets smarter per-issue timeouts based on complexity estimation
- **#243** prevents false timeouts by detecting that an agent session is still producing output

The claude-cli provider now reads stdout/stderr via pipes, merging them through `io.Pipe`. Each chunk of output fires `OnActivity`, which the runner wires to `task.HeartbeatFunc()` to reset the dispatcher heartbeat timer. If no output arrives for 3 minutes, the process is assumed hung and killed.

## Test plan

- [x] `TestActivityNotifierInterface` — compile-time interface check
- [x] `TestSetOnActivity` — callback storage and clearing
- [x] `TestChatFiresOnActivity` — callback fires during streaming
- [x] `TestPartialOutputRoundTrip` — session store persistence
- [x] All existing tests pass (store, agent, provider packages)
- [x] `go build ./...` + `GOOS=linux go build ./...`
- [x] `golangci-lint` — 0 issues
- [x] `markdownlint` — 0 errors

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)