### PR TITLE
feat(#245): pre-flight issue decomposition for oversized tasks

### DIFF
--- a/internal/dispatcher/config.go
+++ b/internal/dispatcher/config.go
@@ -15,15 +15,19 @@ type Config struct {
 	MaxConsecutiveFailures     int           `yaml:"max_consecutive_failures"`
 	DependencyRecheckInterval  time.Duration `yaml:"dependency_recheck_interval"`
 	HeartbeatCheckInterval     time.Duration `yaml:"heartbeat_check_interval"`
+	DecompositionThreshold     time.Duration `yaml:"decomposition_threshold"`
+	DecompositionModel         string        `yaml:"decomposition_model"`
 }
 
 // configFile is the on-disk YAML representation with friendly duration fields.
 type configFile struct {
-	HeartbeatIntervalMinutes   int     `yaml:"heartbeat_interval_minutes"`
-	HeartbeatTimeoutMultiplier float64 `yaml:"heartbeat_timeout_multiplier"`
-	MaxConsecutiveFailures     int     `yaml:"max_consecutive_failures"`
-	DependencyRecheckSeconds   int     `yaml:"dependency_recheck_seconds"`
-	HeartbeatCheckSeconds      int     `yaml:"heartbeat_check_seconds"`
+	HeartbeatIntervalMinutes       int     `yaml:"heartbeat_interval_minutes"`
+	HeartbeatTimeoutMultiplier     float64 `yaml:"heartbeat_timeout_multiplier"`
+	MaxConsecutiveFailures         int     `yaml:"max_consecutive_failures"`
+	DependencyRecheckSeconds       int     `yaml:"dependency_recheck_seconds"`
+	HeartbeatCheckSeconds          int     `yaml:"heartbeat_check_seconds"`
+	DecompositionThresholdMinutes  int     `yaml:"decomposition_threshold_minutes"`
+	DecompositionModel             string  `yaml:"decomposition_model"`
 }
 
 // DefaultConfig returns production-ready defaults for a self-hosted deployment.
@@ -66,6 +70,12 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	if cf.HeartbeatCheckSeconds > 0 {
 		cfg.HeartbeatCheckInterval = time.Duration(cf.HeartbeatCheckSeconds) * time.Second
+	}
+	if cf.DecompositionThresholdMinutes > 0 {
+		cfg.DecompositionThreshold = time.Duration(cf.DecompositionThresholdMinutes) * time.Minute
+	}
+	if cf.DecompositionModel != "" {
+		cfg.DecompositionModel = cf.DecompositionModel
 	}
 
 	return cfg, nil

--- a/internal/dispatcher/decompose.go
+++ b/internal/dispatcher/decompose.go
@@ -1,0 +1,165 @@
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/pkg/models"
+	"go.uber.org/zap"
+)
+
+// SubTask is a single child issue proposed by the Decomposer.
+type SubTask struct {
+	Title     string          `json:"title"`
+	Body      string          `json:"body"`
+	AgentType models.AgentType `json:"agent_type"`
+	DependsOn []int           `json:"depends_on,omitempty"`
+}
+
+// Decomposer breaks an oversized issue into smaller sub-tasks.
+// Implementations may call an AI provider (e.g. haiku for fast triage)
+// or use rule-based heuristics.
+type Decomposer interface {
+	Decompose(ctx context.Context, issue *forge.Issue, estimatedTimeout, maxTimeout time.Duration) ([]SubTask, error)
+}
+
+// shouldDecompose returns true when the issue should be split into children.
+// Conditions: decomposition is enabled, timeout exceeds threshold, issue is not
+// already a child (has no parent_issue), and issue does not carry the
+// no-decompose label.
+func shouldDecompose(timeout time.Duration, cfg *Config, fm *models.IssueFrontmatter, issue *forge.Issue) bool {
+	// Feature disabled when threshold is zero.
+	if cfg.DecompositionThreshold <= 0 {
+		return false
+	}
+
+	// Already a child issue — don't recurse.
+	if fm != nil && fm.ParentIssue > 0 {
+		return false
+	}
+
+	// Manual override: no-decompose label.
+	for _, l := range issue.Labels {
+		if l == "no-decompose" {
+			return false
+		}
+	}
+
+	return timeout > cfg.DecompositionThreshold
+}
+
+// decomposeAndCreateChildren runs the decomposer and creates child issues.
+// It blocks the parent and returns true if decomposition occurred.
+func (d *Dispatcher) decomposeAndCreateChildren(
+	ctx context.Context,
+	issue *forge.Issue,
+	fm *models.IssueFrontmatter,
+	agentType models.AgentType,
+	timeout time.Duration,
+) (bool, error) {
+	if d.decomposer == nil {
+		return false, nil
+	}
+	if !shouldDecompose(timeout, d.config, fm, issue) {
+		return false, nil
+	}
+
+	d.logger.Info("decomposing oversized issue",
+		zap.Int("issue", issue.Number),
+		zap.Duration("estimated_timeout", timeout),
+		zap.Duration("threshold", d.config.DecompositionThreshold),
+	)
+
+	subtasks, err := d.decomposer.Decompose(ctx, issue, timeout, MaxTimeout)
+	if err != nil {
+		d.logger.Warn("decomposition failed, routing as-is",
+			zap.Int("issue", issue.Number),
+			zap.Error(err),
+		)
+		return false, nil
+	}
+
+	if len(subtasks) < 2 {
+		d.logger.Info("decomposer returned < 2 subtasks, routing as-is",
+			zap.Int("issue", issue.Number),
+			zap.Int("subtask_count", len(subtasks)),
+		)
+		return false, nil
+	}
+
+	childNumbers, createErr := d.createChildIssues(ctx, issue, agentType, subtasks)
+	if createErr != nil {
+		return false, fmt.Errorf("create child issues for #%d: %w", issue.Number, createErr)
+	}
+
+	// Block parent on all children.
+	if blockErr := d.blockIssue(ctx, issue.Number, childNumbers); blockErr != nil {
+		return false, fmt.Errorf("block parent #%d: %w", issue.Number, blockErr)
+	}
+
+	d.logger.Info("issue decomposed",
+		zap.Int("parent", issue.Number),
+		zap.Ints("children", childNumbers),
+	)
+
+	return true, nil
+}
+
+// createChildIssues creates forge issues for each subtask, linking them
+// back to the parent via frontmatter. Returns the created issue numbers.
+func (d *Dispatcher) createChildIssues(
+	ctx context.Context,
+	parent *forge.Issue,
+	fallbackAgent models.AgentType,
+	subtasks []SubTask,
+) ([]int, error) {
+	numbers := make([]int, 0, len(subtasks))
+
+	for i, st := range subtasks {
+		at := st.AgentType
+		if at == "" {
+			at = fallbackAgent
+		}
+
+		body := buildChildBody(parent.Number, at, st.Body, st.DependsOn)
+
+		labels := []string{
+			"status:queued",
+			fmt.Sprintf("agent:%s", at),
+			"decomposed",
+		}
+
+		created, err := d.tracker.CreateIssue(ctx, &forge.CreateIssueRequest{
+			Title:  st.Title,
+			Body:   body,
+			Labels: labels,
+		})
+		if err != nil {
+			return numbers, fmt.Errorf("create child %d/%d: %w", i+1, len(subtasks), err)
+		}
+
+		numbers = append(numbers, created.Number)
+		d.logger.Info("child issue created",
+			zap.Int("parent", parent.Number),
+			zap.Int("child", created.Number),
+			zap.String("title", st.Title),
+		)
+	}
+
+	return numbers, nil
+}
+
+// buildChildBody constructs the issue body with frontmatter linking to parent.
+func buildChildBody(parentNumber int, agentType models.AgentType, description string, dependsOn []int) string {
+	fm := fmt.Sprintf("---\nschema_version: \"1.0.0\"\ntype: task\nagent_type: %s\nparent_issue: %d\n", agentType, parentNumber)
+	if len(dependsOn) > 0 {
+		fm += "depends_on:\n"
+		for _, dep := range dependsOn {
+			fm += fmt.Sprintf("  - %d\n", dep)
+		}
+	}
+	fm += "---\n\n"
+	return fm + description
+}

