### PR TITLE
fix: add --no-session-persistence to claudecli provider

### DIFF
--- a/internal/provider/claudecli/claudecli.go
+++ b/internal/provider/claudecli/claudecli.go
@@ -103,7 +103,7 @@ func (c *Client) Chat(ctx context.Context, req provider.ChatRequest) (*provider.
 		}
 	}
 
-	args := []string{"--print", "--dangerously-skip-permissions"}
+	args := []string{"--print", "--dangerously-skip-permissions", "--no-session-persistence"}
 	if c.allowedTools != "" {
 		args = append(args, "--allowedTools", c.allowedTools)
 	}


### PR DESCRIPTION
## Summary

- Adds `--no-session-persistence` to claudecli CLI args to prevent session files accumulating on CT 202
- Samverk tasks are one-shot and never resumed, so persisted sessions just waste disk

One-line change in `claudecli.go`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/provider/claudecli/...` passes
- [x] `golangci-lint` -- 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)