### PR TITLE
fix: provider-down failures no longer escalate issues to needs-human

### DIFF
--- a/internal/dispatcher/classify_failure.go
+++ b/internal/dispatcher/classify_failure.go
@@ -44,10 +44,10 @@ func classifyFailure(errMsg string) models.FailureClass {
 		return models.FailureClassOOMKill
 	}
 
-	// Provider down: connection errors.
+	// Provider down: connection errors and provider hangs.
 	if strings.Contains(lower, "context deadline exceeded") || strings.Contains(lower, "connection refused") ||
 		strings.Contains(lower, "no such host") || strings.Contains(lower, "i/o timeout") ||
-		strings.Contains(lower, "no healthy provider") {
+		strings.Contains(lower, "no healthy provider") || strings.Contains(lower, "hung: no output") {
 		return models.FailureClassProviderDown
 	}
 

--- a/internal/dispatcher/classify_failure_test.go
+++ b/internal/dispatcher/classify_failure_test.go
@@ -499,6 +499,16 @@ func TestClassifyFailure(t *testing.T) {
 			input: "panic: runtime error: invalid memory address or nil pointer dereference",
 			want:  models.FailureClassPanic,
 		},
+		{
+			name:  "claude-cli hung with no output is provider_down",
+			input: "provider chat: claude-cli: hung: no output for 3m0s: output: ",
+			want:  models.FailureClassProviderDown,
+		},
+		{
+			name:  "hung no output generic",
+			input: "hung: no output for 5m0s",
+			want:  models.FailureClassProviderDown,
+		},
 	}
 
 	for _, tt := range tests {
@@ -609,6 +619,39 @@ func TestFailureClass_IsRetryableAndIsPermanentAreMutuallyExclusive(t *testing.T
 			t.Parallel()
 			if fc.IsRetryable() && fc.IsPermanent() {
 				t.Errorf("FailureClass(%q) is both retryable and permanent — impossible state", fc)
+			}
+		})
+	}
+}
+
+func TestFailureClass_IsProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		fc   models.FailureClass
+		want bool
+	}{
+		{models.FailureClassProviderDown, true},
+		{models.FailureClassOOMKill, true},
+		{models.FailureClassTimeout, false},
+		{models.FailureClassAuth, false},
+		{models.FailureClassBudget, false},
+		{models.FailureClassPermanent, false},
+		{models.FailureClassShutdown, false},
+		{models.FailureClassPanic, false},
+		{models.FailureClassPostProcess, false},
+		{models.FailureClassClassify, false},
+		{models.FailureClassCycle, false},
+		{models.FailureClassDecompose, false},
+		{models.FailureClassUnknown, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.fc), func(t *testing.T) {
+			t.Parallel()
+			got := tt.fc.IsProviderFailure()
+			if got != tt.want {
+				t.Errorf("FailureClass(%q).IsProviderFailure() = %v, want %v", tt.fc, got, tt.want)
 			}
 		})
 	}

--- a/internal/dispatcher/failure.go
+++ b/internal/dispatcher/failure.go
@@ -28,14 +28,28 @@ func (d *Dispatcher) recordFailure(ctx context.Context, issueNumber int, session
 		return
 	}
 
-	// Increment persisted counter and use it as the attempt number.
-	attempt, err := d.store.IncrementIssueFailureCount(ctx, issueNumber)
-	if err != nil {
-		d.logger.Error("increment failure count",
+	// Provider failures are infrastructure problems, not issue problems.
+	// Record the event for analysis but do NOT increment the per-issue
+	// failure counter, so provider outages can't escalate issues to needs-human.
+	var attempt int
+	if fc.IsProviderFailure() {
+		d.logger.Warn("provider failure -- not counting toward issue escalation",
 			zap.Int("issue", issueNumber),
-			zap.Error(err),
+			zap.String("class", string(fc)),
+			zap.String("error", errMsg),
 		)
-		attempt = 1 // fallback
+		attempt = d.getPersistedFailureCount(ctx, issueNumber)
+	} else {
+		// Increment persisted counter for task-specific failures.
+		var err error
+		attempt, err = d.store.IncrementIssueFailureCount(ctx, issueNumber)
+		if err != nil {
+			d.logger.Error("increment failure count",
+				zap.Int("issue", issueNumber),
+				zap.Error(err),
+			)
+			attempt = 1 // fallback
+		}
 	}
 
 	event := &models.FailureEvent{
@@ -50,7 +64,7 @@ func (d *Dispatcher) recordFailure(ctx context.Context, issueNumber int, session
 		Timestamp:    time.Now().UTC(),
 	}
 
-	if err = d.store.SaveFailureEvent(ctx, event); err != nil {
+	if err := d.store.SaveFailureEvent(ctx, event); err != nil {
 		d.logger.Error("save failure event",
 			zap.Int("issue", issueNumber),
 			zap.String("class", string(fc)),

--- a/pkg/models/failure.go
+++ b/pkg/models/failure.go
@@ -35,6 +35,18 @@ func (fc FailureClass) IsRetryable() bool {
 	}
 }
 
+// IsProviderFailure returns true if the failure is an infrastructure problem
+// (provider unreachable, unhealthy, or hung) rather than an issue-specific problem.
+// Provider failures should NOT count toward per-issue escalation thresholds.
+func (fc FailureClass) IsProviderFailure() bool {
+	switch fc {
+	case FailureClassProviderDown, FailureClassOOMKill:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsPermanent returns true if retrying will never succeed.
 func (fc FailureClass) IsPermanent() bool {
 	switch fc {


### PR DESCRIPTION
## Summary

Provider failures (no healthy provider, connection timeout, claude-cli hung) were incrementing per-issue failure counters and escalating to `status:needs-human` after 3 failures. This polluted the human queue with automatable issues.

Now `recordFailure()` checks `FailureClass.IsProviderFailure()` before incrementing the per-issue counter. Provider failures are logged and recorded for circuit breaker analysis but don't count toward human escalation.

Also classifies "hung: no output" errors as `FailureClassProviderDown` (was `Unknown`).

Closes #472

## Changes

- `pkg/models/failure.go`: add `IsProviderFailure()` method
- `internal/dispatcher/failure.go`: skip counter increment for provider failures
- `internal/dispatcher/classify_failure.go`: add "hung: no output" pattern
- `internal/dispatcher/classify_failure_test.go`: tests for new classification + `IsProviderFailure`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New test: `TestFailureClass_IsProviderFailure` covers all 13 failure classes
- [x] New test: "hung: no output" classified as `FailureClassProviderDown`
- [x] Pre-push CI passes (build, test, lint, markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)