### PR TITLE
fix: add Accept header to Synapset client for JSON content negotiation

### DIFF
--- a/internal/synapset/client.go
+++ b/internal/synapset/client.go
@@ -284,6 +284,7 @@ func (c *Client) doRequestWithSession(ctx context.Context, rpcReq jsonRPCRequest
 		return nil, "", fmt.Errorf("build request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
 	if session != "" {
 		httpReq.Header.Set("Mcp-Session-Id", session)
 	}


### PR DESCRIPTION
## Summary

- Adds `Accept: application/json` header to all Synapset HTTP requests
- Fixes JSON parsing errors when Synapset returns text-formatted responses due to missing content-type negotiation

## Test plan

- [x] All 14 existing Synapset tests pass
- [x] Pre-push CI green (build, test, lint, markdownlint)

Closes #544

Co-Authored-By: Claude <noreply@anthropic.com>