### PR TITLE
feat: add pre-posting validation gate for agent output

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -312,6 +312,22 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 		}
 	}
 
+	// Step 6c: Validate output before posting (code-gen/test agents).
+	valResult := ValidateBeforePost(ctx, task.AgentType, workDir, resp.Message.Content, r.logger)
+	if valResult != nil && !valResult.Pass {
+		if !valResult.Retryable {
+			r.failTask(ctx, task, fmt.Sprintf("validation failed (not retryable): %s", valResult.Errors[0].Message))
+			return fmt.Errorf("validation: %s", valResult.Errors[0].Message)
+		}
+		// Code error — retry once with validation errors as context.
+		retryResp, retryErr := r.retryWithValidationErrors(ctx, task, req, workDir, valResult)
+		if retryErr != nil {
+			r.failTask(ctx, task, fmt.Sprintf("validation retry failed: %v", retryErr))
+			return fmt.Errorf("validation retry: %w", retryErr)
+		}
+		resp = retryResp // use the retry response for postProcess
+	}
+
 	// Step 7: Post-process response based on agent type.
 	if err = r.postProcess(ctx, task, resp.Message.Content, workDir); err != nil {
 		r.failTask(ctx, task, fmt.Sprintf("post-process error: %v", err))
@@ -339,6 +355,59 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 	r.logTimeoutAccuracy(ctx, task)
 
 	return nil
+}
+
+// retryWithValidationErrors re-prompts the provider with validation error
+// context, giving it one chance to self-correct. Costs are attributed to the
+// same session. Returns the retry response or error.
+func (r *Runner) retryWithValidationErrors(
+	ctx context.Context,
+	task Task,
+	originalReq provider.ChatRequest,
+	workDir string,
+	valResult *ValidationResult,
+) (*provider.ChatResponse, error) {
+	// Build error context from validation errors.
+	var errMsg strings.Builder
+	errMsg.WriteString("Your previous output failed validation. Fix these errors:\n\n")
+	for _, ve := range valResult.Errors {
+		fmt.Fprintf(&errMsg, "## %s error\n%s\n", ve.Phase, ve.Message)
+		if ve.Output != "" {
+			fmt.Fprintf(&errMsg, "```\n%s\n```\n", ve.Output)
+		}
+	}
+
+	// Append error context as a new user message.
+	// Copy the original Messages slice to avoid mutating it.
+	retryReq := originalReq
+	retryReq.Messages = append(append([]provider.Message{}, originalReq.Messages...), provider.Message{
+		Role:    provider.RoleUser,
+		Content: errMsg.String(),
+	})
+
+	r.logger.Info("retrying with validation errors",
+		zap.Int("issue", task.Issue.Number),
+		zap.Int("error_count", len(valResult.Errors)),
+	)
+
+	// Re-call provider.
+	retryResp, err := r.provider.Chat(ctx, retryReq)
+	if err != nil {
+		return nil, fmt.Errorf("retry provider call: %w", err)
+	}
+
+	// Record cost for retry (same session).
+	if costErr := r.costs.RecordUsage(ctx, task.SessionID, r.provider.Name(), r.model, retryResp); costErr != nil {
+		r.logger.Error("retry cost recording failed", zap.Error(costErr))
+	}
+
+	// Re-validate the retry output.
+	retryVal := ValidateBeforePost(ctx, task.AgentType, workDir, retryResp.Message.Content, r.logger)
+	if retryVal != nil && !retryVal.Pass {
+		return nil, fmt.Errorf("validation failed after retry: %s", retryVal.Errors[0].Message)
+	}
+
+	return retryResp, nil
 }
 
 // postProgress posts a PROGRESS comment if the session has new partial output

--- a/internal/agent/runner_tier_test.go
+++ b/internal/agent/runner_tier_test.go
@@ -292,7 +292,7 @@ func TestFullRunWithTier3PolicyBlocksPostProcess(t *testing.T) {
 			return &provider.ChatResponse{
 				Message: provider.Message{
 					Role:    provider.RoleAssistant,
-					Content: "I'll fix this bug.",
+					Content: "This is a sufficiently long research response that passes the analytical validation gate minimum length check.",
 				},
 			}, nil
 		},

