### PR TITLE
feat(#246): timeout calibration feedback loop

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -249,6 +249,9 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		)
 	}
 
+	// Step 9b: Log timeout accuracy (non-fatal, best-effort).
+	r.logTimeoutAccuracy(ctx, task)
+
 	return nil
 }
 
@@ -455,6 +458,26 @@ func (r *Runner) failTask(ctx context.Context, task Task, errMsg string) {
 			zap.String("error", err.Error()),
 		)
 	}
+}
+
+// logTimeoutAccuracy compares the estimated timeout against actual session
+// duration and logs the ratio. This data feeds into timeout calibration (#246).
+func (r *Runner) logTimeoutAccuracy(ctx context.Context, task Task) {
+	session, err := r.store.GetSession(ctx, task.SessionID)
+	if err != nil {
+		return
+	}
+	if session.EstimatedTimeout <= 0 || session.FinishedAt == nil {
+		return
+	}
+	actual := session.FinishedAt.Sub(session.StartedAt)
+	ratio := float64(actual) / float64(session.EstimatedTimeout)
+	r.logger.Info("timeout accuracy",
+		zap.Int("issue", task.Issue.Number),
+		zap.Duration("estimated", session.EstimatedTimeout),
+		zap.Duration("actual", actual),
+		zap.Float64("ratio", ratio),
+	)
 }
 
 // saveCheckpoint posts a CHECKPOINT comment on the issue if the session has

--- a/internal/dispatcher/complexity.go
+++ b/internal/dispatcher/complexity.go
@@ -1,11 +1,14 @@
 package dispatcher
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/internal/store"
 	"github.com/herbhall/samverk/pkg/models"
+	"go.uber.org/zap"
 )
 
 // Default timeout bounds.
@@ -136,6 +139,61 @@ func countCheckboxes(body string) int {
 		}
 	}
 	return count
+}
+
+// minCalibrationSamples is the minimum number of completed sessions required
+// before historical data replaces heuristic timeout estimation.
+const minCalibrationSamples = 20
+
+// calibrationSafetyMargin is the multiplier applied to p90 duration to provide
+// headroom for variance in task completion time.
+const calibrationSafetyMargin = 1.2
+
+// CalibratedTimeout returns a timeout based on historical session data when
+// enough samples exist for the (agentType, provider) pair. It uses p90
+// duration with a 20% safety margin, clamped to [MinTimeout, MaxTimeout].
+// Falls back to heuristic estimation when insufficient data is available.
+func CalibratedTimeout(
+	ctx context.Context,
+	st store.Store,
+	logger *zap.Logger,
+	issue *forge.Issue,
+	fm *models.IssueFrontmatter,
+	agentType models.AgentType,
+	providerKey string,
+) time.Duration {
+	// Frontmatter override always takes priority.
+	if fm != nil && fm.TimeoutMinutes > 0 {
+		return clampTimeout(time.Duration(fm.TimeoutMinutes) * time.Minute)
+	}
+
+	profile, err := st.GetTaskProfile(ctx, string(agentType), providerKey)
+	if err != nil {
+		logger.Warn("calibration: failed to get task profile, falling back to heuristic",
+			zap.String("agent_type", string(agentType)),
+			zap.String("provider", providerKey),
+			zap.Error(err),
+		)
+		return EstimateTimeout(issue, fm, agentType, providerKey)
+	}
+
+	if profile != nil && profile.SampleCount >= minCalibrationSamples {
+		calibrated := time.Duration(float64(profile.P90Duration) * calibrationSafetyMargin)
+		heuristic := EstimateTimeout(issue, fm, agentType, providerKey)
+		result := clampTimeout(calibrated)
+
+		logger.Info("timeout calibrated from historical data",
+			zap.String("agent_type", string(agentType)),
+			zap.String("provider", providerKey),
+			zap.Int("samples", profile.SampleCount),
+			zap.Duration("p90", profile.P90Duration),
+			zap.Duration("calibrated", result),
+			zap.Duration("heuristic", heuristic),
+		)
+		return result
+	}
+
+	return EstimateTimeout(issue, fm, agentType, providerKey)
 }
 
 // countFileRefs counts file path references matching common project directories.

