### PR TITLE
feat: add light/dark mode toggle to dashboard

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,16 +1,19 @@
 import { Outlet, NavLink } from 'react-router'
+import { useTheme } from '../hooks/useTheme'
 
 export function Layout() {
+  const { theme, toggle } = useTheme()
+
   return (
-    <div className="flex h-screen bg-gray-50">
-      <aside className="w-56 border-r bg-white p-4">
-        <h1 className="mb-6 text-lg font-bold">Samverk</h1>
+    <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
+      <aside className="w-56 border-r dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
+        <h1 className="mb-6 text-lg font-bold dark:text-white">Samverk</h1>
         <nav className="space-y-1">
           <NavLink
             to="/"
             end
             className={({ isActive }) =>
-              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`
             }
           >
             Dashboard
@@ -18,7 +21,7 @@ export function Layout() {
           <NavLink
             to="/issues"
             className={({ isActive }) =>
-              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`
             }
           >
             Issues
@@ -26,7 +29,7 @@ export function Layout() {
           <NavLink
             to="/my-queue"
             className={({ isActive }) =>
-              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-amber-50 text-amber-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`
             }
           >
             My Queue
@@ -34,7 +37,7 @@ export function Layout() {
           <NavLink
             to="/agents"
             className={({ isActive }) =>
-              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`
             }
           >
             Agents
@@ -42,7 +45,7 @@ export function Layout() {
           <NavLink
             to="/metrics"
             className={({ isActive }) =>
-              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`
             }
           >
             Metrics
@@ -50,11 +53,18 @@ export function Layout() {
           <NavLink
             to="/logs"
             className={({ isActive }) =>
-              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`
+              `block rounded px-3 py-2 text-sm ${isActive ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`
             }
           >
             Logs
           </NavLink>
+          <button
+            onClick={toggle}
+            className="mt-4 flex w-full items-center gap-2 rounded px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+          >
+            {theme === 'dark' ? '\u2600' : '\u25CF'}
+            <span>{theme === 'dark' ? 'Light mode' : 'Dark mode'}</span>
+          </button>
         </nav>
       </aside>
       <main className="flex-1 overflow-auto p-6">

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('samverk-theme') as Theme | null
+    if (stored) return stored
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    localStorage.setItem('samverk-theme', theme)
+  }, [theme])
+
+  const toggle = () => setTheme(t => t === 'dark' ? 'light' : 'dark')
+
+  return { theme, toggle }
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -6,13 +6,13 @@ function typeBadgeColor(type: string): string {
   switch (type) {
     case 'claude':
     case 'claude-cli':
-      return 'bg-orange-100 text-orange-800'
+      return 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300'
     case 'ollama':
-      return 'bg-purple-100 text-purple-800'
+      return 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300'
     case 'openai':
-      return 'bg-green-100 text-green-800'
+      return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300'
     default:
-      return 'bg-gray-100 text-gray-700'
+      return 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
   }
 }
 
@@ -39,9 +39,9 @@ function ProviderCard({
   const chains = routingChainsForProvider(provider.name, routingChains)
 
   return (
-    <div className="rounded-lg border bg-white p-5">
+    <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-base font-semibold text-gray-900">{provider.name}</h3>
+        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">{provider.name}</h3>
         <span
           className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadgeColor(provider.type)}`}
         >
@@ -49,7 +49,7 @@ function ProviderCard({
         </span>
       </div>
 
-      <p className="mb-3 font-mono text-sm text-gray-600">{provider.model}</p>
+      <p className="mb-3 font-mono text-sm text-gray-600 dark:text-gray-400">{provider.model}</p>
 
       <div className="flex items-center gap-2 mb-3">
         <span
@@ -65,7 +65,7 @@ function ProviderCard({
           {chains.map((chain) => (
             <span
               key={chain}
-              className="inline-block rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700"
+              className="inline-block rounded-full bg-blue-50 dark:bg-blue-900/30 px-2.5 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-300"
             >
               {chain}
             </span>
@@ -78,7 +78,7 @@ function ProviderCard({
           href={provider.account_url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 rounded border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          className="inline-flex items-center gap-1 rounded border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
         >
           Manage Account
           <svg
@@ -102,9 +102,9 @@ function ProviderCard({
 
 function EmptyState() {
   return (
-    <div className="rounded-lg border bg-white p-10 text-center">
-      <p className="text-sm text-gray-500">No providers configured</p>
-      <p className="mt-1 text-xs text-gray-400">
+    <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 p-10 text-center">
+      <p className="text-sm text-gray-500 dark:text-gray-400">No providers configured</p>
+      <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
         Add providers to .samverk/providers.yaml to see them here.
       </p>
     </div>
@@ -123,20 +123,20 @@ export function Agents() {
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-gray-900">Agents</h2>
-        <span className="text-xs text-gray-400">Auto-refreshes every 5s</span>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Agents</h2>
+        <span className="text-xs text-gray-400 dark:text-gray-500">Auto-refreshes every 5s</span>
       </div>
 
       {metrics.isLoading && (
         <div className="flex items-center justify-center py-20">
-          <p className="text-gray-500">Loading providers...</p>
+          <p className="text-gray-500 dark:text-gray-400">Loading providers...</p>
         </div>
       )}
 
       {metrics.isError && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-          <p className="font-medium text-red-800">Failed to load provider data</p>
-          <p className="mt-1 text-sm text-red-600">{metrics.error?.message ?? 'Unknown error'}</p>
+        <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4">
+          <p className="font-medium text-red-800 dark:text-red-300">Failed to load provider data</p>
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">{metrics.error?.message ?? 'Unknown error'}</p>
         </div>
       )}
 

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -7,7 +7,7 @@ function StatusIndicator({ connected, label }: { connected: boolean; label: stri
       <span
         className={`inline-block h-2.5 w-2.5 rounded-full ${connected ? 'bg-green-500' : 'bg-red-500'}`}
       />
-      <span className="text-sm text-gray-700">{label}</span>
+      <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
       <span className={`text-xs ${connected ? 'text-green-600' : 'text-red-600'}`}>
         {connected ? 'Connected' : 'Disconnected'}
       </span>
@@ -17,10 +17,10 @@ function StatusIndicator({ connected, label }: { connected: boolean; label: stri
 
 function StatCard({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) {
   return (
-    <div className="rounded-lg border bg-white p-5">
-      <p className="text-sm font-medium text-gray-500">{title}</p>
-      <p className="mt-1 text-2xl font-semibold text-gray-900">{value}</p>
-      {subtitle != null && <p className="mt-1 text-xs text-gray-400">{subtitle}</p>}
+    <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+      <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{title}</p>
+      <p className="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">{value}</p>
+      {subtitle != null && <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">{subtitle}</p>}
     </div>
   )
 }
@@ -64,7 +64,7 @@ export function Dashboard() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <p className="text-gray-500">Loading dashboard...</p>
+        <p className="text-gray-500 dark:text-gray-400">Loading dashboard...</p>
       </div>
     )
   }
@@ -73,9 +73,9 @@ export function Dashboard() {
     const errorMsg =
       status.error?.message || sessions.error?.message || costs.error?.message || 'Unknown error'
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-        <p className="font-medium text-red-800">Failed to load dashboard</p>
-        <p className="mt-1 text-sm text-red-600">{errorMsg}</p>
+      <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4">
+        <p className="font-medium text-red-800 dark:text-red-300">Failed to load dashboard</p>
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errorMsg}</p>
       </div>
     )
   }
@@ -86,20 +86,20 @@ export function Dashboard() {
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-gray-900">Dashboard</h2>
-        <span className="text-xs text-gray-400">Auto-refreshes every 30s</span>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h2>
+        <span className="text-xs text-gray-400 dark:text-gray-500">Auto-refreshes every 30s</span>
       </div>
 
       <section className="mb-8">
-        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
           System Status
         </h3>
-        <div className="rounded-lg border bg-white p-4">
+        <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
           <div className="flex items-center gap-3 mb-4">
             <span
               className={`inline-block h-3 w-3 rounded-full ${status.data?.healthy ? 'bg-green-500' : 'bg-yellow-500'}`}
             />
-            <span className="font-medium text-gray-900">
+            <span className="font-medium text-gray-900 dark:text-gray-100">
               {status.data?.healthy ? 'System Healthy' : 'System Degraded'}
             </span>
           </div>
@@ -113,16 +113,16 @@ export function Dashboard() {
               label="Database"
             />
           </div>
-          <div className="mt-3 border-t pt-3">
-            <p className="text-sm text-gray-500">
-              MCP Tools: <span className="font-medium text-gray-700">{status.data?.tool_count ?? 0}</span>
+          <div className="mt-3 border-t dark:border-gray-700 pt-3">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              MCP Tools: <span className="font-medium text-gray-700 dark:text-gray-300">{status.data?.tool_count ?? 0}</span>
             </p>
           </div>
         </div>
       </section>
 
       <section className="mb-8">
-        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
           Activity
         </h3>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
@@ -148,13 +148,13 @@ export function Dashboard() {
 
       {activeSessions.length > 0 && (
         <section>
-          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
             Running Sessions
           </h3>
-          <div className="overflow-hidden rounded-lg border bg-white">
+          <div className="overflow-hidden rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+                <tr className="border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
                   <th className="px-4 py-2">Issue</th>
                   <th className="px-4 py-2">Agent</th>
                   <th className="px-4 py-2">Provider</th>
@@ -164,12 +164,12 @@ export function Dashboard() {
               </thead>
               <tbody>
                 {activeSessions.map((s) => (
-                  <tr key={s.id} className="border-b last:border-b-0">
-                    <td className="px-4 py-2 font-medium">#{s.issue_number}</td>
-                    <td className="px-4 py-2">{s.agent_type}</td>
-                    <td className="px-4 py-2">{s.provider}</td>
-                    <td className="px-4 py-2 font-mono text-xs">{s.model}</td>
-                    <td className="px-4 py-2 text-gray-500">
+                  <tr key={s.id} className="border-b dark:border-gray-700 last:border-b-0">
+                    <td className="px-4 py-2 font-medium dark:text-gray-100">#{s.issue_number}</td>
+                    <td className="px-4 py-2 dark:text-gray-300">{s.agent_type}</td>
+                    <td className="px-4 py-2 dark:text-gray-300">{s.provider}</td>
+                    <td className="px-4 py-2 font-mono text-xs dark:text-gray-300">{s.model}</td>
+                    <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
                       {new Date(s.started_at).toLocaleString()}
                     </td>
                   </tr>

--- a/web/src/pages/Issues.tsx
+++ b/web/src/pages/Issues.tsx
@@ -6,7 +6,7 @@ type StateFilter = 'open' | 'closed' | 'all'
 
 function LabelBadge({ label }: { label: string }) {
   return (
-    <span className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+    <span className="inline-block rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-300">
       {label}
     </span>
   )
@@ -56,20 +56,20 @@ export function Issues() {
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-gray-900">Issues</h2>
-        <span className="text-xs text-gray-400">Auto-refreshes every 30s</span>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Issues</h2>
+        <span className="text-xs text-gray-400 dark:text-gray-500">Auto-refreshes every 30s</span>
       </div>
 
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
-        <div className="flex rounded-lg border bg-white">
+        <div className="flex rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800">
           {(['open', 'closed', 'all'] as const).map((state) => (
             <button
               key={state}
               onClick={() => setStateFilter(state)}
               className={`px-4 py-2 text-sm capitalize ${
                 stateFilter === state
-                  ? 'bg-blue-50 font-medium text-blue-700'
-                  : 'text-gray-600 hover:bg-gray-50'
+                  ? 'bg-blue-50 dark:bg-blue-900/30 font-medium text-blue-700 dark:text-blue-300'
+                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
               } ${state === 'open' ? 'rounded-l-lg' : ''} ${state === 'all' ? 'rounded-r-lg' : ''}`}
             >
               {state}
@@ -81,10 +81,10 @@ export function Issues() {
           placeholder="Search by title or number..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="rounded-lg border bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 sm:w-64"
+          className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 sm:w-64"
         />
         {issues.data != null && (
-          <span className="text-sm text-gray-500">
+          <span className="text-sm text-gray-500 dark:text-gray-400">
             {filteredIssues.length} of {issues.data.length} issues
           </span>
         )}
@@ -92,30 +92,30 @@ export function Issues() {
 
       {issues.isLoading && (
         <div className="flex items-center justify-center py-20">
-          <p className="text-gray-500">Loading issues...</p>
+          <p className="text-gray-500 dark:text-gray-400">Loading issues...</p>
         </div>
       )}
 
       {issues.isError && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-          <p className="font-medium text-red-800">Failed to load issues</p>
-          <p className="mt-1 text-sm text-red-600">{issues.error?.message}</p>
+        <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4">
+          <p className="font-medium text-red-800 dark:text-red-300">Failed to load issues</p>
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">{issues.error?.message}</p>
         </div>
       )}
 
       {issues.isSuccess && filteredIssues.length === 0 && (
-        <div className="rounded-lg border bg-white p-8 text-center">
-          <p className="text-gray-500">
+        <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 p-8 text-center">
+          <p className="text-gray-500 dark:text-gray-400">
             {searchQuery.trim() !== '' ? 'No issues match your search.' : 'No issues found.'}
           </p>
         </div>
       )}
 
       {issues.isSuccess && filteredIssues.length > 0 && (
-        <div className="overflow-hidden rounded-lg border bg-white">
+        <div className="overflow-hidden rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+              <tr className="border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
                 <th className="px-4 py-2 w-16">#</th>
                 <th className="px-4 py-2">Title</th>
                 <th className="px-4 py-2 w-20">State</th>
@@ -154,25 +154,25 @@ function IssueRow({
     <>
       <tr
         onClick={onToggle}
-        className="cursor-pointer border-b last:border-b-0 hover:bg-gray-50"
+        className="cursor-pointer border-b dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700"
       >
-        <td className="px-4 py-2.5 font-medium text-gray-900">{issue.number}</td>
+        <td className="px-4 py-2.5 font-medium text-gray-900 dark:text-gray-100">{issue.number}</td>
         <td className="px-4 py-2.5">
           <div className="flex items-center gap-2">
             <span
-              className={`text-xs ${expanded ? 'rotate-90' : ''} inline-block transition-transform`}
+              className={`text-xs ${expanded ? 'rotate-90' : ''} inline-block transition-transform dark:text-gray-400`}
             >
               &#9654;
             </span>
-            <span className="text-gray-900">{issue.title}</span>
+            <span className="text-gray-900 dark:text-gray-100">{issue.title}</span>
           </div>
         </td>
         <td className="px-4 py-2.5">
           <span
             className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
               issue.state === 'open'
-                ? 'bg-green-100 text-green-700'
-                : 'bg-purple-100 text-purple-700'
+                ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
+                : 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
             }`}
           >
             {issue.state}
@@ -185,21 +185,21 @@ function IssueRow({
             ))}
           </div>
         </td>
-        <td className="px-4 py-2.5 text-gray-600">
+        <td className="px-4 py-2.5 text-gray-600 dark:text-gray-400">
           {issue.assignees.length > 0 ? issue.assignees.join(', ') : '-'}
         </td>
-        <td className="px-4 py-2.5 text-gray-500">{formatDate(issue.updated_at)}</td>
+        <td className="px-4 py-2.5 text-gray-500 dark:text-gray-400">{formatDate(issue.updated_at)}</td>
       </tr>
       {expanded && (
-        <tr className="bg-gray-50">
+        <tr className="bg-gray-50 dark:bg-gray-900">
           <td colSpan={6} className="px-4 py-4">
             <div className="ml-6 max-w-3xl">
               {issue.body.trim() !== '' ? (
-                <pre className="whitespace-pre-wrap text-sm text-gray-700 font-sans leading-relaxed">
+                <pre className="whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300 font-sans leading-relaxed">
                   {issue.body}
                 </pre>
               ) : (
-                <p className="text-sm italic text-gray-400">No description provided.</p>
+                <p className="text-sm italic text-gray-400 dark:text-gray-500">No description provided.</p>
               )}
             </div>
           </td>

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -20,14 +20,14 @@ function formatJSON(s: string): string {
 
 function LevelBadge({ level }: { level: string }) {
   const colors: Record<string, string> = {
-    debug: 'bg-gray-100 text-gray-600',
-    info: 'bg-blue-100 text-blue-700',
-    warn: 'bg-amber-100 text-amber-800',
-    error: 'bg-red-100 text-red-800',
+    debug: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300',
+    info: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+    warn: 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300',
+    error: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300',
   }
   return (
     <span
-      className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${colors[level] || 'bg-gray-100 text-gray-600'}`}
+      className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${colors[level] || 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'}`}
     >
       {level}
     </span>
@@ -101,14 +101,14 @@ export function Logs() {
 
   return (
     <div>
-      <h2 className="mb-4 text-lg font-semibold">Logs</h2>
+      <h2 className="mb-4 text-lg font-semibold dark:text-gray-100">Logs</h2>
 
       {/* Filter bar */}
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <select
           value={level}
           onChange={(e) => setLevel(e.target.value)}
-          className="rounded border px-2 py-1 text-sm"
+          className="rounded border dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm dark:text-gray-100"
         >
           <option value="">All levels</option>
           <option value="debug">debug</option>
@@ -125,7 +125,7 @@ export function Logs() {
           onKeyDown={(e) => {
             if (e.key === 'Enter') handleSearch()
           }}
-          className="w-48 rounded border px-2 py-1 text-sm"
+          className="w-48 rounded border dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm dark:text-gray-100 dark:placeholder-gray-500"
         />
 
         <input
@@ -133,7 +133,7 @@ export function Logs() {
           placeholder="Session ID"
           value={sessionId}
           onChange={(e) => setSessionId(e.target.value)}
-          className="w-36 rounded border px-2 py-1 text-sm"
+          className="w-36 rounded border dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm dark:text-gray-100 dark:placeholder-gray-500"
         />
 
         <input
@@ -141,7 +141,7 @@ export function Logs() {
           placeholder="Issue #"
           value={issueNum}
           onChange={(e) => setIssueNum(e.target.value)}
-          className="w-20 rounded border px-2 py-1 text-sm"
+          className="w-20 rounded border dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm dark:text-gray-100 dark:placeholder-gray-500"
         />
 
         <button
@@ -151,7 +151,7 @@ export function Logs() {
           Search
         </button>
 
-        <label className="flex items-center gap-1 text-sm text-gray-600">
+        <label className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
           <input
             type="checkbox"
             checked={autoRefresh}
@@ -163,16 +163,16 @@ export function Logs() {
 
       {/* Log table */}
       {logs.isLoading && offset === 0 && (
-        <div className="text-sm text-gray-500">Loading...</div>
+        <div className="text-sm text-gray-500 dark:text-gray-400">Loading...</div>
       )}
       {logs.error && (
-        <div className="text-sm text-red-600">Error: {String(logs.error)}</div>
+        <div className="text-sm text-red-600 dark:text-red-400">Error: {String(logs.error)}</div>
       )}
       {displayEntries.length > 0 && (
-        <div className="rounded-lg border bg-white">
+        <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b bg-gray-50 text-left text-xs font-medium uppercase text-gray-500">
+              <tr className="border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
                 <th className="w-28 px-3 py-2">Time</th>
                 <th className="w-16 px-3 py-2">Level</th>
                 <th className="w-32 px-3 py-2">Component</th>
@@ -183,13 +183,13 @@ export function Logs() {
               {displayEntries.map((entry) => (
                 <Fragment key={entry.id}>
                   <tr
-                    className="cursor-pointer border-b hover:bg-gray-50"
+                    className="cursor-pointer border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
                     onClick={() =>
                       setExpandedId(expandedId === entry.id ? null : entry.id)
                     }
                   >
                     <td
-                      className="px-3 py-2 text-xs text-gray-500"
+                      className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400"
                       title={entry.ts}
                     >
                       {relativeTime(entry.ts)}
@@ -197,17 +197,17 @@ export function Logs() {
                     <td className="px-3 py-2">
                       <LevelBadge level={entry.level} />
                     </td>
-                    <td className="px-3 py-2 text-xs text-gray-600">
+                    <td className="px-3 py-2 text-xs text-gray-600 dark:text-gray-400">
                       {entry.component}
                     </td>
-                    <td className="max-w-md truncate px-3 py-2 font-mono text-xs">
+                    <td className="max-w-md truncate px-3 py-2 font-mono text-xs dark:text-gray-300">
                       {entry.msg}
                     </td>
                   </tr>
                   {expandedId === entry.id && entry.fields && (
-                    <tr className="border-b bg-gray-50">
+                    <tr className="border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
                       <td colSpan={4} className="px-3 py-2">
-                        <pre className="whitespace-pre-wrap text-xs text-gray-600">
+                        <pre className="whitespace-pre-wrap text-xs text-gray-600 dark:text-gray-400">
                           {formatJSON(entry.fields)}
                         </pre>
                       </td>
@@ -220,10 +220,10 @@ export function Logs() {
           {displayEntries.length > 0 &&
             logs.data &&
             logs.data.length === PAGE_SIZE && (
-              <div className="border-t px-3 py-2 text-center">
+              <div className="border-t dark:border-gray-700 px-3 py-2 text-center">
                 <button
                   onClick={handleLoadMore}
-                  className="text-sm text-blue-600 hover:underline"
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   Load more
                 </button>
@@ -232,7 +232,7 @@ export function Logs() {
         </div>
       )}
       {logs.data && displayEntries.length === 0 && (
-        <div className="rounded-lg border bg-white py-8 text-center text-sm text-gray-500">
+        <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
           No log entries found
         </div>
       )}

--- a/web/src/pages/Metrics.tsx
+++ b/web/src/pages/Metrics.tsx
@@ -15,7 +15,7 @@ function formatBytes(bytes: number): string {
 }
 
 function formatMs(ms: number): string {
-  if (ms === 0) return '—'
+  if (ms === 0) return '\u2014'
   if (ms >= 1_000) return `${(ms / 1_000).toFixed(2)}s`
   return `${ms.toFixed(1)}ms`
 }
@@ -63,17 +63,21 @@ function GaugeCard({ label, percent, usedLabel, totalLabel, warnPct, critPct }: 
   critPct: number
 }) {
   const color = percent >= critPct ? 'text-red-600' : percent >= warnPct ? 'text-amber-600' : 'text-green-600'
-  const bgColor = percent >= critPct ? 'bg-red-100' : percent >= warnPct ? 'bg-amber-100' : 'bg-green-100'
+  const bgColor = percent >= critPct
+    ? 'bg-red-100 dark:bg-red-900/30'
+    : percent >= warnPct
+      ? 'bg-amber-100 dark:bg-amber-900/30'
+      : 'bg-green-100 dark:bg-green-900/30'
   const barColor = percent >= critPct ? 'bg-red-500' : percent >= warnPct ? 'bg-amber-500' : 'bg-green-500'
 
   return (
-    <div className={`rounded-lg border p-4 ${bgColor}`}>
-      <div className="text-xs font-medium text-gray-500 uppercase">{label}</div>
+    <div className={`rounded-lg border dark:border-gray-700 p-4 ${bgColor}`}>
+      <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{label}</div>
       <div className={`text-2xl font-bold ${color}`}>{percent.toFixed(1)}%</div>
-      <div className="mt-2 h-2 rounded-full bg-gray-200">
+      <div className="mt-2 h-2 rounded-full bg-gray-200 dark:bg-gray-700">
         <div className={`h-2 rounded-full ${barColor}`} style={{ width: `${Math.min(percent, 100)}%` }} />
       </div>
-      <div className="mt-1 text-xs text-gray-500">{usedLabel} / {totalLabel}</div>
+      <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{usedLabel} / {totalLabel}</div>
     </div>
   )
 }
@@ -83,8 +87,8 @@ function HostSection({ current, history }: { current: HostMetricsDTO; history: H
   const diskTrend = estimateDaysToThreshold(history, current.disk_percent, 70)
 
   return (
-    <div className="rounded-lg border bg-white p-4">
-      <h3 className="mb-3 text-sm font-semibold text-gray-900">Host Resources</h3>
+    <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+      <h3 className="mb-3 text-sm font-semibold text-gray-900 dark:text-gray-100">Host Resources</h3>
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
         <GaugeCard
           label="Disk"
@@ -124,7 +128,7 @@ function HostSection({ current, history }: { current: HostMetricsDTO; history: H
           {current.alerts.map((a, i) => (
             <div
               key={i}
-              className={`rounded px-3 py-1 text-xs ${a.level === 'critical' ? 'bg-red-100 text-red-800' : 'bg-amber-100 text-amber-800'}`}
+              className={`rounded px-3 py-1 text-xs ${a.level === 'critical' ? 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300' : 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300'}`}
             >
               {a.message}
             </div>
@@ -132,7 +136,7 @@ function HostSection({ current, history }: { current: HostMetricsDTO; history: H
         </div>
       )}
       {history.length > 1 && (
-        <div className="mt-2 text-xs text-gray-500">
+        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
           Disk trend: {diskTrend || 'stable'}
         </div>
       )}
@@ -142,27 +146,27 @@ function HostSection({ current, history }: { current: HostMetricsDTO; history: H
 
 function MetricRow({ label, value, tooltip }: { label: string; value: string; tooltip?: string }) {
   return (
-    <div className="flex items-center justify-between py-2 border-b last:border-b-0">
+    <div className="flex items-center justify-between py-2 border-b dark:border-gray-700 last:border-b-0">
       {tooltip ? (
-        <span className="group relative text-sm text-gray-600 cursor-help underline decoration-dotted decoration-gray-400 underline-offset-2">
+        <span className="group relative text-sm text-gray-600 dark:text-gray-400 cursor-help underline decoration-dotted decoration-gray-400 dark:decoration-gray-600 underline-offset-2">
           {label}
-          <span className="pointer-events-none absolute left-0 bottom-full mb-1 z-10 hidden w-64 rounded bg-gray-900 px-3 py-2 text-xs leading-relaxed text-gray-100 shadow-lg group-hover:block">
+          <span className="pointer-events-none absolute left-0 bottom-full mb-1 z-10 hidden w-64 rounded bg-gray-900 dark:bg-gray-700 px-3 py-2 text-xs leading-relaxed text-gray-100 shadow-lg group-hover:block">
             {tooltip}
           </span>
         </span>
       ) : (
-        <span className="text-sm text-gray-600">{label}</span>
+        <span className="text-sm text-gray-600 dark:text-gray-400">{label}</span>
       )}
-      <span className="text-sm font-medium text-gray-900 font-mono">{value}</span>
+      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 font-mono">{value}</span>
     </div>
   )
 }
 
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-lg border bg-white">
-      <div className="px-4 py-3 border-b bg-gray-50">
-        <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
+    <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800">
+      <div className="px-4 py-3 border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">{title}</h3>
       </div>
       <div className="px-4 py-2">{children}</div>
     </div>
@@ -171,21 +175,21 @@ function SectionCard({ title, children }: { title: string; children: React.React
 
 function NullSection({ title }: { title: string }) {
   return (
-    <div className="rounded-lg border bg-white">
-      <div className="px-4 py-3 border-b bg-gray-50">
-        <h3 className="text-sm font-semibold text-gray-400">{title}</h3>
+    <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800">
+      <div className="px-4 py-3 border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+        <h3 className="text-sm font-semibold text-gray-400 dark:text-gray-500">{title}</h3>
       </div>
-      <div className="px-4 py-6 text-center text-sm text-gray-400">Not running</div>
+      <div className="px-4 py-6 text-center text-sm text-gray-400 dark:text-gray-500">Not running</div>
     </div>
   )
 }
 
 function StatCard({ label, value, sub, color }: { label: string; value: string; sub?: string; color?: string }) {
   return (
-    <div className="rounded-lg border bg-white px-4 py-3">
-      <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</p>
-      <p className={`mt-1 text-2xl font-bold ${color ?? 'text-gray-900'}`}>{value}</p>
-      {sub && <p className="mt-0.5 text-xs text-gray-400">{sub}</p>}
+    <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-3">
+      <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</p>
+      <p className={`mt-1 text-2xl font-bold ${color ?? 'text-gray-900 dark:text-gray-100'}`}>{value}</p>
+      {sub && <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">{sub}</p>}
     </div>
   )
 }
@@ -260,27 +264,27 @@ function ActivityFeed({ sessions }: { sessions: Session[] }) {
   }, [sessions])
 
   const statusColor: Record<string, string> = {
-    completed: 'bg-green-100 text-green-700',
-    running: 'bg-blue-100 text-blue-700',
-    failed: 'bg-red-100 text-red-700',
-    timeout: 'bg-orange-100 text-orange-700',
+    completed: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300',
+    running: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
+    failed: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300',
+    timeout: 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300',
   }
 
   return (
     <SectionCard title="Recent Activity">
       {recent.length === 0 ? (
-        <div className="py-6 text-center text-sm text-gray-400">No sessions recorded</div>
+        <div className="py-6 text-center text-sm text-gray-400 dark:text-gray-500">No sessions recorded</div>
       ) : (
         <div className="max-h-80 overflow-auto">
           {recent.map((s) => (
-            <div key={s.id} className="flex items-center gap-3 border-b py-2 last:border-b-0">
-              <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusColor[s.status] ?? 'bg-gray-100 text-gray-600'}`}>
+            <div key={s.id} className="flex items-center gap-3 border-b dark:border-gray-700 py-2 last:border-b-0">
+              <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusColor[s.status] ?? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'}`}>
                 {s.status}
               </span>
-              <span className="text-sm text-gray-900 font-medium">#{s.issue_number}</span>
-              <span className="text-xs text-gray-500">{s.agent_type}</span>
-              <span className="text-xs text-gray-400 font-mono">{s.provider}</span>
-              <span className="ml-auto text-xs text-gray-400 whitespace-nowrap">{formatRelative(s.started_at)}</span>
+              <span className="text-sm text-gray-900 dark:text-gray-100 font-medium">#{s.issue_number}</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">{s.agent_type}</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">{s.provider}</span>
+              <span className="ml-auto text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">{formatRelative(s.started_at)}</span>
             </div>
           ))}
         </div>
@@ -295,7 +299,7 @@ function TrendingSection({ entries }: { entries: HistoryEntry[] }) {
   if (entries.length < 2) {
     return (
       <SectionCard title="Trending (24h)">
-        <div className="py-6 text-center text-sm text-gray-400">Collecting data...</div>
+        <div className="py-6 text-center text-sm text-gray-400 dark:text-gray-500">Collecting data...</div>
       </SectionCard>
     )
   }
@@ -322,10 +326,10 @@ function TrendingSection({ entries }: { entries: HistoryEntry[] }) {
     <SectionCard title="Trending (24h)">
       <div className="space-y-1 py-1">
         {rows.map((r) => (
-          <div key={r.label} className="flex items-center justify-between py-1.5 border-b last:border-b-0">
-            <span className="text-sm text-gray-600 w-36">{r.label}</span>
+          <div key={r.label} className="flex items-center justify-between py-1.5 border-b dark:border-gray-700 last:border-b-0">
+            <span className="text-sm text-gray-600 dark:text-gray-400 w-36">{r.label}</span>
             <Sparkline data={r.data} color={r.color} />
-            <span className="text-sm font-medium text-gray-900 font-mono w-16 text-right">{r.current}</span>
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100 font-mono w-16 text-right">{r.current}</span>
           </div>
         ))}
       </div>
@@ -336,10 +340,10 @@ function TrendingSection({ entries }: { entries: HistoryEntry[] }) {
 // --- Existing Section Components (unchanged) ---
 
 const pressureColors: Record<string, string> = {
-  low: 'bg-green-50 border-green-200 text-green-800',
-  moderate: 'bg-yellow-50 border-yellow-200 text-yellow-800',
-  high: 'bg-orange-50 border-orange-200 text-orange-800',
-  critical: 'bg-red-50 border-red-200 text-red-800',
+  low: 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-800 dark:text-green-300',
+  moderate: 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800 text-yellow-800 dark:text-yellow-300',
+  high: 'bg-orange-50 dark:bg-orange-900/20 border-orange-200 dark:border-orange-800 text-orange-800 dark:text-orange-300',
+  critical: 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-800 dark:text-red-300',
 }
 
 function PressureSection({ pressure }: { pressure: PressureMetrics }) {
@@ -434,35 +438,35 @@ function ScalingSection({
       <MetricRow label="Current Target" value={config.current_target.toString()} />
       {events != null && events.length > 0 && (
         <div className="mt-3">
-          <p className="mb-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <p className="mb-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
             Recent Events
           </p>
           <div className="space-y-1">
             {events.map((e) => (
-              <div key={e.timestamp} className="rounded bg-gray-50 px-3 py-2 text-xs">
+              <div key={e.timestamp} className="rounded bg-gray-50 dark:bg-gray-900 px-3 py-2 text-xs">
                 <div className="flex items-center justify-between">
                   <span
                     className={
                       e.action === 'scale-up'
-                        ? 'font-semibold text-green-700'
-                        : 'font-semibold text-amber-700'
+                        ? 'font-semibold text-green-700 dark:text-green-400'
+                        : 'font-semibold text-amber-700 dark:text-amber-400'
                     }
                   >
-                    {e.action === 'scale-up' ? '▲' : '▼'} {e.from_workers}→{e.to_workers} workers
+                    {e.action === 'scale-up' ? '\u25B2' : '\u25BC'} {e.from_workers}\u2192{e.to_workers} workers
                   </span>
-                  <span className="text-gray-400">
+                  <span className="text-gray-400 dark:text-gray-500">
                     {Math.round(e.confidence * 100)}% conf
                   </span>
                 </div>
-                <p className="mt-0.5 text-gray-500 truncate">{e.reason}</p>
-                <p className="text-gray-400">{new Date(e.timestamp).toLocaleString()}</p>
+                <p className="mt-0.5 text-gray-500 dark:text-gray-400 truncate">{e.reason}</p>
+                <p className="text-gray-400 dark:text-gray-500">{new Date(e.timestamp).toLocaleString()}</p>
               </div>
             ))}
           </div>
         </div>
       )}
       {(events == null || events.length === 0) && (
-        <div className="py-4 text-center text-xs text-gray-400">No scaling events yet</div>
+        <div className="py-4 text-center text-xs text-gray-400 dark:text-gray-500">No scaling events yet</div>
       )}
     </SectionCard>
   )
@@ -481,17 +485,17 @@ function CapacitySection({ capacity, maxWorkers }: { capacity: CapacityInfo | nu
       <MetricRow label="Routing Chains" value={routingChainNames.length.toString()} />
       {capacity.providers.length > 0 && (
         <div className="mt-3">
-          <p className="mb-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <p className="mb-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
             Providers
           </p>
           <div className="space-y-1">
             {capacity.providers.map((p) => (
-              <div key={p.name} className="flex items-center justify-between rounded bg-gray-50 px-3 py-2 text-xs">
+              <div key={p.name} className="flex items-center justify-between rounded bg-gray-50 dark:bg-gray-900 px-3 py-2 text-xs">
                 <div className="flex items-center gap-2">
                   <span className={`inline-block h-2 w-2 rounded-full ${p.healthy ? 'bg-green-500' : 'bg-red-400'}`} />
-                  <span className="font-medium text-gray-700">{p.name}</span>
+                  <span className="font-medium text-gray-700 dark:text-gray-300">{p.name}</span>
                 </div>
-                <span className="text-gray-500 font-mono">{p.model}</span>
+                <span className="text-gray-500 dark:text-gray-400 font-mono">{p.model}</span>
               </div>
             ))}
           </div>
@@ -499,14 +503,14 @@ function CapacitySection({ capacity, maxWorkers }: { capacity: CapacityInfo | nu
       )}
       {routingChainNames.length > 0 && (
         <div className="mt-3">
-          <p className="mb-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <p className="mb-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
             Routing
           </p>
           <div className="space-y-1">
             {routingChainNames.map((chain) => (
-              <div key={chain} className="flex items-center justify-between rounded bg-gray-50 px-3 py-2 text-xs">
-                <span className="font-medium text-gray-700">{chain}</span>
-                <span className="text-gray-500 font-mono">{capacity.routing_chains[chain].join(' → ')}</span>
+              <div key={chain} className="flex items-center justify-between rounded bg-gray-50 dark:bg-gray-900 px-3 py-2 text-xs">
+                <span className="font-medium text-gray-700 dark:text-gray-300">{chain}</span>
+                <span className="text-gray-500 dark:text-gray-400 font-mono">{capacity.routing_chains[chain].join(' \u2192 ')}</span>
               </div>
             ))}
           </div>
@@ -571,20 +575,20 @@ export function Metrics() {
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-gray-900">Metrics</h2>
-        <span className="text-xs text-gray-400">Auto-refreshes every 5s</span>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Metrics</h2>
+        <span className="text-xs text-gray-400 dark:text-gray-500">Auto-refreshes every 5s</span>
       </div>
 
       {metrics.isLoading && (
         <div className="flex items-center justify-center py-20">
-          <p className="text-gray-500">Loading metrics...</p>
+          <p className="text-gray-500 dark:text-gray-400">Loading metrics...</p>
         </div>
       )}
 
       {metrics.isError && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-          <p className="font-medium text-red-800">Failed to load metrics</p>
-          <p className="mt-1 text-sm text-red-600">{metrics.error?.message ?? 'Unknown error'}</p>
+        <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4">
+          <p className="font-medium text-red-800 dark:text-red-300">Failed to load metrics</p>
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">{metrics.error?.message ?? 'Unknown error'}</p>
         </div>
       )}
 
@@ -592,7 +596,7 @@ export function Metrics() {
         <div className="space-y-6">
           {/* Top-line stats */}
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
-            <StatCard label="Open Issues" value={openCount.toString()} color="text-blue-700" sub={`${closedCount} closed`} />
+            <StatCard label="Open Issues" value={openCount.toString()} color="text-blue-700 dark:text-blue-400" sub={`${closedCount} closed`} />
             <StatCard label="Sessions" value={totalSessions.toString()} sub={`${completedSessions} completed`} />
             <StatCard
               label="Tasks Completed"

--- a/web/src/pages/MyQueue.tsx
+++ b/web/src/pages/MyQueue.tsx
@@ -20,15 +20,15 @@ function getPriority(labels: string[]): { rank: number; label: string } {
 function priorityColor(label: string): string {
   switch (label) {
     case 'priority:critical':
-      return 'bg-red-100 text-red-800'
+      return 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300'
     case 'priority:high':
-      return 'bg-orange-100 text-orange-800'
+      return 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300'
     case 'priority:normal':
-      return 'bg-yellow-100 text-yellow-800'
+      return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300'
     case 'priority:low':
-      return 'bg-green-100 text-green-800'
+      return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300'
     default:
-      return 'bg-gray-100 text-gray-600'
+      return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
   }
 }
 
@@ -80,8 +80,8 @@ function CopyButton({ text }: { text: string }) {
       onClick={handleCopy}
       className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
         copied
-          ? 'bg-green-100 text-green-700'
-          : 'bg-blue-50 text-blue-700 hover:bg-blue-100'
+          ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
+          : 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-800/40'
       }`}
       title="Copy agent prompt to clipboard"
     >
@@ -120,36 +120,36 @@ export function MyQueue() {
     <div>
       <div className="mb-6 flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">My Queue</h2>
-          <p className="mt-1 text-sm text-gray-500">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">My Queue</h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Issues that need your input -- sorted by priority. Copy the prompt to resolve in an agent session.
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <span className="rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800">
+          <span className="rounded-full bg-amber-100 dark:bg-amber-900/30 px-3 py-1 text-sm font-medium text-amber-800 dark:text-amber-300">
             {humanIssues.length} awaiting
           </span>
-          <span className="text-xs text-gray-400">Auto-refreshes every 30s</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">Auto-refreshes every 30s</span>
         </div>
       </div>
 
       {issues.isLoading && (
         <div className="flex items-center justify-center py-20">
-          <p className="text-gray-500">Loading issues...</p>
+          <p className="text-gray-500 dark:text-gray-400">Loading issues...</p>
         </div>
       )}
 
       {issues.isError && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-          <p className="font-medium text-red-800">Failed to load issues</p>
-          <p className="mt-1 text-sm text-red-600">{issues.error?.message}</p>
+        <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4">
+          <p className="font-medium text-red-800 dark:text-red-300">Failed to load issues</p>
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">{issues.error?.message}</p>
         </div>
       )}
 
       {issues.isSuccess && humanIssues.length === 0 && (
-        <div className="rounded-lg border bg-white p-8 text-center">
-          <p className="text-lg font-medium text-gray-700">Queue empty</p>
-          <p className="mt-1 text-sm text-gray-500">No issues need your attention right now.</p>
+        <div className="rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800 p-8 text-center">
+          <p className="text-lg font-medium text-gray-700 dark:text-gray-300">Queue empty</p>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">No issues need your attention right now.</p>
         </div>
       )}
 
@@ -166,11 +166,11 @@ export function MyQueue() {
             return (
               <div
                 key={issue.number}
-                className="overflow-hidden rounded-lg border bg-white"
+                className="overflow-hidden rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800"
               >
                 <div
                   onClick={() => toggleExpand(issue.number)}
-                  className="flex cursor-pointer items-center gap-4 px-4 py-3 hover:bg-gray-50"
+                  className="flex cursor-pointer items-center gap-4 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   <span
                     className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold ${priorityColor(priority.label)}`}
@@ -178,55 +178,55 @@ export function MyQueue() {
                     {priority.label.replace('priority:', '').toUpperCase()}
                   </span>
 
-                  <span className="text-sm font-medium text-gray-500">#{issue.number}</span>
+                  <span className="text-sm font-medium text-gray-500 dark:text-gray-400">#{issue.number}</span>
 
-                  <span className="flex-1 font-medium text-gray-900">{issue.title}</span>
+                  <span className="flex-1 font-medium text-gray-900 dark:text-gray-100">{issue.title}</span>
 
                   <div className="flex flex-wrap gap-1">
                     {otherLabels.map((label) => (
                       <span
                         key={label}
-                        className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                        className="inline-block rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-300"
                       >
                         {label}
                       </span>
                     ))}
                   </div>
 
-                  <span className="text-xs text-gray-400 whitespace-nowrap">{formatDate(issue.updated_at)}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">{formatDate(issue.updated_at)}</span>
 
                   <CopyButton text={prompt} />
 
                   <span
-                    className={`text-xs text-gray-400 ${expanded ? 'rotate-90' : ''} inline-block transition-transform`}
+                    className={`text-xs text-gray-400 dark:text-gray-500 ${expanded ? 'rotate-90' : ''} inline-block transition-transform`}
                   >
                     &#9654;
                   </span>
                 </div>
 
                 {expanded && (
-                  <div className="border-t bg-gray-50 px-4 py-4">
+                  <div className="border-t dark:border-gray-700 bg-gray-50 dark:bg-gray-900 px-4 py-4">
                     <div className="grid gap-4 lg:grid-cols-2">
                       <div>
-                        <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                           Issue Description
                         </h4>
-                        <div className="max-h-64 overflow-auto rounded border bg-white p-3">
+                        <div className="max-h-64 overflow-auto rounded border dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
                           {issue.body.trim() !== '' ? (
-                            <pre className="whitespace-pre-wrap text-sm text-gray-700 font-sans leading-relaxed">
+                            <pre className="whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300 font-sans leading-relaxed">
                               {issue.body}
                             </pre>
                           ) : (
-                            <p className="text-sm italic text-gray-400">No description provided.</p>
+                            <p className="text-sm italic text-gray-400 dark:text-gray-500">No description provided.</p>
                           )}
                         </div>
                       </div>
 
                       <div>
-                        <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                           Agent Prompt
                         </h4>
-                        <div className="relative rounded border bg-gray-900 p-3">
+                        <div className="relative rounded border dark:border-gray-700 bg-gray-900 p-3">
                           <pre className="whitespace-pre-wrap text-sm text-green-400 font-mono leading-relaxed">
                             {prompt}
                           </pre>
@@ -234,7 +234,7 @@ export function MyQueue() {
                             <CopyButton text={prompt} />
                           </div>
                         </div>
-                        <p className="mt-2 text-xs text-gray-500">
+                        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                           Paste this into a Claude Code session to resolve and complete the issue.
                         </p>
                       </div>


### PR DESCRIPTION
Adds class-based dark mode (Tailwind v4). Theme toggle in sidebar, persists to localStorage, respects prefers-color-scheme. All 6 pages updated with dark: variants.

Closes #563
Co-Authored-By: Claude <noreply@anthropic.com>