### PR TITLE
feat(#412): cross-model QC routing via dedicated provider chain

### DIFF
--- a/deploy/config/providers.yaml
+++ b/deploy/config/providers.yaml
@@ -40,3 +40,7 @@ routing:
 
   # Frontend SPA work
   frontend: [claude-sonnet]
+
+  # QC validation: use a different model than the default code-gen chain (ADR-030).
+  # Haiku first ensures cross-model diversity; sonnet fallback if haiku is unhealthy.
+  qc:       [claude-haiku, claude-sonnet]

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -128,6 +128,12 @@ func selectProviderKey(issue *forge.Issue, agentType models.AgentType) (key, rea
 		return "local", "title prefix chore:"
 	}
 
+	// QC: dedicated chain ensures cross-model validation (ADR-030).
+	// Checked after complex/local so critical QC issues still get the complex chain.
+	if agentType == models.AgentTypeQC {
+		return "qc", "agent type qc (cross-model validation)"
+	}
+
 	// Triage: low priority, docs agent, or short issue body.
 	if labels["priority:low"] {
 		return "triage", "label priority:low"

--- a/internal/dispatcher/router_test.go
+++ b/internal/dispatcher/router_test.go
@@ -118,6 +118,27 @@ func TestSelectProviderKey(t *testing.T) {
 			wantReason: "short issue body",
 		},
 
+		// --- qc tier ---
+		{
+			name:      "agent type qc → qc",
+			issue:     &forge.Issue{Title: "validate: check output", Body: longBody},
+			agentType: models.AgentTypeQC,
+			wantKey:   "qc",
+			wantReason: "cross-model",
+		},
+		{
+			// complex beats qc: priority:critical takes precedence
+			name: "priority:critical beats qc agent type",
+			issue: &forge.Issue{
+				Title:  "validate: critical output",
+				Body:   longBody,
+				Labels: []string{"priority:critical"},
+			},
+			agentType: models.AgentTypeQC,
+			wantKey:   "complex",
+			wantReason: "priority:critical",
+		},
+
 		// --- default tier ---
 		{
 			name:      "no signals → default",


### PR DESCRIPTION
## Summary

- Add `qc` routing chain in providers.yaml using haiku-first ordering for cross-model diversity (ADR-030)
- Insert QC case in `selectProviderKey()` between local and triage tiers
- Priority:critical still overrides QC routing (intentional)

Closes #412

## Test plan

- [x] 2 table-driven test cases: `qc agent -> qc key` and `priority:critical beats qc`
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [x] golangci-lint 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)