--- a/internal/agent/validator.go
+++ b/internal/agent/validator.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+// ValidationResult reports the outcome of pre-posting validation.
+type ValidationResult struct {
+	Pass      bool
+	Retryable bool // false for infrastructure failures; true for code errors
+	Errors    []ValidationError
+	Duration  time.Duration
+}
+
+// ValidationError describes a single validation failure.
+type ValidationError struct {
+	Phase   string // "build", "test", "format"
+	Message string
+	Output  string // truncated command output (max 2000 chars)
+}
+
+// maxValidationOutput is the maximum length of command output stored in a ValidationError.
+const maxValidationOutput = 2000
+
+// ValidateBeforePost checks agent output quality before posting.
+// For code-gen/test agents with a worktree (CLI flow): runs build/test on the worktree.
+// For code-gen/test agents without a worktree (API flow): skips (no local context to validate).
+// For analytical agents: checks format only.
+// Returns nil when no validation is needed.
+func ValidateBeforePost(ctx context.Context, agentType models.AgentType, workDir, response string, logger *zap.Logger) *ValidationResult {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	start := time.Now()
+
+	switch agentType {
+	case models.AgentTypeCodeGen, models.AgentTypeTest:
+		if workDir != "" {
+			result := validateWorktree(ctx, workDir, logger)
+			result.Duration = time.Since(start)
+			return result
+		}
+		// API flow without worktree: no local context to validate.
+		// This is an accepted degradation -- validation requires a worktree.
+		return nil
+
+	case models.AgentTypeDocs, models.AgentTypeResearch, models.AgentTypeQC,
+		models.AgentTypeHuman, models.AgentTypeOrchestrator, models.AgentTypeDispatcher,
+		models.AgentTypeInfra, models.AgentTypePC:
+		result := validateAnalytical(response)
+		result.Duration = time.Since(start)
+		return result
+
+	default:
+		return nil
+	}
+}
+
+// validateWorktree runs `go build ./...` and `go test ./...` in the worktree.
+func validateWorktree(ctx context.Context, workDir string, logger *zap.Logger) *ValidationResult {
+	result := &ValidationResult{Pass: true, Retryable: true}
+
+	// Build check.
+	buildOut, buildErr := runInDir(ctx, workDir, "go", "build", "./...")
+	if buildErr != nil {
+		logger.Warn("validation: build failed",
+			zap.String("workDir", workDir),
+			zap.String("output", truncate(buildOut, maxValidationOutput)),
+		)
+		result.Pass = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "build",
+			Message: fmt.Sprintf("go build failed: %v", buildErr),
+			Output:  truncate(buildOut, maxValidationOutput),
+		})
+		return result // Don't run tests if build fails.
+	}
+
+	// Test check.
+	testOut, testErr := runInDir(ctx, workDir, "go", "test", "./...")
+	if testErr != nil {
+		logger.Warn("validation: tests failed",
+			zap.String("workDir", workDir),
+			zap.String("output", truncate(testOut, maxValidationOutput)),
+		)
+		result.Pass = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "test",
+			Message: fmt.Sprintf("go test failed: %v", testErr),
+			Output:  truncate(testOut, maxValidationOutput),
+		})
+	}
+
+	return result
+}
+
+// validateAnalytical checks that analytical agent output is non-empty and reasonable.
+func validateAnalytical(response string) *ValidationResult {
+	trimmed := strings.TrimSpace(response)
+	if len(trimmed) < 50 {
+		return &ValidationResult{
+			Pass:      false,
+			Retryable: true,
+			Errors: []ValidationError{
+				{
+					Phase:   "format",
+					Message: fmt.Sprintf("response too short (%d chars, minimum 50)", len(trimmed)),
+				},
+			},
+		}
+	}
+	return &ValidationResult{Pass: true}
+}
+
+// runInDir executes a command in the given directory and returns combined output.
+// Uses a 120-second timeout to prevent hung builds from blocking the pipeline.
+func runInDir(ctx context.Context, dir, name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // G204: args are internally constructed
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// truncate returns at most maxLen characters from s.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "\n... (truncated)"
+}

