### PR TITLE
feat: equip agents with DevKit rules, project type detection, and git safety

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: foundation-rebuild
-updated: 2026-03-15T18:00:00Z
+updated: 2026-03-15T22:00:00Z
 updated_by: claude-code
 ---
 
@@ -8,16 +8,16 @@ updated_by: claude-code
 
 ## Phase
 
-Phase 5A: Foundation rebuild. Dispatcher OFF pending pipeline fixes. Implementing solo developer agent model (ADR-035). Focus: fix the agent pipeline so the tool can build itself.
+Phase 5A: Foundation rebuild. Dispatcher re-enabled on CT 202 with workspace isolation. Implementing solo developer agent model (ADR-035). Next: agent tooling (#521) and end-to-end verification.
 
 ## What Is Running
 
 - Samverk server: CT 202 (192.168.1.162:8080) -- healthy, API auth enabled
 - MCP endpoint: POST /mcp (Streamable HTTP, bearer auth)
-- Dispatcher: STOPPED (1 worker, scaling disabled) -- pending Phase 5A completion
+- Dispatcher: RUNNING (1 worker, workspace isolation via /var/lib/samverk/repo)
 - PR watcher: runs concurrently with dispatcher (auto-merge eligible PRs)
 - Gitea: CT 200 (192.168.1.160:3000 / gitea.herbhall.net) -- primary runtime forge
-- Staging: CT 203 (192.168.1.199:8080) -- available for testing
+- Staging: CT 203 (192.168.1.199:8080) -- available for testing (not yet deployed with latest)
 
 ## Phase 5A Progress
 
@@ -30,24 +30,31 @@ Phase 5A: Foundation rebuild. Dispatcher OFF pending pipeline fixes. Implementin
 | #515 | Tier enforcement in agent runner | #522 | MERGED |
 | #516 | Intelligent failure response engine | #525 | MERGED |
 | #519 | Staging CT 203 | #524 | MERGED |
-| #517 | Isolated agent workspaces (git worktrees) | #529 | OPEN (CI passing, auto-merge) |
+| #517 | Isolated agent workspaces (git worktrees) | #529 | MERGED |
+| #535 | Wire SetRepoDir in dispatcher startup | #536 | MERGED |
+| #518 | Pre-posting validation gate | #537 | MERGED |
 
 ### Remaining
 
 | Issue | Title | Depends On | Status |
 |-------|-------|------------|--------|
-| #518 | Pre-posting validation gate | #517 | Not started |
-| #521 | Agent tooling (DevKit rules, MCP, Synapset) | #517 | Not started (Wave 3) |
+| #521 | Agent tooling (DevKit rules, MCP, Synapset) | #517 | Not started |
 | #527 | Research: Docker containers as agent workspaces | -- | Not started |
 
 ### Gate Criteria (Resume Dispatcher)
 
-All of the following must be true before re-enabling the dispatcher:
+Progress toward full gate:
 
-1. #517 merged (workspace isolation)
-2. #521 merged (agent tooling parity)
-3. At least one successful end-to-end agent run on staging (CT 203)
-4. Failure response engine verified with at least 3 failure classes
+1. ~~#517 merged (workspace isolation)~~ DONE
+2. #521 merged (agent tooling parity) -- NOT YET
+3. At least one successful end-to-end agent run on staging (CT 203) -- NOT YET
+4. Failure response engine verified with at least 3 failure classes -- NOT YET
+
+Dispatcher is running in production with partial gate (workspace isolation + validation gate active). Full gate completion requires #521 and e2e verification.
+
+### Known Issues
+
+- SQLITE_BUSY warnings in logs: autoscaler and metric writer contend on shared SQLite DB when serve and dispatch run concurrently. Non-blocking but should be addressed.
 
 ## Architecture
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -175,7 +175,8 @@ func (r *Runner) Run(ctx context.Context, task Task) error {
 						zap.Error(mcpErr),
 					)
 				}
