### PR TITLE
feat(#244): session checkpoint and resume

### DIFF
--- a/internal/agent/checkpoint.go
+++ b/internal/agent/checkpoint.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+// checkpointPrefix is the marker that identifies a checkpoint comment.
+const checkpointPrefix = "CHECKPOINT ["
+
+// FormatCheckpoint wraps partial output in the checkpoint comment format.
+// The session ID is embedded so multi-retry scenarios can identify which
+// attempt produced the checkpoint.
+func FormatCheckpoint(sessionID, partialOutput string) string {
+	return fmt.Sprintf("CHECKPOINT [%s]\n\n```\n%s\n```", sessionID, partialOutput)
+}
+
+// FindLatestCheckpoint scans issue comments (newest first) for the most
+// recent CHECKPOINT block and returns its content. Returns empty string
+// if no checkpoint exists.
+func FindLatestCheckpoint(comments []*forge.Comment) string {
+	// Comments are typically returned oldest-first; scan in reverse.
+	for i := len(comments) - 1; i >= 0; i-- {
+		body := comments[i].Body
+		if content := extractCheckpointContent(body); content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
+// extractCheckpointContent pulls the content from inside a CHECKPOINT comment.
+// Expected format:
+//
+//	CHECKPOINT [session_id]
+//
+//	```
+//	<content>
+//	```
+func extractCheckpointContent(body string) string {
+	if !strings.HasPrefix(body, checkpointPrefix) {
+		return ""
+	}
+
+	// Find the opening code fence.
+	start := strings.Index(body, "```\n")
+	if start < 0 {
+		return ""
+	}
+	start += len("```\n")
+
+	// Find the closing code fence.
+	end := strings.LastIndex(body, "\n```")
+	if end < 0 || end <= start {
+		return ""
+	}
+
+	return body[start:end]
+}
+
+// HashCheckpoint returns a hex-encoded SHA-256 of the checkpoint content.
+// Used to dedup: if a session already posted this exact checkpoint, skip.
+func HashCheckpoint(content string) string {
+	h := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(h[:])
+}
+
+// DeduplicateEdits filters out EDIT blocks from newEdits that already exist
+// in the checkpoint content. Two edits match when they have the same path
+// and identical content hash. This prevents writing files that were already
+// committed to the branch in a prior attempt.
+func DeduplicateEdits(newEdits []FileEdit, checkpointContent string) []FileEdit {
+	if checkpointContent == "" {
+		return newEdits
+	}
+
+	// Parse EDIT blocks from the checkpoint.
+	prior := ParseEditBlocks(checkpointContent)
+	if prior == nil || len(prior.Edits) == 0 {
+		return newEdits
+	}
+
+	// Build a set of path+hash for prior edits.
+	existing := make(map[string]string, len(prior.Edits))
+	for _, e := range prior.Edits {
+		existing[e.Path] = hashContent(e.Content)
+	}
+
+	result := make([]FileEdit, 0, len(newEdits))
+	for _, e := range newEdits {
+		priorHash, found := existing[e.Path]
+		if found && priorHash == hashContent(e.Content) {
+			// Identical file — already on the branch from a prior attempt.
+			continue
+		}
+		result = append(result, e)
+	}
+	return result
+}
+
+// hashContent returns a hex-encoded SHA-256 of file content.
+func hashContent(content string) string {
+	h := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(h[:])
+}
+
+// BuildResumePrompt creates the system prompt injection that instructs the
+// model to continue from a prior checkpoint rather than starting over.
+func BuildResumePrompt(checkpointContent string) string {
+	return fmt.Sprintf(`You previously produced the following partial work on this issue. Continue from where you left off. Do not regenerate completed sections. If the partial work contains EDIT blocks, those files are already written — focus on remaining files and the PR creation step.
+
+<prior-work>
+%s
+</prior-work>`, checkpointContent)
+}

--- a/internal/agent/checkpoint_test.go
+++ b/internal/agent/checkpoint_test.go
@@ -1,0 +1,170 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/herbhall/samverk/internal/forge"
+)
+
+func TestFormatCheckpoint(t *testing.T) {
+	got := FormatCheckpoint("sess-1", "partial work here")
+	want := "CHECKPOINT [sess-1]\n\n```\npartial work here\n```"
+	if got != want {
+		t.Errorf("FormatCheckpoint =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFindLatestCheckpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []*forge.Comment
+		want     string
+	}{
+		{
+			name:     "no comments",
+			comments: nil,
+			want:     "",
+		},
+		{
+			name: "no checkpoint comments",
+			comments: []*forge.Comment{
+				{Body: "This is a regular comment."},
+				{Body: "Agent error: timeout"},
+			},
+			want: "",
+		},
+		{
+			name: "single checkpoint",
+			comments: []*forge.Comment{
+				{Body: "CHECKPOINT [sess-1]\n\n```\nEDIT path/to/file.go\ncontent here\n```"},
+			},
+			want: "EDIT path/to/file.go\ncontent here",
+		},
+		{
+			name: "multiple checkpoints returns latest",
+			comments: []*forge.Comment{
+				{Body: "CHECKPOINT [sess-1]\n\n```\nold content\n```"},
+				{Body: "some other comment"},
+				{Body: "CHECKPOINT [sess-2]\n\n```\nnewer content\n```"},
+			},
+			want: "newer content",
+		},
+		{
+			name: "malformed checkpoint missing code fence",
+			comments: []*forge.Comment{
+				{Body: "CHECKPOINT [sess-1]\n\nno code fence here"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindLatestCheckpoint(tt.comments)
+			if got != tt.want {
+				t.Errorf("FindLatestCheckpoint = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHashCheckpoint(t *testing.T) {
+	hash1 := HashCheckpoint("content A")
+	hash2 := HashCheckpoint("content B")
+	hash3 := HashCheckpoint("content A")
+
+	if hash1 == hash2 {
+		t.Error("different content should produce different hashes")
+	}
+	if hash1 != hash3 {
+		t.Error("same content should produce same hash")
+	}
+	if len(hash1) != 64 {
+		t.Errorf("hash length = %d, want 64 (hex-encoded SHA-256)", len(hash1))
+	}
+}
+
+func TestDeduplicateEdits(t *testing.T) {
+	tests := []struct {
+		name       string
+		newEdits   []FileEdit
+		checkpoint string
+		wantCount  int
+		wantPaths  []string
+	}{
+		{
+			name:       "empty checkpoint returns all edits",
+			newEdits:   []FileEdit{{Path: "a.go", Content: "aaa"}},
+			checkpoint: "",
+			wantCount:  1,
+		},
+		{
+			name: "identical edit is deduped",
+			newEdits: []FileEdit{
+				{Path: "a.go", Content: "aaa"},
+			},
+			checkpoint: "EDIT a.go\naaa\nEND",
+			wantCount:  0,
+		},
+		{
+			name: "different content same path is kept",
+			newEdits: []FileEdit{
+				{Path: "a.go", Content: "bbb"},
+			},
+			checkpoint: "EDIT a.go\naaa\nEND",
+			wantCount:  1,
+			wantPaths:  []string{"a.go"},
+		},
+		{
+			name: "mixed: one deduped one kept",
+			newEdits: []FileEdit{
+				{Path: "a.go", Content: "aaa"},
+				{Path: "b.go", Content: "bbb"},
+			},
+			checkpoint: "EDIT a.go\naaa\nEND",
+			wantCount:  1,
+			wantPaths:  []string{"b.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DeduplicateEdits(tt.newEdits, tt.checkpoint)
+			if len(got) != tt.wantCount {
+				t.Errorf("DeduplicateEdits returned %d edits, want %d", len(got), tt.wantCount)
+			}
+			for i, wantPath := range tt.wantPaths {
+				if i < len(got) && got[i].Path != wantPath {
+					t.Errorf("edit[%d].Path = %q, want %q", i, got[i].Path, wantPath)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildResumePrompt(t *testing.T) {
+	got := BuildResumePrompt("some prior work")
+	if got == "" {
+		t.Fatal("BuildResumePrompt returned empty string")
+	}
+	// Verify it contains the prior work wrapped in XML tags.
+	if !contains(got, "<prior-work>") || !contains(got, "</prior-work>") {
+		t.Error("expected <prior-work> tags in resume prompt")
+	}
+	if !contains(got, "some prior work") {
+		t.Error("expected checkpoint content in resume prompt")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -753,7 +753,8 @@ func (m *mockProvider) Name() string {
 
 type mockTracker struct {
 	forge.IssueTracker
-	addCommentFn func(ctx context.Context, number int, body string) (*forge.Comment, error)
+	addCommentFn   func(ctx context.Context, number int, body string) (*forge.Comment, error)
+	listCommentsFn func(ctx context.Context, number int) ([]*forge.Comment, error)
 }
 
 func (m *mockTracker) AddComment(ctx context.Context, number int, body string) (*forge.Comment, error) {
@@ -761,6 +762,13 @@ func (m *mockTracker) AddComment(ctx context.Context, number int, body string) (
 		return m.addCommentFn(ctx, number, body)
 	}
 	return &forge.Comment{ID: 1, Body: body}, nil
+}
+
+func (m *mockTracker) ListComments(ctx context.Context, number int) ([]*forge.Comment, error) {
+	if m.listCommentsFn != nil {
+		return m.listCommentsFn(ctx, number)
+	}
+	return nil, nil
 }
 
 type mockStore struct {

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -67,11 +67,12 @@ func (r *Runner) SetPRManager(pm forge.PullRequestManager) {
 // Steps:
 //  1. Update session status to "active"
 //  2. Check budget -- if exceeded, mark "failed" and return
-//  3. Build system prompt and chat request
-//  4. Call provider.Chat
-//  5. Record cost via cost tracker
-//  6. Post response as issue comment
-//  7. Mark session "completed"
+//  3. Detect prior checkpoint for resume
+//  4. Build system prompt and chat request (with resume context if available)
+//  5. Call provider.Chat
+//  6. Record cost via cost tracker
+//  7. Post response as issue comment (dedup edits against checkpoint)
+//  8. Mark session "completed"
 //
 // On any error, the session is marked "failed" and an error comment is posted.
 func (r *Runner) Run(ctx context.Context, task Task) error {
@@ -97,18 +98,38 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		return fmt.Errorf("check budget: %w", err)
 	}
 
-	// Step 3: Build chat request.
-	fileContext := r.extractFileContext(task.Issue.Body)
-	systemPrompt := BuildSystemPrompt(task, fileContext)
-	req := provider.ChatRequest{
-		Model: r.model,
-		Messages: []provider.Message{
-			{Role: provider.RoleSystem, Content: systemPrompt},
-			{Role: provider.RoleUser, Content: task.Issue.Body},
-		},
+	// Step 3: Detect prior checkpoint for resume.
+	var resumePrompt string
+	comments, listErr := r.tracker.ListComments(ctx, task.Issue.Number)
+	if listErr != nil {
+		r.logger.Warn("failed to list comments for checkpoint detection",
+			zap.Int("issue", task.Issue.Number),
+			zap.Error(listErr),
+		)
+	} else if checkpoint := FindLatestCheckpoint(comments); checkpoint != "" {
+		resumePrompt = BuildResumePrompt(checkpoint)
+		r.logger.Info("resuming from checkpoint",
+			zap.Int("issue", task.Issue.Number),
+			zap.String("session", task.SessionID),
+		)
 	}
 
-	// Step 4: Call provider (with heartbeat and streaming activity detection).
+	// Step 4: Build chat request.
+	fileContext := r.extractFileContext(task.Issue.Body)
+	systemPrompt := BuildSystemPrompt(task, fileContext)
+	messages := []provider.Message{
+		{Role: provider.RoleSystem, Content: systemPrompt},
+	}
+	if resumePrompt != "" {
+		messages = append(messages, provider.Message{Role: provider.RoleSystem, Content: resumePrompt})
+	}
+	messages = append(messages, provider.Message{Role: provider.RoleUser, Content: task.Issue.Body})
+	req := provider.ChatRequest{
+		Model:    r.model,
+		Messages: messages,
+	}
+
+	// Step 5: Call provider (with heartbeat and streaming activity detection).
 	//
 	// Two heartbeat mechanisms work together:
 	//   a) Ticker-based: fires every heartbeatPulseInterval as a fallback for
@@ -152,7 +173,7 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		return fmt.Errorf("provider chat: %w", err)
 	}
 
-	// Step 5: Record cost.
+	// Step 6: Record cost.
 	if err = r.costs.RecordUsage(ctx, task.SessionID, r.provider.Name(), r.model, resp); err != nil {
 		r.logger.Error("failed to record cost",
 			zap.String("session_id", task.SessionID),
@@ -161,18 +182,18 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		// Non-fatal: continue even if cost recording fails.
 	}
 
-	// Step 6: Post-process response based on agent type.
+	// Step 7: Post-process response based on agent type.
 	if err = r.postProcess(ctx, task, resp.Message.Content); err != nil {
 		r.failTask(ctx, task, fmt.Sprintf("post-process error: %v", err))
 		return fmt.Errorf("post-process: %w", err)
 	}
 
-	// Step 7: Mark session completed.
+	// Step 8: Mark session completed.
 	if err = r.completeSession(ctx, task.SessionID); err != nil {
 		return fmt.Errorf("complete session: %w", err)
 	}
 
-	// Step 8: Update task profile (non-fatal; best-effort).
+	// Step 9: Update task profile (non-fatal; best-effort).
 	if profErr := r.store.UpdateTaskProfile(ctx, string(task.AgentType), r.provider.Name()); profErr != nil {
 		r.logger.Warn("failed to update task profile",
 			zap.String("agent_type", string(task.AgentType)),
@@ -192,6 +213,11 @@ func (r *Runner) postProcess(ctx context.Context, task Task, response string) er
 	case models.AgentTypeCodeGen, models.AgentTypeTest:
 		if r.repoWriter != nil && r.prManager != nil {
 			parsed := ParseEditBlocks(response)
+			// Dedup edits against any prior checkpoint to avoid rewriting
+			// files that were already committed in a previous attempt.
+			if checkpoint := r.latestCheckpoint(ctx, task.Issue.Number); checkpoint != "" {
+				parsed.Edits = DeduplicateEdits(parsed.Edits, checkpoint)
+			}
 			if len(parsed.Edits) > 0 {
 				return r.openPR(ctx, task, parsed)
 			}
@@ -286,6 +312,20 @@ func (r *Runner) extractFileContext(body string) map[string]string {
 	return result
 }
 
+// latestCheckpoint fetches issue comments and returns the most recent
+// checkpoint content, or empty string if none exists.
+func (r *Runner) latestCheckpoint(ctx context.Context, issueNumber int) string {
+	comments, err := r.tracker.ListComments(ctx, issueNumber)
+	if err != nil {
+		r.logger.Warn("failed to list comments for checkpoint dedup",
+			zap.Int("issue", issueNumber),
+			zap.Error(err),
+		)
+		return ""
+	}
+	return FindLatestCheckpoint(comments)
+}
+
 // updateSessionStatus fetches and updates a session's status in the store.
 func (r *Runner) updateSessionStatus(ctx context.Context, sessionID string, status models.SessionStatus, errMsg string) error {
 	session, err := r.store.GetSession(ctx, sessionID)
@@ -316,7 +356,12 @@ func (r *Runner) completeSession(ctx context.Context, sessionID string) error {
 }
 
 // failTask marks the session as failed and posts an error comment on the issue.
+// If the session has partial output, a CHECKPOINT comment is posted first so
+// that a retry can resume from where the previous attempt left off.
 func (r *Runner) failTask(ctx context.Context, task Task, errMsg string) {
+	// Attempt to save checkpoint from partial output.
+	r.saveCheckpoint(ctx, task)
+
 	if err := r.updateSessionStatus(ctx, task.SessionID, models.SessionStatusFailed, errMsg); err != nil {
 		r.logger.Error("failed to update session on error",
 			zap.String("session_id", task.SessionID),
@@ -330,6 +375,48 @@ func (r *Runner) failTask(ctx context.Context, task Task, errMsg string) {
 			zap.String("session_id", task.SessionID),
 			zap.Int("issue", task.Issue.Number),
 			zap.String("error", err.Error()),
+		)
+	}
+}
+
+// saveCheckpoint posts a CHECKPOINT comment on the issue if the session has
+// non-empty partial output and the checkpoint hash differs from the previous one.
+func (r *Runner) saveCheckpoint(ctx context.Context, task Task) {
+	session, err := r.store.GetSession(ctx, task.SessionID)
+	if err != nil {
+		r.logger.Error("checkpoint: failed to get session",
+			zap.String("session_id", task.SessionID),
+			zap.Error(err),
+		)
+		return
+	}
+
+	if session.PartialOutput == "" {
+		return
+	}
+
+	hash := HashCheckpoint(session.PartialOutput)
+	if hash == session.CheckpointHash {
+		// Same content as the last checkpoint — skip posting a duplicate.
+		return
+	}
+
+	comment := FormatCheckpoint(task.SessionID, session.PartialOutput)
+	if _, err = r.tracker.AddComment(ctx, task.Issue.Number, comment); err != nil {
+		r.logger.Error("checkpoint: failed to post comment",
+			zap.String("session_id", task.SessionID),
+			zap.Int("issue", task.Issue.Number),
+			zap.Error(err),
+		)
+		return
+	}
+
+	// Persist the hash so future retries can detect duplicates.
+	session.CheckpointHash = hash
+	if err = r.store.UpdateSession(ctx, session); err != nil {
+		r.logger.Error("checkpoint: failed to update session hash",
+			zap.String("session_id", task.SessionID),
+			zap.Error(err),
 		)
 	}
 }

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -353,5 +353,182 @@ func TestRunnerHeartbeatNil(t *testing.T) {
 	}
 }
 
+func TestRunnerResumeFromCheckpoint(t *testing.T) {
+	// When a prior CHECKPOINT comment exists, the runner should inject a
+	// resume prompt into the messages sent to the provider.
+	var capturedMessages []provider.Message
+
+	ms := newDefaultMockStore()
+	mp := &mockProvider{
+		chatFn: func(_ context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+			capturedMessages = req.Messages
+			return &provider.ChatResponse{
+				Message: provider.Message{
+					Role:    provider.RoleAssistant,
+					Content: "Continued from checkpoint.",
+				},
+			}, nil
+		},
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test-provider" },
+	}
+
+	checkpointBody := FormatCheckpoint("sess-old", "EDIT main.go\npackage main\nEND_EDIT")
+	mt := &mockTracker{
+		addCommentFn: func(_ context.Context, _ int, _ string) (*forge.Comment, error) {
+			return &forge.Comment{ID: 1}, nil
+		},
+		listCommentsFn: func(_ context.Context, _ int) ([]*forge.Comment, error) {
+			return []*forge.Comment{
+				{Body: checkpointBody},
+			}, nil
+		},
+	}
+
+	runner := newTestRunner(mp, mt, ms)
+	task := newDefaultTask()
+
+	err := runner.Run(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	// Should have 3 messages: system prompt, resume prompt, user message.
+	if len(capturedMessages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(capturedMessages))
+	}
+	if capturedMessages[1].Role != provider.RoleSystem {
+		t.Errorf("resume message role = %q, want %q", capturedMessages[1].Role, provider.RoleSystem)
+	}
+	if !searchString(capturedMessages[1].Content, "<prior-work>") {
+		t.Error("resume message should contain <prior-work> tags")
+	}
+}
+
+func TestRunnerNoCheckpoint(t *testing.T) {
+	// When no checkpoint exists, messages should be the standard 2 (system + user).
+	var capturedMessages []provider.Message
+
+	ms := newDefaultMockStore()
+	mp := &mockProvider{
+		chatFn: func(_ context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+			capturedMessages = req.Messages
+			return &provider.ChatResponse{
+				Message: provider.Message{
+					Role:    provider.RoleAssistant,
+					Content: "Fresh start.",
+				},
+			}, nil
+		},
+		healthyFn: func(_ context.Context) bool { return true },
+		nameFn:    func() string { return "test-provider" },
+	}
+
+	mt := &mockTracker{
+		addCommentFn: func(_ context.Context, _ int, _ string) (*forge.Comment, error) {
+			return &forge.Comment{ID: 1}, nil
+		},
+		listCommentsFn: func(_ context.Context, _ int) ([]*forge.Comment, error) {
+			return nil, nil // no comments
+		},
+	}
+
+	runner := newTestRunner(mp, mt, ms)
+	task := newDefaultTask()
+
+	err := runner.Run(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(capturedMessages) != 2 {
+		t.Errorf("expected 2 messages (no checkpoint), got %d", len(capturedMessages))
+	}
+}
+
+func TestFailTaskPostsCheckpoint(t *testing.T) {
+	var postedComments []string
+
+	ms := newDefaultMockStore()
+	ms.getSessionFn = func(_ context.Context, id string) (*models.Session, error) {
+		return &models.Session{
+			ID:            id,
+			Status:        models.SessionStatusActive,
+			PartialOutput: "some partial work",
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}, nil
+	}
+
+	mt := &mockTracker{
+		addCommentFn: func(_ context.Context, _ int, body string) (*forge.Comment, error) {
+			postedComments = append(postedComments, body)
+			return &forge.Comment{ID: 1, Body: body}, nil
+		},
+	}
+
+	runner := newTestRunner(&mockProvider{
+		nameFn: func() string { return "test" },
+	}, mt, ms)
+	task := newDefaultTask()
+
+	runner.failTask(context.Background(), task, "provider timeout")
+
+	// Should post 2 comments: checkpoint + error.
+	if len(postedComments) != 2 {
+		t.Fatalf("expected 2 comments (checkpoint + error), got %d", len(postedComments))
+	}
+
+	// First comment should be the checkpoint.
+	if !searchString(postedComments[0], "CHECKPOINT [") {
+		t.Errorf("first comment should be CHECKPOINT, got: %s", postedComments[0])
+	}
+	if !searchString(postedComments[0], "some partial work") {
+		t.Error("checkpoint should contain partial output")
+	}
+
+	// Second comment should be the error.
+	if !searchString(postedComments[1], "Agent error:") {
+		t.Errorf("second comment should be error, got: %s", postedComments[1])
+	}
+}
+
+func TestFailTaskSkipsCheckpointWhenEmpty(t *testing.T) {
+	var postedComments []string
+
+	ms := newDefaultMockStore()
+	ms.getSessionFn = func(_ context.Context, id string) (*models.Session, error) {
+		return &models.Session{
+			ID:            id,
+			Status:        models.SessionStatusActive,
+			PartialOutput: "", // no partial output
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}, nil
+	}
+
+	mt := &mockTracker{
+		addCommentFn: func(_ context.Context, _ int, body string) (*forge.Comment, error) {
+			postedComments = append(postedComments, body)
+			return &forge.Comment{ID: 1, Body: body}, nil
+		},
+	}
+
+	runner := newTestRunner(&mockProvider{
+		nameFn: func() string { return "test" },
+	}, mt, ms)
+	task := newDefaultTask()
+
+	runner.failTask(context.Background(), task, "some error")
+
+	// Should post only 1 comment: the error (no checkpoint).
+	if len(postedComments) != 1 {
+		t.Fatalf("expected 1 comment (error only), got %d", len(postedComments))
+	}
+	if !searchString(postedComments[0], "Agent error:") {
+		t.Errorf("comment should be error, got: %s", postedComments[0])
+	}
+}
+
 // Old buildSystemPrompt tests removed — replaced by prompts_test.go
 // which covers BuildSystemPrompt with per-agent-type verification.

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -28,8 +28,8 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO sessions (id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO sessions (id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sess.ID,
 		sess.IssueNumber,
 		sess.AgentType,
@@ -40,6 +40,7 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 		finishedAt,
 		sess.Error,
 		sess.PartialOutput,
+		sess.CheckpointHash,
 		sess.CreatedAt.Format(time.RFC3339),
 		sess.UpdatedAt.Format(time.RFC3339),
 	)
@@ -52,7 +53,7 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 // GetSession retrieves a session by ID. Returns ErrNotFound if no row matches.
 func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Session, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at
+		`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id)
 
 	sess, err := scanSession(row)
@@ -72,7 +73,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, sess *models.Session) e
 	}
 
 	result, err := s.db.ExecContext(ctx,
-		`UPDATE sessions SET issue_number=?, agent_type=?, provider=?, model=?, status=?, started_at=?, finished_at=?, error=?, partial_output=?, updated_at=?
+		`UPDATE sessions SET issue_number=?, agent_type=?, provider=?, model=?, status=?, started_at=?, finished_at=?, error=?, partial_output=?, checkpoint_hash=?, updated_at=?
 		 WHERE id=?`,
 		sess.IssueNumber,
 		sess.AgentType,
@@ -83,6 +84,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, sess *models.Session) e
 		finishedAt,
 		sess.Error,
 		sess.PartialOutput,
+		sess.CheckpointHash,
 		sess.UpdatedAt.Format(time.RFC3339),
 		sess.ID,
 	)
@@ -110,11 +112,11 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, status models.SessionSta
 
 	if status != "" {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at
+			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at
 			 FROM sessions WHERE status = ? ORDER BY created_at DESC`, string(status))
 	} else {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, created_at, updated_at
+			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at
 			 FROM sessions ORDER BY created_at DESC`)
 	}
 	if err != nil {
@@ -146,7 +148,7 @@ func scanSession(row *sql.Row) (*models.Session, error) {
 
 	err := row.Scan(
 		&sess.ID, &sess.IssueNumber, &sess.AgentType, &sess.Provider, &sess.Model,
-		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &createdAt, &updatedAt,
+		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &sess.CheckpointHash, &createdAt, &updatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
@@ -188,7 +190,7 @@ func scanSessionRows(rows *sql.Rows) (*models.Session, error) {
 
 	err := rows.Scan(
 		&sess.ID, &sess.IssueNumber, &sess.AgentType, &sess.Provider, &sess.Model,
-		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &createdAt, &updatedAt,
+		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &sess.CheckpointHash, &createdAt, &updatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("scan session row: %w", err)

--- a/internal/store/session_test.go
+++ b/internal/store/session_test.go
@@ -163,6 +163,60 @@ func TestListSessionsEmpty(t *testing.T) {
 	}
 }
 
+func TestCheckpointHashRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	sess := &models.Session{
+		IssueNumber: 77,
+		AgentType:   "code-gen",
+		Provider:    "claude-cli",
+		Model:       "opus-4",
+		Status:      models.SessionStatusActive,
+		StartedAt:   now,
+	}
+
+	if err := s.CreateSession(ctx, sess); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Initially empty.
+	got, err := s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.CheckpointHash != "" {
+		t.Errorf("initial checkpoint_hash = %q, want empty", got.CheckpointHash)
+	}
+
+	// Update with a checkpoint hash.
+	sess.CheckpointHash = "abc123def456"
+	if err := s.UpdateSession(ctx, sess); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, err = s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if got.CheckpointHash != "abc123def456" {
+		t.Errorf("checkpoint_hash = %q, want %q", got.CheckpointHash, "abc123def456")
+	}
+
+	// Verify it appears in list results too.
+	sessions, err := s.ListSessions(ctx, models.SessionStatusActive)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions count = %d, want 1", len(sessions))
+	}
+	if sessions[0].CheckpointHash != "abc123def456" {
+		t.Errorf("list checkpoint_hash = %q, want %q", sessions[0].CheckpointHash, "abc123def456")
+	}
+}
+
 func TestPartialOutputRoundTrip(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -99,9 +99,10 @@ CREATE TABLE IF NOT EXISTS sessions (
 	started_at     TEXT NOT NULL,
 	finished_at    TEXT,
 	error          TEXT,
-	partial_output TEXT NOT NULL DEFAULT '',
-	created_at     TEXT NOT NULL,
-	updated_at     TEXT NOT NULL
+	partial_output  TEXT NOT NULL DEFAULT '',
+	checkpoint_hash TEXT NOT NULL DEFAULT '',
+	created_at      TEXT NOT NULL,
+	updated_at      TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS cost_records (
@@ -159,6 +160,7 @@ CREATE TABLE IF NOT EXISTS task_profiles (
 	// is not available, so we detect and skip manually.
 	migrations := []string{
 		`ALTER TABLE sessions ADD COLUMN partial_output TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN checkpoint_hash TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, m := range migrations {
 		if _, err := s.db.ExecContext(context.Background(), m); err != nil {

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -24,7 +24,8 @@ type Session struct {
 	StartedAt     time.Time     `json:"started_at"`
 	FinishedAt    *time.Time    `json:"finished_at,omitempty"`
 	Error         string        `json:"error,omitempty"`
-	PartialOutput string        `json:"partial_output,omitempty"` // last checkpoint of streaming output
-	CreatedAt     time.Time     `json:"created_at"`
+	PartialOutput  string        `json:"partial_output,omitempty"`  // last checkpoint of streaming output
+	CheckpointHash string        `json:"checkpoint_hash,omitempty"` // SHA-256 of posted checkpoint for dedup
+	CreatedAt      time.Time     `json:"created_at"`
 	UpdatedAt     time.Time     `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary

- Save partial output as CHECKPOINT comments on issue when a session fails, so retries can resume from prior work
- Detect existing checkpoints on issue comments and inject resume prompt into provider messages
- Deduplicate EDIT blocks against prior checkpoint content to avoid rewriting files already committed
- Add `CheckpointHash` to Session model for cross-retry dedup (SHA-256 of checkpoint content)
- SQLite incremental migration for `checkpoint_hash` column

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 9 new tests green)
- [x] `golangci-lint run` — 0 issues
- [x] `GOOS=linux go build ./...` cross-compile passes
- [x] Pre-push hook passes (build + test + lint + markdownlint)

Closes #244

Generated with [Claude Code](https://claude.com/claude-code)