--- a/internal/agent/validator_test.go
+++ b/internal/agent/validator_test.go
@@ -1,0 +1,312 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/herbhall/samverk/pkg/models"
+)
+
+func TestValidateBeforePost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		agentType models.AgentType
+		workDir   string
+		response  string
+		wantNil   bool
+		wantPass  bool
+	}{
+		{
+			name:      "code-gen with empty workDir returns nil",
+			agentType: models.AgentTypeCodeGen,
+			workDir:   "",
+			response:  "some code output",
+			wantNil:   true,
+		},
+		{
+			name:      "test with empty workDir returns nil",
+			agentType: models.AgentTypeTest,
+			workDir:   "",
+			response:  "some test output",
+			wantNil:   true,
+		},
+		{
+			name:      "docs agent validates as analytical with long response",
+			agentType: models.AgentTypeDocs,
+			response:  strings.Repeat("a", 60),
+			wantPass:  true,
+		},
+		{
+			name:      "research agent validates as analytical with long response",
+			agentType: models.AgentTypeResearch,
+			response:  strings.Repeat("a", 60),
+			wantPass:  true,
+		},
+		{
+			name:      "qc agent validates as analytical with short response",
+			agentType: models.AgentTypeQC,
+			response:  "short",
+			wantPass:  false,
+		},
+		{
+			name:      "human agent validates as analytical with empty response",
+			agentType: models.AgentTypeHuman,
+			response:  "",
+			wantPass:  false,
+		},
+		{
+			name:      "orchestrator validates as analytical",
+			agentType: models.AgentTypeOrchestrator,
+			response:  strings.Repeat("x", 50),
+			wantPass:  true,
+		},
+		{
+			name:      "dispatcher validates as analytical",
+			agentType: models.AgentTypeDispatcher,
+			response:  strings.Repeat("x", 50),
+			wantPass:  true,
+		},
+		{
+			name:      "infra validates as analytical",
+			agentType: models.AgentTypeInfra,
+			response:  strings.Repeat("x", 50),
+			wantPass:  true,
+		},
+		{
+			name:      "pc validates as analytical",
+			agentType: models.AgentTypePC,
+			response:  strings.Repeat("x", 50),
+			wantPass:  true,
+		},
+		{
+			name:      "unknown agent type returns nil",
+			agentType: models.AgentType("custom"),
+			response:  "anything",
+			wantNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ValidateBeforePost(context.Background(), tt.agentType, tt.workDir, tt.response, nil)
+			if tt.wantNil {
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+			if result.Pass != tt.wantPass {
+				t.Errorf("Pass = %v, want %v", result.Pass, tt.wantPass)
+			}
+		})
+	}
+}
+
+func TestValidateAnalytical(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response string
+		wantPass bool
+		wantErr  string
+	}{
+		{
+			name:     "empty response fails",
+			response: "",
+			wantPass: false,
+			wantErr:  "response too short (0 chars, minimum 50)",
+		},
+		{
+			name:     "whitespace-only response fails",
+			response: "   \n\t  ",
+			wantPass: false,
+			wantErr:  "response too short (0 chars, minimum 50)",
+		},
+		{
+			name:     "short response fails",
+			response: "too short",
+			wantPass: false,
+			wantErr:  "response too short (9 chars, minimum 50)",
+		},
+		{
+			name:     "exactly 49 chars fails",
+			response: strings.Repeat("a", 49),
+			wantPass: false,
+		},
+		{
+			name:     "exactly 50 chars passes",
+			response: strings.Repeat("a", 50),
+			wantPass: true,
+		},
+		{
+			name:     "long response passes",
+			response: strings.Repeat("a", 500),
+			wantPass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := validateAnalytical(tt.response)
+			if result.Pass != tt.wantPass {
+				t.Errorf("Pass = %v, want %v", result.Pass, tt.wantPass)
+			}
+			if !tt.wantPass && tt.wantErr != "" {
+				if len(result.Errors) == 0 {
+					t.Fatal("expected errors, got none")
+				}
+				if result.Errors[0].Message != tt.wantErr {
+					t.Errorf("error message = %q, want %q", result.Errors[0].Message, tt.wantErr)
+				}
+				if result.Errors[0].Phase != "format" {
+					t.Errorf("error phase = %q, want %q", result.Errors[0].Phase, "format")
+				}
+			}
+			if !tt.wantPass && !result.Retryable {
+				t.Error("analytical failures should be retryable")
+			}
+		})
+	}
+}
+
+func TestValidateWorktree_ValidCode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeGoFiles(t, dir, "module testmod\ngo 1.22\n",
+		"package main\nfunc main() {}\n",
+		"package main\nimport \"testing\"\nfunc TestMain(m *testing.M) { m.Run() }\n",
+	)
+
+	result := validateWorktree(context.Background(), dir, zap.NewNop())
+	if !result.Pass {
+		t.Errorf("expected pass, got errors: %+v", result.Errors)
+	}
+}
+
+func TestValidateWorktree_BuildFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeGoFiles(t, dir, "module testmod\ngo 1.22\n",
+		"package main\nfunc main() { invalid syntax here }\n",
+		"",
+	)
+
+	result := validateWorktree(context.Background(), dir, zap.NewNop())
+	if result.Pass {
+		t.Fatal("expected failure, got pass")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected errors, got none")
+	}
+	if result.Errors[0].Phase != "build" {
+		t.Errorf("phase = %q, want %q", result.Errors[0].Phase, "build")
+	}
+	if !result.Retryable {
+		t.Error("build failures should be retryable")
+	}
+}
+
+func TestValidateWorktree_TestFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeGoFiles(t, dir, "module testmod\ngo 1.22\n",
+		"package main\nfunc main() {}\n",
+		"package main\nimport \"testing\"\nfunc TestFail(t *testing.T) { t.Fatal(\"intentional failure\") }\n",
+	)
+
+	result := validateWorktree(context.Background(), dir, zap.NewNop())
+	if result.Pass {
+		t.Fatal("expected failure, got pass")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected errors, got none")
+	}
+	if result.Errors[0].Phase != "test" {
+		t.Errorf("phase = %q, want %q", result.Errors[0].Phase, "test")
+	}
+	if !result.Retryable {
+		t.Error("test failures should be retryable")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{
+			name:   "short string unchanged",
+			input:  "hello",
+			maxLen: 10,
+			want:   "hello",
+		},
+		{
+			name:   "exact length unchanged",
+			input:  "hello",
+			maxLen: 5,
+			want:   "hello",
+		},
+		{
+			name:   "long string truncated",
+			input:  "hello world",
+			maxLen: 5,
+			want:   "hello\n... (truncated)",
+		},
+		{
+			name:   "empty string unchanged",
+			input:  "",
+			maxLen: 10,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := truncate(tt.input, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}
+
+// writeGoFiles creates a minimal Go module in dir with go.mod, main.go, and
+// optionally main_test.go (when testContent is non-empty).
+func writeGoFiles(t *testing.T, dir, goMod, mainContent, testContent string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if mainContent != "" {
+		if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainContent), 0o644); err != nil {
+			t.Fatalf("write main.go: %v", err)
+		}
+	}
+	if testContent != "" {
+		if err := os.WriteFile(filepath.Join(dir, "main_test.go"), []byte(testContent), 0o644); err != nil {
+			t.Fatalf("write main_test.go: %v", err)
+		}
+	}
+}

