### PR TITLE
fix: make issue assignment best-effort for Gitea compatibility

### DIFF
--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -181,7 +181,9 @@ func (d *Dispatcher) route(ctx context.Context, issue *forge.Issue, agentType mo
 		return fmt.Errorf("add claimed label to #%d: %w", issue.Number, err)
 	}
 	if err := d.tracker.Assign(ctx, issue.Number, string(agentType)); err != nil {
-		return fmt.Errorf("assign #%d to %s: %w", issue.Number, agentType, err)
+		// Best-effort: Gitea requires assignee to be a repo collaborator,
+		// GitHub silently ignores invalid assignees. Don't block routing.
+		d.logger.Warn("assign issue (non-fatal)", zap.Int("issue", issue.Number), zap.String("agent", string(agentType)), zap.Error(err))
 	}
 
 	providerKey, reason := selectProviderKey(issue, agentType)


### PR DESCRIPTION
## Summary

- Makes `Assign()` call in dispatcher non-fatal (logs warn instead of returning error)
- Gitea requires assignees to be repo collaborators; GitHub silently ignores invalid ones
- Discovered during Phase 6 Gitea E2E validation -- assignment to agent type name fails because agent types aren't Gitea users

## Test plan

- [x] All dispatcher tests pass
- [x] Pre-push CI green
- [x] Verified: Gitea dispatcher now routes issues past the assignment step

Co-Authored-By: Claude <noreply@anthropic.com>