### PR TITLE
fix: set SQLite pragmas via DSN for all pooled connections

### DIFF
--- a/internal/logstore/logstore.go
+++ b/internal/logstore/logstore.go
@@ -43,21 +43,12 @@ type LogStore struct {
 // New opens (or creates) a SQLite database at dbPath for log storage,
 // enables WAL mode and busy_timeout, and runs migrations.
 func New(dbPath string) (*LogStore, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	// Set busy_timeout via DSN so it applies to ALL pooled connections,
+	// not just the first one (PRAGMA only affects the connection it runs on).
+	dsn := dbPath + "?_pragma=busy_timeout%3d5000&_pragma=journal_mode%3dWAL"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open log database: %w", err)
-	}
-
-	// Enable WAL mode for concurrent read performance.
-	if _, err = db.ExecContext(context.Background(), "PRAGMA journal_mode=WAL"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("enable WAL: %w", err)
-	}
-
-	// Set busy timeout to avoid SQLITE_BUSY during concurrent writes.
-	if _, err = db.ExecContext(context.Background(), "PRAGMA busy_timeout=5000"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("set busy_timeout: %w", err)
 	}
 
 	s := &LogStore{db: db}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,28 +75,13 @@ type SQLiteStore struct {
 // New opens (or creates) an SQLite database at dbPath, runs migrations,
 // and enables WAL mode and foreign keys.
 func New(dbPath string) (*SQLiteStore, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	// Set pragmas via DSN so they apply to ALL pooled connections,
+	// not just the first one. PRAGMA statements only affect the connection
+	// they execute on, which causes SQLITE_BUSY on other pool connections.
+	dsn := dbPath + "?_pragma=busy_timeout%3d5000&_pragma=journal_mode%3dWAL&_pragma=foreign_keys%3dON"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
-	}
-
-	// Enable WAL mode for concurrent read performance.
-	if _, err = db.ExecContext(context.Background(), "PRAGMA journal_mode=WAL"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("enable WAL: %w", err)
-	}
-
-	// Enable foreign key enforcement.
-	if _, err = db.ExecContext(context.Background(), "PRAGMA foreign_keys=ON"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
-	}
-
-	// Set busy timeout so concurrent readers/writers (serve + dispatch) retry
-	// instead of returning SQLITE_BUSY immediately.
-	if _, err = db.ExecContext(context.Background(), "PRAGMA busy_timeout=5000"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("set busy timeout: %w", err)
 	}
 
 	s := &SQLiteStore{db: db}


### PR DESCRIPTION
## Summary

- Moves `busy_timeout`, `journal_mode`, and `foreign_keys` PRAGMAs from post-open statements to DSN query parameters
- PRAGMA statements only apply to the specific connection they execute on. With connection pooling, other pool connections never get the pragmas, causing SQLITE_BUSY during concurrent startup (serve + dispatch)
- Affects both `internal/store/` and `internal/logstore/`

## Test plan

- [x] All store tests pass (sessions, costs, scaling, metrics, failures, corrections)
- [x] All logstore tests pass (insert, query, prune, syncer, sync)
- [x] Full test suite passes (`go test ./...`)
- [x] Pre-push CI green

Co-Authored-By: Claude <noreply@anthropic.com>