--- a/internal/dispatcher/complexity_test.go
+++ b/internal/dispatcher/complexity_test.go
@@ -1,12 +1,15 @@
 package dispatcher
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/internal/store"
 	"github.com/herbhall/samverk/pkg/models"
+	"go.uber.org/zap"
 )
 
 func TestEstimateTimeout_FrontmatterOverride(t *testing.T) {
@@ -184,6 +187,101 @@ func TestCountFileRefs(t *testing.T) {
 				t.Errorf("countFileRefs() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+// calibrationMockStore is a minimal mock implementing only GetTaskProfile
+// for testing CalibratedTimeout. All other Store methods panic if called.
+type calibrationMockStore struct {
+	store.Store // embed interface to satisfy remaining methods (will panic if called)
+	profile     *models.TaskProfile
+	err         error
+}
+
+func (m *calibrationMockStore) GetTaskProfile(_ context.Context, _, _ string) (*models.TaskProfile, error) {
+	return m.profile, m.err
+}
+
+func TestCalibratedTimeout_FallbackWhenNoData(t *testing.T) {
+	st := &calibrationMockStore{profile: nil}
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "short body"}
+	logger := zap.NewNop()
+
+	got := CalibratedTimeout(context.Background(), st, logger, issue, nil, models.AgentTypeCodeGen, "default")
+	heuristic := EstimateTimeout(issue, nil, models.AgentTypeCodeGen, "default")
+
+	if got != heuristic {
+		t.Errorf("with no profile, got %v, want heuristic %v", got, heuristic)
+	}
+}
+
+func TestCalibratedTimeout_FallbackWhenTooFewSamples(t *testing.T) {
+	st := &calibrationMockStore{
+		profile: &models.TaskProfile{
+			SampleCount: 5,
+			P90Duration: 10 * time.Minute,
+		},
+	}
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "short body"}
+	logger := zap.NewNop()
+
+	got := CalibratedTimeout(context.Background(), st, logger, issue, nil, models.AgentTypeCodeGen, "default")
+	heuristic := EstimateTimeout(issue, nil, models.AgentTypeCodeGen, "default")
+
+	if got != heuristic {
+		t.Errorf("with %d samples (< %d), got %v, want heuristic %v", 5, minCalibrationSamples, got, heuristic)
+	}
+}
+
+func TestCalibratedTimeout_UsesHistoricalWhenEnoughSamples(t *testing.T) {
+	p90 := 12 * time.Minute
+	st := &calibrationMockStore{
+		profile: &models.TaskProfile{
+			SampleCount: 25,
+			P90Duration: p90,
+		},
+	}
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "short body"}
+	logger := zap.NewNop()
+
+	got := CalibratedTimeout(context.Background(), st, logger, issue, nil, models.AgentTypeCodeGen, "default")
+	want := time.Duration(float64(p90) * calibrationSafetyMargin)
+
+	if got != want {
+		t.Errorf("with %d samples, got %v, want calibrated %v (p90 %v * %.1f)", 25, got, want, p90, calibrationSafetyMargin)
+	}
+}
+
+func TestCalibratedTimeout_ClampsToMax(t *testing.T) {
+	st := &calibrationMockStore{
+		profile: &models.TaskProfile{
+			SampleCount: 30,
+			P90Duration: 55 * time.Minute, // 55 * 1.2 = 66min > MaxTimeout
+		},
+	}
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "short body"}
+	logger := zap.NewNop()
+
+	got := CalibratedTimeout(context.Background(), st, logger, issue, nil, models.AgentTypeCodeGen, "default")
+	if got != MaxTimeout {
+		t.Errorf("got %v, want MaxTimeout %v", got, MaxTimeout)
+	}
+}
+
+func TestCalibratedTimeout_FrontmatterOverrideStillWins(t *testing.T) {
+	st := &calibrationMockStore{
+		profile: &models.TaskProfile{
+			SampleCount: 30,
+			P90Duration: 20 * time.Minute,
+		},
+	}
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "short body"}
+	fm := &models.IssueFrontmatter{TimeoutMinutes: 45}
+	logger := zap.NewNop()
+
+	got := CalibratedTimeout(context.Background(), st, logger, issue, fm, models.AgentTypeCodeGen, "default")
+	if got != 45*time.Minute {
+		t.Errorf("got %v, want 45m (frontmatter override)", got)
 	}
 }
 

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -174,8 +174,14 @@ func (d *Dispatcher) route(ctx context.Context, issue *forge.Issue, agentType mo
 
 	providerKey, reason := selectProviderKey(issue, agentType)
 
-	// Estimate per-issue timeout from complexity signals or frontmatter override.
-	timeout := EstimateTimeout(issue, fm, agentType, providerKey)
+	// Estimate per-issue timeout: use calibrated (historical) when available,
+	// fall back to heuristic signals or frontmatter override.
+	var timeout time.Duration
+	if d.store != nil {
+		timeout = CalibratedTimeout(ctx, d.store, d.logger, issue, fm, agentType, providerKey)
+	} else {
+		timeout = EstimateTimeout(issue, fm, agentType, providerKey)
+	}
 	d.logger.Info("timeout estimated",
 		zap.Int("issue", issue.Number),
 		zap.Duration("timeout", timeout),
@@ -207,13 +213,14 @@ func (d *Dispatcher) route(ctx context.Context, issue *forge.Issue, agentType mo
 	if d.pool != nil && d.store != nil {
 		sessionID := fmt.Sprintf("sess_%d_%d", issue.Number, time.Now().Unix())
 		session := &models.Session{
-			ID:          sessionID,
-			IssueNumber: issue.Number,
-			AgentType:   string(agentType),
-			Status:      models.SessionStatusPending,
-			StartedAt:   time.Now(),
-			CreatedAt:   time.Now(),
-			UpdatedAt:   time.Now(),
+			ID:               sessionID,
+			IssueNumber:      issue.Number,
+			AgentType:        string(agentType),
+			Status:           models.SessionStatusPending,
+			EstimatedTimeout: timeout,
+			StartedAt:        time.Now(),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
 		}
 		if err := d.store.CreateSession(ctx, session); err != nil {
 			return fmt.Errorf("create session for #%d: %w", issue.Number, err)

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -28,8 +28,8 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO sessions (id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO sessions (id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, estimated_timeout_ms, partial_output, checkpoint_hash, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sess.ID,
 		sess.IssueNumber,
 		sess.AgentType,
@@ -39,6 +39,7 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 		sess.StartedAt.Format(time.RFC3339),
 		finishedAt,
 		sess.Error,
+		sess.EstimatedTimeout.Milliseconds(),
 		sess.PartialOutput,
 		sess.CheckpointHash,
 		sess.CreatedAt.Format(time.RFC3339),
@@ -53,7 +54,7 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *models.Session) e
 // GetSession retrieves a session by ID. Returns ErrNotFound if no row matches.
 func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Session, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at
+		`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, estimated_timeout_ms, partial_output, checkpoint_hash, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id)
 
 	sess, err := scanSession(row)
@@ -73,7 +74,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, sess *models.Session) e
 	}
 
 	result, err := s.db.ExecContext(ctx,
-		`UPDATE sessions SET issue_number=?, agent_type=?, provider=?, model=?, status=?, started_at=?, finished_at=?, error=?, partial_output=?, checkpoint_hash=?, updated_at=?
+		`UPDATE sessions SET issue_number=?, agent_type=?, provider=?, model=?, status=?, started_at=?, finished_at=?, error=?, estimated_timeout_ms=?, partial_output=?, checkpoint_hash=?, updated_at=?
 		 WHERE id=?`,
 		sess.IssueNumber,
 		sess.AgentType,
@@ -83,6 +84,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, sess *models.Session) e
 		sess.StartedAt.Format(time.RFC3339),
 		finishedAt,
 		sess.Error,
+		sess.EstimatedTimeout.Milliseconds(),
 		sess.PartialOutput,
 		sess.CheckpointHash,
 		sess.UpdatedAt.Format(time.RFC3339),
@@ -112,11 +114,11 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, status models.SessionSta
 
 	if status != "" {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at
+			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, estimated_timeout_ms, partial_output, checkpoint_hash, created_at, updated_at
 			 FROM sessions WHERE status = ? ORDER BY created_at DESC`, string(status))
 	} else {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, partial_output, checkpoint_hash, created_at, updated_at
+			`SELECT id, issue_number, agent_type, provider, model, status, started_at, finished_at, error, estimated_timeout_ms, partial_output, checkpoint_hash, created_at, updated_at
 			 FROM sessions ORDER BY created_at DESC`)
 	}
 	if err != nil {
@@ -138,17 +140,18 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, status models.SessionSta
 // scanSession scans a single session from a *sql.Row.
 func scanSession(row *sql.Row) (*models.Session, error) {
 	var (
-		sess       models.Session
-		status     string
-		startedAt  string
-		finishedAt sql.NullString
-		createdAt  string
-		updatedAt  string
+		sess               models.Session
+		status             string
+		startedAt          string
+		finishedAt         sql.NullString
+		estimatedTimeoutMs int64
+		createdAt          string
+		updatedAt          string
 	)
 
 	err := row.Scan(
 		&sess.ID, &sess.IssueNumber, &sess.AgentType, &sess.Provider, &sess.Model,
-		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &sess.CheckpointHash, &createdAt, &updatedAt,
+		&status, &startedAt, &finishedAt, &sess.Error, &estimatedTimeoutMs, &sess.PartialOutput, &sess.CheckpointHash, &createdAt, &updatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
@@ -158,6 +161,7 @@ func scanSession(row *sql.Row) (*models.Session, error) {
 	}
 
 	sess.Status = models.SessionStatus(status)
+	sess.EstimatedTimeout = time.Duration(estimatedTimeoutMs) * time.Millisecond
 	if sess.StartedAt, err = time.Parse(time.RFC3339, startedAt); err != nil {
 		return nil, fmt.Errorf("parse started_at: %w", err)
 	}
@@ -180,23 +184,25 @@ func scanSession(row *sql.Row) (*models.Session, error) {
 // scanSessionRows scans a single session from *sql.Rows.
 func scanSessionRows(rows *sql.Rows) (*models.Session, error) {
 	var (
-		sess       models.Session
-		status     string
-		startedAt  string
-		finishedAt sql.NullString
-		createdAt  string
-		updatedAt  string
+		sess               models.Session
+		status             string
+		startedAt          string
+		finishedAt         sql.NullString
+		estimatedTimeoutMs int64
+		createdAt          string
+		updatedAt          string
 	)
 
 	err := rows.Scan(
 		&sess.ID, &sess.IssueNumber, &sess.AgentType, &sess.Provider, &sess.Model,
-		&status, &startedAt, &finishedAt, &sess.Error, &sess.PartialOutput, &sess.CheckpointHash, &createdAt, &updatedAt,
+		&status, &startedAt, &finishedAt, &sess.Error, &estimatedTimeoutMs, &sess.PartialOutput, &sess.CheckpointHash, &createdAt, &updatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("scan session row: %w", err)
 	}
 
 	sess.Status = models.SessionStatus(status)
+	sess.EstimatedTimeout = time.Duration(estimatedTimeoutMs) * time.Millisecond
 	if sess.StartedAt, err = time.Parse(time.RFC3339, startedAt); err != nil {
 		return nil, fmt.Errorf("parse started_at: %w", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -104,6 +104,7 @@ CREATE TABLE IF NOT EXISTS sessions (
 	started_at     TEXT NOT NULL,
 	finished_at    TEXT,
 	error          TEXT,
+	estimated_timeout_ms INTEGER NOT NULL DEFAULT 0,
 	partial_output  TEXT NOT NULL DEFAULT '',
 	checkpoint_hash TEXT NOT NULL DEFAULT '',
 	created_at      TEXT NOT NULL,
@@ -187,6 +188,7 @@ CREATE TABLE IF NOT EXISTS metric_snapshots (
 	migrations := []string{
 		`ALTER TABLE sessions ADD COLUMN partial_output TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN checkpoint_hash TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN estimated_timeout_ms INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, m := range migrations {
 		if _, err := s.db.ExecContext(context.Background(), m); err != nil {

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -15,17 +15,18 @@ const (
 
 // Session represents a unit of agent work on an issue.
 type Session struct {
-	ID            string        `json:"id"`
-	IssueNumber   int           `json:"issue_number"`
-	AgentType     string        `json:"agent_type"` // e.g., "code-gen", "qc", "research"
-	Provider      string        `json:"provider"`   // e.g., "ollama", "claude", "openai"
-	Model         string        `json:"model"`      // e.g., "qwen2.5-coder:7b"
-	Status        SessionStatus `json:"status"`
-	StartedAt     time.Time     `json:"started_at"`
-	FinishedAt    *time.Time    `json:"finished_at,omitempty"`
-	Error         string        `json:"error,omitempty"`
-	PartialOutput  string        `json:"partial_output,omitempty"`  // last checkpoint of streaming output
-	CheckpointHash string        `json:"checkpoint_hash,omitempty"` // SHA-256 of posted checkpoint for dedup
-	CreatedAt      time.Time     `json:"created_at"`
-	UpdatedAt     time.Time     `json:"updated_at"`
+	ID               string        `json:"id"`
+	IssueNumber      int           `json:"issue_number"`
+	AgentType        string        `json:"agent_type"` // e.g., "code-gen", "qc", "research"
+	Provider         string        `json:"provider"`   // e.g., "ollama", "claude", "openai"
+	Model            string        `json:"model"`      // e.g., "qwen2.5-coder:7b"
+	Status           SessionStatus `json:"status"`
+	StartedAt        time.Time     `json:"started_at"`
+	FinishedAt       *time.Time    `json:"finished_at,omitempty"`
+	Error            string        `json:"error,omitempty"`
+	EstimatedTimeout time.Duration `json:"estimated_timeout_ms,omitempty"` // timeout predicted at dispatch time
+	PartialOutput    string        `json:"partial_output,omitempty"`       // last checkpoint of streaming output
+	CheckpointHash   string        `json:"checkpoint_hash,omitempty"`      // SHA-256 of posted checkpoint for dedup
+	CreatedAt        time.Time     `json:"created_at"`
+	UpdatedAt        time.Time     `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary

- Records estimated timeout at dispatch time in sessions table (new `estimated_timeout_ms` column)
- `CalibratedTimeout()` uses historical p90 duration * 1.2 safety margin when >= 20 samples exist for (agent_type, provider) pair
- Falls back to heuristic `EstimateTimeout()` when insufficient data
- Frontmatter `timeout_minutes` override always takes priority
- Accuracy logging after session completion tracks estimated vs actual ratio

## Test plan

- [x] `go build ./...` passes
- [x] `go test` passes (5 new calibration tests + existing tests)
- [x] `golangci-lint` clean (0 issues)
- [x] `GOOS=linux` cross-compile passes
- [x] Pre-push hook passes (build + test + lint + markdownlint)

Closes #246

Co-Authored-By: Claude <noreply@anthropic.com>