--- a/internal/dispatcher/decompose_test.go
+++ b/internal/dispatcher/decompose_test.go
@@ -1,0 +1,281 @@
+package dispatcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/herbhall/samverk/internal/forge"
+	"github.com/herbhall/samverk/pkg/models"
+	"go.uber.org/zap"
+)
+
+// mockDecomposer is a test double for the Decomposer interface.
+type mockDecomposer struct {
+	result []SubTask
+	err    error
+	called bool
+}
+
+func (m *mockDecomposer) Decompose(_ context.Context, _ *forge.Issue, _, _ time.Duration) ([]SubTask, error) {
+	m.called = true
+	return m.result, m.err
+}
+
+func TestShouldDecompose(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeout   time.Duration
+		threshold time.Duration
+		fm        *models.IssueFrontmatter
+		labels    []string
+		want      bool
+	}{
+		{
+			name:      "disabled when threshold is zero",
+			timeout:   90 * time.Minute,
+			threshold: 0,
+			want:      false,
+		},
+		{
+			name:      "below threshold",
+			timeout:   30 * time.Minute,
+			threshold: 60 * time.Minute,
+			want:      false,
+		},
+		{
+			name:      "above threshold triggers decomposition",
+			timeout:   90 * time.Minute,
+			threshold: 60 * time.Minute,
+			want:      true,
+		},
+		{
+			name:      "child issue skipped",
+			timeout:   90 * time.Minute,
+			threshold: 60 * time.Minute,
+			fm:        &models.IssueFrontmatter{ParentIssue: 42},
+			want:      false,
+		},
+		{
+			name:      "no-decompose label skipped",
+			timeout:   90 * time.Minute,
+			threshold: 60 * time.Minute,
+			labels:    []string{"no-decompose"},
+			want:      false,
+		},
+		{
+			name:      "nil frontmatter allowed",
+			timeout:   90 * time.Minute,
+			threshold: 60 * time.Minute,
+			fm:        nil,
+			want:      true,
+		},
+		{
+			name:      "exact threshold not triggered",
+			timeout:   60 * time.Minute,
+			threshold: 60 * time.Minute,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{DecompositionThreshold: tt.threshold}
+			issue := &forge.Issue{Number: 1, Title: "test", Labels: tt.labels}
+			got := shouldDecompose(tt.timeout, cfg, tt.fm, issue)
+			if got != tt.want {
+				t.Errorf("shouldDecompose() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecomposeAndCreateChildren_DisabledWhenNoDecomposer(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "body"}
+	decomposed, err := d.decomposeAndCreateChildren(
+		context.Background(), issue, nil, models.AgentTypeCodeGen, 90*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decomposed {
+		t.Error("expected no decomposition without decomposer")
+	}
+}
+
+func TestDecomposeAndCreateChildren_SkippedBelowThreshold(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+	d.config.DecompositionThreshold = 60 * time.Minute
+
+	dec := &mockDecomposer{}
+	d.decomposer = dec
+
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "body"}
+	tracker.issues[1] = issue
+
+	decomposed, err := d.decomposeAndCreateChildren(
+		context.Background(), issue, nil, models.AgentTypeCodeGen, 30*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decomposed {
+		t.Error("expected no decomposition below threshold")
+	}
+	if dec.called {
+		t.Error("decomposer should not have been called")
+	}
+}
+
+func TestDecomposeAndCreateChildren_CreatesChildren(t *testing.T) {
+	tracker := newMockTracker()
+	cfg := DefaultConfig()
+	cfg.DecompositionThreshold = 30 * time.Minute
+	d := New(tracker, &mockPolicy{costThreshold: 5.0}, nil, nil, cfg, zap.NewNop())
+
+	parent := &forge.Issue{Number: 100, Title: "big task", Body: "lots of work"}
+	tracker.issues[100] = parent
+
+	dec := &mockDecomposer{
+		result: []SubTask{
+			{Title: "child 1", Body: "do part 1", AgentType: models.AgentTypeCodeGen},
+			{Title: "child 2", Body: "do part 2", AgentType: models.AgentTypeTest},
+		},
+	}
+	d.decomposer = dec
+
+	decomposed, err := d.decomposeAndCreateChildren(
+		context.Background(), parent, nil, models.AgentTypeCodeGen, 60*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !decomposed {
+		t.Fatal("expected decomposition to occur")
+	}
+	if !dec.called {
+		t.Error("decomposer should have been called")
+	}
+
+	// Verify child issues were created.
+	if len(tracker.issues) != 3 { // parent + 2 children
+		t.Errorf("expected 3 issues, got %d", len(tracker.issues))
+	}
+
+	// Verify children have correct labels.
+	// mockTracker assigns num = len(issues)+1, so children get 2 and 3
+	// (parent at 100 makes len=1 before first child).
+	for _, num := range []int{2, 3} {
+		child := tracker.issues[num]
+		if child == nil {
+			t.Errorf("child #%d not found", num)
+			continue
+		}
+		hasDecomposed := false
+		hasQueued := false
+		for _, l := range child.Labels {
+			if l == "decomposed" {
+				hasDecomposed = true
+			}
+			if l == "status:queued" {
+				hasQueued = true
+			}
+		}
+		if !hasDecomposed {
+			t.Errorf("child #%d missing 'decomposed' label", num)
+		}
+		if !hasQueued {
+			t.Errorf("child #%d missing 'status:queued' label", num)
+		}
+	}
+
+	// Verify parent was blocked (AddLabel and AddComment called).
+	hasBlockLabel := false
+	hasBlockComment := false
+	for _, call := range tracker.calls {
+		if call == "AddLabel" {
+			hasBlockLabel = true
+		}
+		if call == "AddComment" {
+			hasBlockComment = true
+		}
+	}
+	if !hasBlockLabel {
+		t.Error("expected AddLabel call for blocking parent")
+	}
+	if !hasBlockComment {
+		t.Error("expected AddComment call for blocking parent")
+	}
+}
+
+func TestDecomposeAndCreateChildren_SingleSubtaskSkipped(t *testing.T) {
+	tracker := newMockTracker()
+	cfg := DefaultConfig()
+	cfg.DecompositionThreshold = 30 * time.Minute
+	d := New(tracker, &mockPolicy{costThreshold: 5.0}, nil, nil, cfg, zap.NewNop())
+
+	issue := &forge.Issue{Number: 1, Title: "test", Body: "body"}
+	tracker.issues[1] = issue
+
+	dec := &mockDecomposer{
+		result: []SubTask{
+			{Title: "only child", Body: "still one task"},
+		},
+	}
+	d.decomposer = dec
+
+	decomposed, err := d.decomposeAndCreateChildren(
+		context.Background(), issue, nil, models.AgentTypeCodeGen, 60*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decomposed {
+		t.Error("expected no decomposition with single subtask")
+	}
+}
+
+func TestBuildChildBody(t *testing.T) {
+	body := buildChildBody(42, models.AgentTypeCodeGen, "implement feature X", nil)
+	if body == "" {
+		t.Fatal("expected non-empty body")
+	}
+
+	// Verify frontmatter contains parent reference.
+	if got := body; !contains(got, "parent_issue: 42") {
+		t.Errorf("body missing parent_issue: %s", got)
+	}
+	if !contains(body, "agent_type: code-gen") {
+		t.Errorf("body missing agent_type: %s", body)
+	}
+	if !contains(body, "implement feature X") {
+		t.Errorf("body missing description: %s", body)
+	}
+}
+
+func TestBuildChildBody_WithDependsOn(t *testing.T) {
+	body := buildChildBody(42, models.AgentTypeTest, "write tests", []int{10, 11})
+	if !contains(body, "depends_on:") {
+		t.Errorf("body missing depends_on: %s", body)
+	}
+	if !contains(body, "- 10") || !contains(body, "- 11") {
+		t.Errorf("body missing dependency numbers: %s", body)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -31,6 +31,7 @@ type Dispatcher struct {
 	policy        autonomy.AutonomyPolicy
 	store         store.Store
 	pool          *agent.Pool
+	decomposer    Decomposer
 	config        *Config
 	claimed       map[int]*claimedIssue
 	issueFailures map[int]int // persists failure counts across re-queue cycles
@@ -60,6 +61,13 @@ func New(tracker forge.IssueTracker, policy autonomy.AutonomyPolicy, st store.St
 		metrics:       metrics.NewDispatcherMetrics(),
 		logger:        logger,
 	}
+}
+
+// SetDecomposer configures the optional issue decomposer. When set and the
+// decomposition threshold is exceeded, oversized issues are split into
+// child issues before routing.
+func (d *Dispatcher) SetDecomposer(dec Decomposer) {
+	d.decomposer = dec
 }
 
 // Snapshot returns a point-in-time snapshot of dispatcher metrics.
@@ -217,6 +225,25 @@ func (d *Dispatcher) handleOpened(ctx context.Context, ev forge.Event) error {
 		if blocked {
 			return d.blockIssue(ctx, issue.Number, blockers)
 		}
+	}
+
+	// Pre-flight decomposition: if the estimated timeout exceeds the
+	// configured threshold and this is not already a child issue, break
+	// it into smaller sub-tasks before routing.
+	providerKey, _ := selectProviderKey(issue, agentType)
+	var timeout time.Duration
+	if d.store != nil {
+		timeout = CalibratedTimeout(ctx, d.store, d.logger, issue, fm, agentType, providerKey)
+	} else {
+		timeout = EstimateTimeout(issue, fm, agentType, providerKey)
+	}
+
+	decomposed, decErr := d.decomposeAndCreateChildren(ctx, issue, fm, agentType, timeout)
+	if decErr != nil {
+		return fmt.Errorf("decompose #%d: %w", issue.Number, decErr)
+	}
+	if decomposed {
+		return nil // parent is now blocked on children; don't route it
 	}
 
 	return d.route(ctx, issue, agentType, fm)


### PR DESCRIPTION
## Summary

- Adds `Decomposer` interface and `shouldDecompose()` gate to the dispatcher
- When estimated timeout exceeds configurable `DecompositionThreshold`, oversized issues are split into 2+ child issues before routing
- Child issues get frontmatter with `parent_issue` linking back; parent is blocked until all children complete
- Skip conditions: already a child issue (`parent_issue` set), `no-decompose` label, or threshold disabled (default)
- Config: `decomposition_threshold_minutes` and `decomposition_model` in dispatcher YAML

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/dispatcher/...` — 7 new tests covering threshold, child skip, label override, creation flow, single subtask skip
- [x] `GOOS=linux GOARCH=amd64 go build ./...` cross-compile
- [x] `golangci-lint run ./internal/dispatcher/...` — 0 issues
- [x] All existing tests still pass (`go test ./...`)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)