### PR TITLE
infra: staging environment on CT 203

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build test test-race test-coverage test-integration test-all lint lint-md lint-all ci hooks run clean web dev-web \
-       cross-build cross-build-full deploy deploy-force redeploy ssh
+       cross-build cross-build-full deploy deploy-force deploy-staging redeploy ssh ssh-staging
 
 # Binary
 BIN=samverk
@@ -92,9 +92,19 @@ deploy-force: cross-build-full
 		systemctl start samverk-serve samverk-dispatch'
 	@echo "Force deployment complete. Services restarted."
 
+# Deploy to staging (CT 203)
+STAGING_HOST ?= 192.168.1.199
+
+deploy-staging: cross-build-full
+	bash scripts/safe-deploy.sh $(STAGING_HOST)
+
 # Quick SSH access to production server
 ssh:
 	ssh root@192.168.1.162
+
+# Quick SSH access to staging server
+ssh-staging:
+	ssh root@$(STAGING_HOST)
 
 clean:
 	rm -rf bin/ coverage.out


### PR DESCRIPTION
## Summary

- Created CT 203 LXC container on Proxmox (192.168.1.199) as staging environment
- 4 GB RAM, 4 cores, 32 GB disk, Debian 12, unprivileged with nesting
- Deployed samverk binary, systemd services, and config files
- Health check passing: `curl http://192.168.1.199:8080/healthz`
- Added `make deploy-staging` and `make ssh-staging` Makefile targets

## Infrastructure setup (done outside this PR)

- CT 203 created via `pct create` on Proxmox host (192.168.1.203)
- SSH key auth configured for direct access
- `samverk` service user created with proper directory structure
- `samverk-serve` running, `samverk-dispatch` disabled (matches production state)
- Separate SQLite database (fresh, no production data)

## Test plan

- [x] CT 203 created and running on Proxmox
- [x] Samverk binary deploys and starts on CT 203
- [x] Health check passes: `{"status":"ok","pressure":"moderate"}`
- [x] `make deploy-staging` target parses correctly (verified with `make -n`)
- [x] Staging uses separate database and config
- [ ] Full `make deploy-staging` end-to-end deploy after merge

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)