### PR TITLE
feat: extend metrics trending window from 30m to 24h

### DIFF
--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -49,8 +49,9 @@ type historyResponse struct {
 }
 
 // historyMaxEntries is the maximum number of entries kept in the ring buffer.
-// At a 30-second poll interval this covers ~30 minutes of history.
-const historyMaxEntries = 60
+// At a 5-second dashboard poll interval with 1-in-6 sampling (every 30s),
+// 2880 entries covers 24 hours of history.
+const historyMaxEntries = 2880
 
 // taskProfileDTO is the JSON-serializable form of models.TaskProfile.
 // Duration fields are expressed in milliseconds.

--- a/web/src/pages/Metrics.tsx
+++ b/web/src/pages/Metrics.tsx
@@ -185,7 +185,7 @@ function ActivityFeed({ sessions }: { sessions: Session[] }) {
 function TrendingSection({ entries }: { entries: HistoryEntry[] }) {
   if (entries.length < 2) {
     return (
-      <SectionCard title="Trending (30m)">
+      <SectionCard title="Trending (24h)">
         <div className="py-6 text-center text-sm text-gray-400">Collecting data...</div>
       </SectionCard>
     )
@@ -210,7 +210,7 @@ function TrendingSection({ entries }: { entries: HistoryEntry[] }) {
   ]
 
   return (
-    <SectionCard title="Trending (30m)">
+    <SectionCard title="Trending (24h)">
       <div className="space-y-1 py-1">
         {rows.map((r) => (
           <div key={r.label} className="flex items-center justify-between py-1.5 border-b last:border-b-0">
@@ -418,7 +418,7 @@ export function Metrics() {
 
   const history = useQuery({
     queryKey: ['metrics-history'],
-    queryFn: () => api.getMetricsHistory('30m'),
+    queryFn: () => api.getMetricsHistory('24h'),
     refetchInterval: 30_000,
   })
 


### PR DESCRIPTION
Ring buffer 60 -> 2880 entries. Frontend queries 24h instead of 30m. Gives overnight visibility.