### PR TITLE
fix: classify auth failures and fix Synapset pool parameter

### DIFF
--- a/internal/dispatcher/classify_failure.go
+++ b/internal/dispatcher/classify_failure.go
@@ -24,7 +24,8 @@ func classifyFailure(errMsg string) models.FailureClass {
 	// Auth: OAuth/API key expiry or invalid credentials.
 	if strings.Contains(lower, "401") || strings.Contains(lower, "authentication_error") ||
 		strings.Contains(lower, "oauth token expired") || strings.Contains(lower, "unauthorized") ||
-		strings.Contains(lower, "invalid api key") || strings.Contains(lower, "invalid x-api-key") {
+		strings.Contains(lower, "invalid api key") || strings.Contains(lower, "invalid x-api-key") ||
+		strings.Contains(lower, "not logged in") {
 		return models.FailureClassAuth
 	}
 

--- a/internal/dispatcher/classify_failure_test.go
+++ b/internal/dispatcher/classify_failure_test.go
@@ -136,6 +136,11 @@ func TestClassifyFailure(t *testing.T) {
 			input: "provider returned status 401 with body: ...",
 			want:  models.FailureClassAuth,
 		},
+		{
+			name:  "not logged in is auth",
+			input: "claude-cli: exec: exit status 1: output: Not logged in · Please run /login",
+			want:  models.FailureClassAuth,
+		},
 
 		// --- budget ---
 		{

--- a/internal/synapset/client.go
+++ b/internal/synapset/client.go
@@ -382,7 +382,7 @@ func (c *Client) SearchMemory(ctx context.Context, pool, query string, limit int
 		limit = 5
 	}
 	args := map[string]interface{}{
-		"pool_name": pool,
+		"pool": pool,
 		"query":     query,
 		"limit":     limit,
 	}
@@ -412,7 +412,7 @@ func (c *Client) SearchAll(ctx context.Context, query string, limit int) (memori
 // StoreMemory saves a memory entry to the specified pool.
 func (c *Client) StoreMemory(ctx context.Context, pool, content, category string, tags []string, source string) error {
 	args := map[string]interface{}{
-		"pool_name": pool,
+		"pool": pool,
 		"content":   content,
 		"category":  category,
 	}

--- a/internal/synapset/client_test.go
+++ b/internal/synapset/client_test.go
@@ -157,8 +157,8 @@ func TestSearchMemory(t *testing.T) {
 		}
 		var a map[string]interface{}
 		_ = json.Unmarshal(args, &a)
-		if a["pool_name"] != "devkit" {
-			t.Errorf("pool_name = %v, want devkit", a["pool_name"])
+		if a["pool"] != "devkit" {
+			t.Errorf("pool = %v, want devkit", a["pool"])
 		}
 
 		memoriesJSON, _ := json.Marshal(memories)
@@ -224,8 +224,8 @@ func TestStoreMemory(t *testing.T) {
 	if capturedName != "store_memory" {
 		t.Errorf("tool name = %q, want store_memory", capturedName)
 	}
-	if capturedArgs["pool_name"] != "samverk" {
-		t.Errorf("pool_name = %v, want samverk", capturedArgs["pool_name"])
+	if capturedArgs["pool"] != "samverk" {
+		t.Errorf("pool = %v, want samverk", capturedArgs["pool"])
 	}
 	if capturedArgs["category"] != "decision" {
 		t.Errorf("category = %v, want decision", capturedArgs["category"])


### PR DESCRIPTION
## Summary

- Failure classifier now recognizes "not logged in" from Claude CLI as `auth` class (was falling through to `unknown`)
- Synapset client sends `pool` parameter instead of `pool_name` (matching the actual MCP API schema)

Both bugs discovered during Phase 5A gate testing on staging CT 203.

## Test plan

- [x] Existing classifier tests pass
- [x] New test case for "not logged in" -> auth
- [x] Synapset client tests updated and passing
- [x] Cross-compile check (linux/amd64)
- [x] golangci-lint clean

Closes #534