### PR TITLE
fix: immediate dispatch when worker becomes idle

### DIFF
--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -38,6 +38,7 @@ type Dispatcher struct {
 	issueFailures  map[int]int // in-memory fallback; persisted counter is authoritative when store is set
 	circuitBreaker *CircuitBreaker
 	metrics        *metrics.DispatcherMetrics
+	wakeup         chan struct{}
 	mu             sync.Mutex
 	logger         *zap.Logger
 	stop           context.CancelFunc
@@ -62,6 +63,7 @@ func New(tracker forge.IssueTracker, policy autonomy.AutonomyPolicy, st store.St
 		issueFailures:  make(map[int]int),
 		circuitBreaker: NewCircuitBreaker(logger),
 		metrics:        metrics.NewDispatcherMetrics(),
+		wakeup:         make(chan struct{}, 1),
 		logger:         logger,
 	}
 }
@@ -123,6 +125,13 @@ func (d *Dispatcher) handleTaskComplete(result agent.TaskResult) {
 		decision := decideCorrection(fc, result.IssueNumber, attempt, 0)
 		d.applyCorrection(ctx, result, decision)
 	}
+
+	// Signal the run loop to immediately check for queued work
+	// instead of waiting for the next tick.
+	select {
+	case d.wakeup <- struct{}{}:
+	default: // already signaled, don't block
+	}
 }
 
 // Run starts the watch loop and heartbeat ticker. It blocks until ctx is
@@ -154,6 +163,16 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 			return ctx.Err()
 		case err := <-errCh:
 			return fmt.Errorf("watch stopped: %w", err)
+		case <-d.wakeup:
+			d.logger.Debug("wakeup: task completed, checking for queued work")
+			pollStart := time.Now()
+			if err := d.checkTimeouts(ctx); err != nil {
+				d.logger.Error("heartbeat check", zap.String("error", err.Error()))
+			}
+			if err := d.recheckCrossProjectDeps(ctx); err != nil {
+				d.logger.Error("cross-project dep recheck", zap.String("error", err.Error()))
+			}
+			d.metrics.PollCompleted(time.Since(pollStart))
 		case <-ticker.C:
 			pollStart := time.Now()
 			if err := d.checkTimeouts(ctx); err != nil {

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -1269,6 +1269,73 @@ func TestNoDoubleDispatch_AfterCompletion(t *testing.T) {
 	}
 }
 
+func TestHandleTaskComplete_SignalsWakeup(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	tracker.issues[8] = &forge.Issue{
+		Number: 8,
+		State:  forge.StateOpen,
+		Labels: []string{"status:claimed"},
+	}
+
+	d.mu.Lock()
+	d.claimed[8] = &claimedIssue{AgentID: "code-gen", ClaimedAt: time.Now(), LastHeartbeat: time.Now()}
+	d.mu.Unlock()
+
+	d.handleTaskComplete(agent.TaskResult{
+		IssueNumber: 8,
+		SessionID:   "sess-8",
+		AgentType:   models.AgentTypeCodeGen,
+		Success:     true,
+	})
+
+	// The wakeup channel should have a signal.
+	select {
+	case <-d.wakeup:
+		// Expected: wakeup was signaled.
+	default:
+		t.Error("expected wakeup channel to be signaled after task completion")
+	}
+}
+
+func TestHandleTaskComplete_WakeupDoesNotBlock(t *testing.T) {
+	tracker := newMockTracker()
+	d := newTestDispatcher(tracker)
+
+	// Pre-fill the wakeup channel to simulate an already-pending signal.
+	d.wakeup <- struct{}{}
+
+	tracker.issues[9] = &forge.Issue{
+		Number: 9,
+		State:  forge.StateOpen,
+		Labels: []string{"status:claimed"},
+	}
+
+	d.mu.Lock()
+	d.claimed[9] = &claimedIssue{AgentID: "code-gen", ClaimedAt: time.Now(), LastHeartbeat: time.Now()}
+	d.mu.Unlock()
+
+	// This must not block even though the channel is already full.
+	done := make(chan struct{})
+	go func() {
+		d.handleTaskComplete(agent.TaskResult{
+			IssueNumber: 9,
+			SessionID:   "sess-9",
+			AgentType:   models.AgentTypeCodeGen,
+			Success:     true,
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Expected: completed without blocking.
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTaskComplete blocked on full wakeup channel")
+	}
+}
+
 func hasLabel(labels []string, target string) bool {
 	for _, l := range labels {
 		if l == target {


### PR DESCRIPTION
Adds wakeup channel so the dispatcher polls immediately on task completion instead of waiting 30s for the next tick. Includes tests for signal delivery and non-blocking behavior.

Closes #485
Co-Authored-By: Claude <noreply@anthropic.com>