### PR TITLE
fix(server): protect API routes with BearerAuth middleware

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -139,7 +139,13 @@ func (s *Server) registerRoutes() {
 	}
 
 	if s.cfg.APIHandler != nil {
-		s.cfg.APIHandler.RegisterRoutes(s.mux)
+		apiMux := http.NewServeMux()
+		s.cfg.APIHandler.RegisterRoutes(apiMux)
+		if s.cfg.AuthToken != "" || s.cfg.KeyStore != nil {
+			s.mux.Handle("/api/", BearerAuth(s.cfg.AuthToken, s.cfg.KeyStore)(apiMux))
+		} else {
+			s.mux.Handle("/api/", apiMux)
+		}
 	} else {
 		s.mux.HandleFunc("/api/v1/", s.handleNotImplemented)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -114,6 +114,90 @@ func TestAPINotImplemented(t *testing.T) {
 	}
 }
 
+// stubAPI is a minimal APIRegistrar that registers a single test endpoint.
+type stubAPI struct{}
+
+func (stubAPI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"pong":true}`))
+	})
+}
+
+func TestAPIRoutesRequireAuth(t *testing.T) {
+	const token = "test-api-token"
+
+	s := server.New(server.Config{
+		Addr:       "localhost:0",
+		AuthToken:  token,
+		APIHandler: stubAPI{},
+	}, nil)
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+
+	tests := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+	}{
+		{
+			name:       "no auth returns 401",
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "wrong token returns 401",
+			authHeader: "Bearer wrong-token",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "valid token returns 200",
+			authHeader: "Bearer " + token,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+"/api/v1/ping", http.NoBody)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAPIRoutesNoAuthWhenTokenEmpty(t *testing.T) {
+	s := server.New(server.Config{
+		Addr:       "localhost:0",
+		AuthToken:  "", // no token = no auth
+		APIHandler: stubAPI{},
+	}, nil)
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+
+	resp := get(t, ts.URL+"/api/v1/ping")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (no auth should pass through)", resp.StatusCode, http.StatusOK)
+	}
+}
+
 func TestGracefulShutdown(t *testing.T) {
 	s := server.New(server.Config{Addr: "localhost:0"}, zap.NewNop())
 


### PR DESCRIPTION
## Summary

- Wraps all `/api/v1/` routes with `BearerAuth` middleware using a sub-mux pattern
- Previously only `/mcp` was auth-protected; API routes (including scaling control and worker registration) were fully exposed
- No-op passthrough when neither `AuthToken` nor `KeyStore` is configured (backwards compatible for local dev)

Closes #407, Closes #408

## Test plan

- [x] New `TestAPIRoutesRequireAuth` verifies 401 without token, 401 with wrong token, 200 with valid token
- [x] New `TestAPIRoutesNoAuthWhenTokenEmpty` verifies passthrough when no auth configured
- [x] All existing tests pass (no auth needed since api_test.go creates its own mux)
- [x] Cross-compile check (linux/amd64)
- [ ] Deploy to CT 202 and verify `curl` without token gets 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)