### PR TITLE
fix: reduce CLI hang timeout and add spawn stagger

### DIFF
--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -27,6 +27,10 @@ var ErrPoolShutdown = errors.New("pool is shut down")
 // defaultWorkers is the number of worker goroutines when none is specified.
 const defaultWorkers = 3
 
+// spawnStagger is the minimum interval between consecutive CLI process spawns.
+// Prevents overwhelming the system when multiple workers start simultaneously.
+const spawnStagger = 200 * time.Millisecond
+
 // Task represents a unit of work to be processed by the agent pool.
 type Task struct {
 	Issue         *forge.Issue
@@ -73,6 +77,8 @@ type Pool struct {
 	synapset   *synapset.Client                    // optional Synapset memory client; nil disables enrichment
 	repoDir    string                               // local git clone path for worktree creation; empty disables
 	fetchMu    sync.Mutex                           // serializes FetchLatest calls to avoid concurrent git index locks
+	spawnMu    sync.Mutex                           // serializes CLI process spawns to avoid overwhelming the system
+	lastSpawn  time.Time                            // timestamp of the last provider spawn for stagger enforcement
 }
 
 // NewPool creates a pool with the given number of worker goroutines and starts
@@ -387,6 +393,15 @@ func (p *Pool) processTask(task Task) {
 
 	// Fetch latest code before creating a runner (serialized across workers).
 	p.fetchLatest()
+
+	// Stagger CLI spawns to avoid overwhelming the system when multiple
+	// workers start tasks simultaneously.
+	p.spawnMu.Lock()
+	if since := time.Since(p.lastSpawn); since < spawnStagger {
+		time.Sleep(spawnStagger - since)
+	}
+	p.lastSpawn = time.Now()
+	p.spawnMu.Unlock()
 
 	runner := NewRunner(prov, model, p.tracker, p.store, p.costs, p.logger)
 	runner.cleanupCtx = cleanupCtx

--- a/internal/provider/claudecli/claudecli.go
+++ b/internal/provider/claudecli/claudecli.go
@@ -30,7 +30,8 @@ const (
 
 	// staleOutputTimeout is how long Chat waits for new bytes before treating
 	// the process as hung. Must be shorter than the dispatcher heartbeat timeout.
-	staleOutputTimeout = 3 * time.Minute
+	// 60s balances fast hang detection with allowing slow first tool calls (30-40s).
+	staleOutputTimeout = 60 * time.Second
 
 	// streamBufSize is the read buffer for pipe-based streaming.
 	streamBufSize = 4096


### PR DESCRIPTION
Reduces stale output timeout from 3m to 60s. Adds 200ms spawn stagger between concurrent CLI launches to prevent system overload.

Closes #491
Co-Authored-By: Claude <noreply@anthropic.com>