### PR TITLE
fix(#226): restore systemd hardening with .claude ReadWritePaths

### DIFF
--- a/deploy/samverk-dispatch.service
+++ b/deploy/samverk-dispatch.service
@@ -41,6 +41,7 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 ReadWritePaths=/var/lib/samverk
+ReadWritePaths=/var/lib/samverk/.claude
 PrivateTmp=true
 
 [Install]

--- a/deploy/samverk-serve.service
+++ b/deploy/samverk-serve.service
@@ -26,6 +26,7 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 ReadWritePaths=/var/lib/samverk
+ReadWritePaths=/var/lib/samverk/.claude
 PrivateTmp=true
 
 [Install]


### PR DESCRIPTION
## Summary

- Add `ReadWritePaths=/var/lib/samverk/.claude` to both `samverk-serve.service` and `samverk-dispatch.service`
- Allows claude-cli credential access while maintaining `ProtectSystem=strict` sandbox

Closes #226

## Test plan

- [ ] Deploy to CT 202: `scp deploy/samverk-*.service root@192.168.1.162:/etc/systemd/system/`
- [ ] `systemctl daemon-reload && systemctl restart samverk-serve samverk-dispatch`
- [ ] Verify services healthy: `systemctl status samverk-serve samverk-dispatch`
- [ ] Health check passes: `curl http://192.168.1.162:8080/healthz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)