### PR TITLE
fix: set providers healthy in dashboard and document metric counter lifecycle

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -286,6 +286,7 @@ func serveCmd() *cobra.Command {
 							Name:       name,
 							Type:       pcfg.Type,
 							Model:      pcfg.DefaultModel,
+							Healthy:    true, // Present in config = assumed healthy; real probe is a separate concern.
 							AccountURL: pcfg.AccountURL,
 						})
 					}
@@ -543,6 +544,9 @@ func dispatchCmd() *cobra.Command {
 
 			// Periodically persist pool + dispatcher metrics to SQLite
 			// so the serve process can read them via StoreBackedMetrics.
+			// NOTE: TasksCompleted and TasksFailed are in-memory counters that
+			// reset when the dispatch process restarts. They reflect per-process-
+			// lifetime totals, not cumulative all-time counts.
 			if st != nil {
 				g.Go(func() error {
 					tick := time.NewTicker(30 * time.Second)


### PR DESCRIPTION
Sets Healthy: true on ProviderDTOs built from config (serve process has no provider instances to health-check). Documents that pool task counters are per-process-lifetime, not cumulative.

Closes #457, Closes #456
Co-Authored-By: Claude <noreply@anthropic.com>