--- a/internal/dispatcher/classify_failure.go
+++ b/internal/dispatcher/classify_failure.go
@@ -57,9 +57,10 @@ func classifyFailure(errMsg string) models.FailureClass {
 		return models.FailureClassTimeout
 	}
 
-	// Post-process: PR creation or comment posting errors.
+	// Post-process: PR creation, comment posting, or validation failures.
 	if strings.Contains(lower, "post-process error") || strings.Contains(lower, "create pr:") ||
-		strings.Contains(lower, "create branch") || strings.Contains(lower, "add comment:") {
+		strings.Contains(lower, "create branch") || strings.Contains(lower, "add comment:") ||
+		strings.Contains(lower, "validation failed") || strings.Contains(lower, "validation retry failed") {
 		return models.FailureClassPostProcess
 	}
 

--- a/internal/dispatcher/classify_failure_test.go
+++ b/internal/dispatcher/classify_failure_test.go
@@ -329,6 +329,16 @@ func TestClassifyFailure(t *testing.T) {
 			input: "CREATE PR: cannot create pull request",
 			want:  models.FailureClassPostProcess,
 		},
+		{
+			name:  "validation failed is post_process",
+			input: "validation failed (not retryable): go build failed",
+			want:  models.FailureClassPostProcess,
+		},
+		{
+			name:  "validation retry failed is post_process",
+			input: "validation retry failed: validation failed after retry: go test failed",
+			want:  models.FailureClassPostProcess,
+		},
 
 		// --- classify ---
 		{


### PR DESCRIPTION
## Summary

- Adds `ValidateBeforePost()` that checks agent output quality before posting to issues/PRs
- Code-gen/test agents with a worktree get `go build ./...` + `go test ./...` validation
- Analytical agents (research, docs, QC) get minimum-length format check
- Failed validation gets one retry with error context before escalating to failure engine
- `retryWithValidationErrors()` re-prompts the provider with build/test errors
- Validation failures classified as `post_process` in failure classifier

Closes #518

## Test plan

- [x] Table-driven tests: valid worktree PASS, syntax error FAIL (build), test failure FAIL (test)
- [x] Analytical validation: >= 50 chars PASS, empty/short FAIL
- [x] API flow (no worktree) returns nil (accepted degradation)
- [x] Non-code agent types route through analytical validation
- [x] Failure classifier: "validation failed" and "validation retry failed" -> post_process
- [x] Build, test, lint, cross-compile all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)