-				claudeMD := GenerateAgentCLAUDEMD(ProjectTypeGo, task.Issue.Body)
+				projectType := DetectProjectType(task.Issue.Labels)
+				claudeMD := GenerateAgentCLAUDEMD(projectType, task.Issue.Body)
 				if writeErr := os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(claudeMD), 0o600); writeErr != nil {
 					r.logger.Warn("failed to write CLAUDE.md to workspace",
 						zap.Int("issue", task.Issue.Number),

--- a/internal/agent/tooling.go
+++ b/internal/agent/tooling.go
@@ -85,6 +85,55 @@ Frontend:
 4. JSX unknown type: use ` + "`!= null`" + ` check, not bare ` + "`&&`" + `
 5. Verify all imports are used (ESLint catches what tsc misses)`
 
+// gitSafetyRules is the git workflow block for CLI agents operating in worktrees.
+const gitSafetyRules = `## Git Workflow
+
+You are running in an isolated git worktree on a dedicated branch.
+
+- Do NOT commit directly to main. Your worktree is already on an agent branch.
+- Make your changes, then let the runner handle commit and push.
+- If you need to run git commands, stay on the current branch.
+- Never force-push, skip hooks, or use --no-verify.
+- Never commit secrets, credentials, or API keys.`
+
+// knownGotchas is a curated subset of high-frequency gotchas for agents.
+const knownGotchas = `## Known Gotchas
+
+- gosec G101: Constants near credential code get flagged as hardcoded credentials. Add nolint annotation.
+- gocritic rangeValCopy: Iterating large structs by value copies them. Use index-based access.
+- Build-tag files (!windows): Lint errors in platform-specific files only appear in Linux CI.
+- go:embed cache: Go build cache does not detect changes to embedded files. Use make build.
+- Swagger drift: Any change to Go types in swagger-annotated handlers requires regenerating the spec.
+- context.WithTimeout: Cancels ALL downstream operations including cleanup. Use separate cleanup context.`
+
+// DetectProjectType infers the project type from issue labels. Labels are
+// checked for frontend/fullstack indicators. Falls back to Go (the primary
+// language of Samverk).
+func DetectProjectType(labels []string) string {
+	hasFrontend := false
+	hasBackend := false
+
+	for _, label := range labels {
+		lower := strings.ToLower(label)
+		switch {
+		case strings.Contains(lower, "frontend") || strings.Contains(lower, "web") || strings.Contains(lower, "ui"):
+			hasFrontend = true
+		case strings.Contains(lower, "backend") || strings.Contains(lower, "api") || strings.Contains(lower, "server"):
+			hasBackend = true
+		case strings.Contains(lower, "fullstack") || strings.Contains(lower, "full-stack"):
+			return ProjectTypeFullstack
+		}
+	}
+
+	if hasFrontend && hasBackend {
+		return ProjectTypeFullstack
+	}
+	if hasFrontend {
+		return ProjectTypeFrontend
+	}
+	return ProjectTypeGo
+}
+
 // mcpConfig is the JSON config for CLI agent MCP servers.
 var mcpConfig = map[string]interface{}{
 	"mcpServers": map[string]interface{}{
@@ -100,13 +149,15 @@ var mcpConfig = map[string]interface{}{
 }
 
 // GenerateAgentCLAUDEMD builds a per-worktree CLAUDE.md for agents. It includes
-// core principles, a CI checklist selected by project type, and the issue body
-// as task context.
+// core principles, git safety rules, a CI checklist selected by project type,
+// known gotchas, and the issue body as task context.
 func GenerateAgentCLAUDEMD(projectType, issueBody string) string {
 	var b strings.Builder
 
 	b.WriteString("# Agent Task\n\n")
 	b.WriteString(corePrinciples)
+	b.WriteString("\n\n")
+	b.WriteString(gitSafetyRules)
 	b.WriteString("\n\n")
 
 	switch projectType {
@@ -117,6 +168,9 @@ func GenerateAgentCLAUDEMD(projectType, issueBody string) string {
 	default: // "go" and any unrecognized type default to Go checklist
 		b.WriteString(goCIChecklist)
 	}
+
+	b.WriteString("\n\n")
+	b.WriteString(knownGotchas)
 
 	if issueBody != "" {
 		b.WriteString("\n\n## Task Context\n\n")

--- a/internal/agent/tooling_test.go
+++ b/internal/agent/tooling_test.go
@@ -98,6 +98,59 @@ func TestGenerateAgentCLAUDEMD_EmptyBody(t *testing.T) {
 	}
 }
 
+func TestGenerateAgentCLAUDEMD_GitSafety(t *testing.T) {
+	types := []string{ProjectTypeGo, ProjectTypeFrontend, ProjectTypeFullstack}
+	for _, pt := range types {
+		got := GenerateAgentCLAUDEMD(pt, "some task")
+		if !strings.Contains(got, "## Git Workflow") {
+			t.Errorf("CLAUDE.md for project type %q missing git safety rules", pt)
+		}
+		if !strings.Contains(got, "Never force-push") {
+			t.Errorf("CLAUDE.md for project type %q missing force-push warning", pt)
+		}
+	}
+}
+
+func TestGenerateAgentCLAUDEMD_KnownGotchas(t *testing.T) {
+	got := GenerateAgentCLAUDEMD(ProjectTypeGo, "some task")
+	if !strings.Contains(got, "## Known Gotchas") {
+		t.Error("CLAUDE.md missing Known Gotchas section")
+	}
+	if !strings.Contains(got, "rangeValCopy") {
+		t.Error("CLAUDE.md missing rangeValCopy gotcha")
+	}
+}
+
+func TestDetectProjectType(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   string
+	}{
+		{name: "no labels", labels: nil, want: ProjectTypeGo},
+		{name: "empty labels", labels: []string{}, want: ProjectTypeGo},
+		{name: "backend label", labels: []string{"area:agent", "priority:high"}, want: ProjectTypeGo},
+		{name: "frontend epic", labels: []string{"epic:frontend", "priority:high"}, want: ProjectTypeFrontend},
+		{name: "web label", labels: []string{"area:web"}, want: ProjectTypeFrontend},
+		{name: "ui label", labels: []string{"area:ui"}, want: ProjectTypeFrontend},
+		{name: "explicit fullstack", labels: []string{"fullstack"}, want: ProjectTypeFullstack},
+		{name: "full-stack hyphenated", labels: []string{"full-stack"}, want: ProjectTypeFullstack},
+		{name: "frontend+backend", labels: []string{"epic:frontend", "area:api"}, want: ProjectTypeFullstack},
+		{name: "frontend+server", labels: []string{"area:web", "area:server"}, want: ProjectTypeFullstack},
+		{name: "case insensitive", labels: []string{"EPIC:FRONTEND"}, want: ProjectTypeFrontend},
+		{name: "backend only", labels: []string{"area:api", "priority:high"}, want: ProjectTypeGo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectProjectType(tt.labels)
+			if got != tt.want {
+				t.Errorf("DetectProjectType(%v) = %q, want %q", tt.labels, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteMCPConfig(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- Add `DetectProjectType()` to infer project type from issue labels (frontend/fullstack/go) instead of hardcoding to Go
- Enrich agent CLAUDE.md with git safety rules and curated known gotchas
- Wire label-based detection in runner.go workspace setup
- Add 12-case table-driven tests for detection + tests for new CLAUDE.md sections

## What agents now get in their worktree

1. **Core principles** (unconditional rules)
2. **Git safety rules** (branch workflow, no force-push, no secrets)
3. **CI checklist** auto-selected by project type from issue labels
4. **Known gotchas** (curated high-frequency issues)
5. **Task context** (issue body)
6. **MCP config** (Samverk + Synapset endpoints) -- already existed
7. **Synapset patterns** in system prompt -- already existed

Closes #521

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all agent tests green)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [x] `golangci-lint` -- 0 issues
- [x] `markdownlint` -- 0 errors
- [x] DetectProjectType correctly routes 12 label combinations
- [x] CLAUDE.md includes git safety for all project types
- [x] CLAUDE.md includes known gotchas section

Co-Authored-By: Claude <noreply@anthropic.com>