### PR TITLE
feat(dashboard): inject auth token into SPA for API access

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,7 +151,7 @@ func (s *Server) registerRoutes() {
 	}
 
 	// Serve embedded SPA for all unmatched routes.
-	s.mux.Handle("/", spaHandler())
+	s.mux.Handle("/", spaHandler(s.cfg.AuthToken))
 }
 
 // healthResponse is the JSON body returned by /healthz.

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"embed"
+	"html"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -12,11 +14,28 @@ var staticFS embed.FS
 
 // spaHandler serves the embedded SPA files. For paths that don't match a
 // static file, it serves index.html to support client-side routing.
-func spaHandler() http.Handler {
+//
+// When authToken is non-empty, index.html responses are rewritten to inject
+// a <script> tag that sets window.__SAMVERK_TOKEN__ so the SPA can
+// authenticate against the API.
+func spaHandler(authToken string) http.Handler {
 	sub, err := fs.Sub(staticFS, "static")
 	if err != nil {
 		panic("embedded static filesystem: " + err.Error())
 	}
+
+	// Pre-read index.html for token injection (only when token is configured).
+	var injectedIndex []byte
+	if authToken != "" {
+		raw, readErr := fs.ReadFile(sub, "index.html")
+		if readErr != nil {
+			panic("read embedded index.html: " + readErr.Error())
+		}
+		safe := html.EscapeString(authToken)
+		tag := []byte(`<script>window.__SAMVERK_TOKEN__="` + safe + `";</script>`)
+		injectedIndex = bytes.Replace(raw, []byte("</head>"), append(tag, []byte("</head>")...), 1)
+	}
+
 	fileServer := http.FileServer(http.FS(sub))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Try to serve the actual file first.
@@ -24,10 +43,28 @@ func spaHandler() http.Handler {
 		if path == "" {
 			path = "index.html"
 		}
-		if _, err := fs.Stat(sub, path); err != nil {
+
+		servingIndex := path == "index.html"
+		if _, statErr := fs.Stat(sub, path); statErr != nil {
 			// File not found -- serve index.html for client-side routing.
-			r.URL.Path = "/"
+			servingIndex = true
 		}
+
+		// If we have an injected index, serve it directly instead of
+		// going through FileServer so the token tag is included.
+		if servingIndex && injectedIndex != nil {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write(injectedIndex)
+			return
+		}
+
+		if !servingIndex {
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+
+		// No token configured -- let FileServer handle index.html as-is.
+		r.URL.Path = "/"
 		fileServer.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -3,8 +3,11 @@ package server_test
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/herbhall/samverk/internal/server"
 )
 
 func TestSPAServesIndexAtRoot(t *testing.T) {
@@ -80,6 +83,70 @@ func TestAPIRoutesPriority(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotImplemented {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotImplemented)
+	}
+}
+
+func TestSPATokenInjection(t *testing.T) {
+	const token = "test-dashboard-token"
+
+	s := server.New(server.Config{
+		Addr:      "localhost:0",
+		AuthToken: token,
+	}, nil)
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"root", "/"},
+		{"index.html", "/index.html"},
+		{"client route fallback", "/settings"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := get(t, ts.URL+tt.path)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			html := string(body)
+
+			wantTag := `<script>window.__SAMVERK_TOKEN__="test-dashboard-token";</script>`
+			if !strings.Contains(html, wantTag) {
+				t.Errorf("token script tag not found in response:\n%s", html)
+			}
+			// Tag must appear before </head>.
+			tagIdx := strings.Index(html, wantTag)
+			headIdx := strings.Index(html, "</head>")
+			if tagIdx > headIdx {
+				t.Errorf("token tag at %d appears after </head> at %d", tagIdx, headIdx)
+			}
+		})
+	}
+}
+
+func TestSPANoTokenWhenEmpty(t *testing.T) {
+	// When AuthToken is empty, no script tag should be injected.
+	ts := newTestServer(t) // uses empty Config
+
+	resp := get(t, ts.URL+"/")
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if strings.Contains(string(body), "__SAMVERK_TOKEN__") {
+		t.Errorf("token tag should not be present when AuthToken is empty:\n%s", body)
 	}
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,10 +1,26 @@
 const BASE = '/api/v1'
 
+// Read auth token injected by the Go server at serve time.
+declare global {
+  interface Window {
+    __SAMVERK_TOKEN__?: string
+  }
+}
+
+function getAuthHeaders(): HeadersInit {
+  const token = window.__SAMVERK_TOKEN__
+  if (token) {
+    return { Authorization: `Bearer ${token}` }
+  }
+  return {}
+}
+
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
+      ...getAuthHeaders(),
       ...init?.headers,
     },
   })


### PR DESCRIPTION
## Summary

- Injects `window.__SAMVERK_TOKEN__` into `index.html` at serve time so the SPA can authenticate against `/api/v1/` routes
- Token injection is cached at handler creation (zero per-request overhead)
- `html.EscapeString` prevents XSS if token contains special characters
- No injection when `AuthToken` is empty (backwards compatible for local dev)
- React API client reads the injected token and adds `Authorization: Bearer` header to all fetch calls

Depends on #420 (API auth middleware)
Closes #409

## Test plan

- [x] `TestSPATokenInjection` -- verifies script tag in index.html at `/`, `/index.html`, and client-route fallbacks
- [x] `TestSPANoTokenWhenEmpty` -- verifies no token tag when auth is not configured
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Manual: open dashboard in browser after deploying with auth token

🤖 Generated with [Claude Code](https://claude.com/claude-code)