### PR TITLE
feat: add OAuth 2.1 discovery for Claude mobile MCP

### DIFF
--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// oauthDiscovery is the OAuth 2.1 authorization server metadata document.
+// See RFC 8414 and the OAuth 2.1 draft specification.
+type oauthDiscovery struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	RevocationEndpoint    string   `json:"revocation_endpoint,omitempty"`
+	ResponseTypes         []string `json:"response_types_supported"`
+	GrantTypes            []string `json:"grant_types_supported"`
+	CodeChallenge         []string `json:"code_challenge_methods_supported"`
+}
+
+// oauthPending tracks a pending authorization code exchange.
+type oauthPending struct {
+	redirectURI   string
+	codeChallenge string
+	expiresAt     time.Time
+}
+
+// oauthCodeStore manages short-lived authorization codes.
+// Codes expire after 5 minutes per OAuth 2.1 spec.
+type oauthCodeStore struct {
+	codes sync.Map // map[string]*oauthPending
+}
+
+func (s *oauthCodeStore) store(code string, pending *oauthPending) {
+	s.codes.Store(code, pending)
+}
+
+func (s *oauthCodeStore) loadAndDelete(code string) (*oauthPending, bool) {
+	val, ok := s.codes.LoadAndDelete(code)
+	if !ok {
+		return nil, false
+	}
+	return val.(*oauthPending), true
+}
+
+// oauthTokenResponse is returned by the token endpoint.
+type oauthTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// oauthErrorResponse is returned for OAuth errors.
+type oauthErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// handleOAuthDiscovery serves the OAuth 2.1 authorization server metadata.
+// GET /.well-known/oauth-authorization-server
+func (s *Server) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
+	scheme := "https"
+	if r.TLS == nil {
+		// Check X-Forwarded-Proto for reverse proxy setups (Caddy, Cloudflare).
+		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+			scheme = proto
+		} else {
+			scheme = "http"
+		}
+	}
+	base := scheme + "://" + r.Host
+
+	doc := oauthDiscovery{
+		Issuer:                base,
+		AuthorizationEndpoint: base + "/oauth/authorize",
+		TokenEndpoint:         base + "/oauth/token",
+		RevocationEndpoint:    base + "/oauth/revoke",
+		ResponseTypes:         []string{"code"},
+		GrantTypes:            []string{"authorization_code"},
+		CodeChallenge:         []string{"S256"},
+	}
+	writeJSON(w, http.StatusOK, doc)
+}
+
+// handleOAuthAuthorize handles the authorization request.
+// GET /oauth/authorize?client_id=...&redirect_uri=...&state=...&code_challenge=...&code_challenge_method=S256&response_type=code
+//
+// This auto-approves the request and redirects back with an authorization code.
+// The code must be exchanged at the token endpoint within 5 minutes.
+func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	redirectURI := r.URL.Query().Get("redirect_uri")
+	state := r.URL.Query().Get("state")
+
+	if redirectURI == "" {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_request"})
+		return
+	}
+
+	code := generateOAuthCode()
+
+	s.oauthCodes.store(code, &oauthPending{
+		redirectURI:   redirectURI,
+		codeChallenge: r.URL.Query().Get("code_challenge"),
+		expiresAt:     time.Now().Add(5 * time.Minute),
+	})
+
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_request"})
+		return
+	}
+	q := u.Query()
+	q.Set("code", code)
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// handleOAuthToken exchanges an authorization code for an access token.
+// POST /oauth/token
+// Content-Type: application/x-www-form-urlencoded
+// grant_type=authorization_code&code=...&redirect_uri=...&code_verifier=...
+//
+// Returns the server's configured auth token as the access_token,
+// bridging OAuth to the existing Bearer token auth system.
+func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_request"})
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+	if grantType != "authorization_code" {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "unsupported_grant_type"})
+		return
+	}
+
+	code := r.FormValue("code")
+	if code == "" {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_request"})
+		return
+	}
+
+	pending, ok := s.oauthCodes.loadAndDelete(code)
+	if !ok {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_grant"})
+		return
+	}
+
+	if time.Now().After(pending.expiresAt) {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_grant"})
+		return
+	}
+
+	// Verify PKCE S256 challenge if one was provided during authorization.
+	codeVerifier := r.FormValue("code_verifier")
+	if pending.codeChallenge != "" {
+		if codeVerifier == "" {
+			writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_grant"})
+			return
+		}
+		h := sha256.Sum256([]byte(codeVerifier))
+		challenge := base64.RawURLEncoding.EncodeToString(h[:])
+		if challenge != pending.codeChallenge {
+			writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "invalid_grant"})
+			return
+		}
+	}
+
+	// Bridge: return the server's configured auth token as the OAuth access token.
+	token := s.cfg.AuthToken
+	if token == "" {
+		writeJSON(w, http.StatusBadRequest, oauthErrorResponse{Error: "server_error"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, oauthTokenResponse{
+		AccessToken: token,
+		TokenType:   "Bearer",
+		ExpiresIn:   86400,
+	})
+}
+
+// handleOAuthRevoke handles token revocation requests.
+// POST /oauth/revoke
+// This is a no-op because tokens are server-configured, not revocable.
+// Returns 200 per RFC 7009 (revocation always succeeds from client perspective).
+func (s *Server) handleOAuthRevoke(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// generateOAuthCode produces a cryptographically random 32-byte hex string
+// for use as an OAuth authorization code.
+func generateOAuthCode() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback is intentionally weak -- crypto/rand failure is exceptional.
+		return hex.EncodeToString([]byte(time.Now().String()))
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -1,0 +1,469 @@
+package server_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/herbhall/samverk/internal/server"
+)
+
+func newOAuthTestServer(t *testing.T, token string) *httptest.Server {
+	t.Helper()
+	s := server.New(server.Config{
+		Addr:      "localhost:0",
+		AuthToken: token,
+	}, zap.NewNop())
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestOAuthDiscovery(t *testing.T) {
+	ts := newOAuthTestServer(t, "test-token")
+
+	resp := get(t, ts.URL+"/.well-known/oauth-authorization-server")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var doc struct {
+		Issuer                string   `json:"issuer"`
+		AuthorizationEndpoint string   `json:"authorization_endpoint"`
+		TokenEndpoint         string   `json:"token_endpoint"`
+		RevocationEndpoint    string   `json:"revocation_endpoint"`
+		ResponseTypes         []string `json:"response_types_supported"`
+		GrantTypes            []string `json:"grant_types_supported"`
+		CodeChallenge         []string `json:"code_challenge_methods_supported"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if doc.Issuer == "" {
+		t.Error("issuer is empty")
+	}
+	if doc.AuthorizationEndpoint == "" {
+		t.Error("authorization_endpoint is empty")
+	}
+	if doc.TokenEndpoint == "" {
+		t.Error("token_endpoint is empty")
+	}
+	if doc.RevocationEndpoint == "" {
+		t.Error("revocation_endpoint is empty")
+	}
+	if len(doc.ResponseTypes) == 0 || doc.ResponseTypes[0] != "code" {
+		t.Errorf("response_types = %v, want [code]", doc.ResponseTypes)
+	}
+	if len(doc.GrantTypes) == 0 || doc.GrantTypes[0] != "authorization_code" {
+		t.Errorf("grant_types = %v, want [authorization_code]", doc.GrantTypes)
+	}
+	if len(doc.CodeChallenge) == 0 || doc.CodeChallenge[0] != "S256" {
+		t.Errorf("code_challenge_methods = %v, want [S256]", doc.CodeChallenge)
+	}
+
+	// Endpoints should use the test server's base URL.
+	if !strings.HasPrefix(doc.AuthorizationEndpoint, "http://") {
+		t.Errorf("authorization_endpoint = %q, want http:// prefix", doc.AuthorizationEndpoint)
+	}
+}
+
+func TestOAuthFlow(t *testing.T) {
+	const token = "my-secret-token"
+	ts := newOAuthTestServer(t, token)
+
+	// Use a no-redirect client so we can inspect the 302 Location header.
+	noRedirect := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Step 1: Authorization request.
+	redirectURI := "https://example.com/callback"
+	state := "random-state-value"
+	authURL := ts.URL + "/oauth/authorize?" + url.Values{
+		"client_id":    {"claude-mobile"},
+		"redirect_uri": {redirectURI},
+		"state":        {state},
+		"response_type": {"code"},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, authURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("new auth request: %v", err)
+	}
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("authorize status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatal("no code in redirect")
+	}
+	if loc.Query().Get("state") != state {
+		t.Errorf("state = %q, want %q", loc.Query().Get("state"), state)
+	}
+
+	// Step 2: Exchange code for token.
+	tokenReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+"/oauth/token",
+		strings.NewReader(url.Values{
+			"grant_type":   {"authorization_code"},
+			"code":         {code},
+			"redirect_uri": {redirectURI},
+		}.Encode()))
+	if err != nil {
+		t.Fatalf("new token request: %v", err)
+	}
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	tokenResp, err := http.DefaultClient.Do(tokenReq)
+	if err != nil {
+		t.Fatalf("token exchange: %v", err)
+	}
+	defer func() { _ = tokenResp.Body.Close() }()
+
+	if tokenResp.StatusCode != http.StatusOK {
+		t.Fatalf("token status = %d, want %d", tokenResp.StatusCode, http.StatusOK)
+	}
+
+	var tokenBody struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenBody); err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+
+	if tokenBody.AccessToken != token {
+		t.Errorf("access_token = %q, want %q", tokenBody.AccessToken, token)
+	}
+	if tokenBody.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", tokenBody.TokenType)
+	}
+	if tokenBody.ExpiresIn != 86400 {
+		t.Errorf("expires_in = %d, want 86400", tokenBody.ExpiresIn)
+	}
+}
+
+func TestOAuthPKCE(t *testing.T) {
+	const token = "pkce-test-token"
+	ts := newOAuthTestServer(t, token)
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Generate PKCE pair.
+	codeVerifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	h := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	// Step 1: Authorize with code_challenge.
+	authURL := ts.URL + "/oauth/authorize?" + url.Values{
+		"client_id":             {"claude-mobile"},
+		"redirect_uri":         {"https://example.com/callback"},
+		"state":                {"pkce-state"},
+		"response_type":        {"code"},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, authURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("new auth request: %v", err)
+	}
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	code := loc.Query().Get("code")
+
+	// Step 2: Exchange with correct code_verifier -- should succeed.
+	tokenResp := exchangeToken(t, ts.URL, code, "https://example.com/callback", codeVerifier)
+	defer func() { _ = tokenResp.Body.Close() }()
+
+	if tokenResp.StatusCode != http.StatusOK {
+		t.Errorf("token status = %d, want %d", tokenResp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestOAuthPKCEWrongVerifier(t *testing.T) {
+	const token = "pkce-wrong-test"
+	ts := newOAuthTestServer(t, token)
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	codeVerifier := "correct-verifier-value"
+	h := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	authURL := ts.URL + "/oauth/authorize?" + url.Values{
+		"client_id":             {"claude-mobile"},
+		"redirect_uri":         {"https://example.com/callback"},
+		"state":                {"s"},
+		"response_type":        {"code"},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, authURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("new auth request: %v", err)
+	}
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	code := loc.Query().Get("code")
+
+	// Exchange with WRONG code_verifier -- should fail.
+	tokenResp := exchangeToken(t, ts.URL, code, "https://example.com/callback", "wrong-verifier")
+	defer func() { _ = tokenResp.Body.Close() }()
+
+	if tokenResp.StatusCode != http.StatusBadRequest {
+		t.Errorf("token status = %d, want %d", tokenResp.StatusCode, http.StatusBadRequest)
+	}
+
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "invalid_grant" {
+		t.Errorf("error = %q, want invalid_grant", body.Error)
+	}
+}
+
+func TestOAuthCodeReuse(t *testing.T) {
+	const token = "reuse-test"
+	ts := newOAuthTestServer(t, token)
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	authURL := ts.URL + "/oauth/authorize?" + url.Values{
+		"client_id":    {"claude-mobile"},
+		"redirect_uri": {"https://example.com/callback"},
+		"state":        {"s"},
+		"response_type": {"code"},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, authURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("new auth request: %v", err)
+	}
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	code := loc.Query().Get("code")
+
+	// First exchange succeeds.
+	tokenResp := exchangeToken(t, ts.URL, code, "https://example.com/callback", "")
+	defer func() { _ = tokenResp.Body.Close() }()
+	if tokenResp.StatusCode != http.StatusOK {
+		t.Fatalf("first exchange status = %d, want %d", tokenResp.StatusCode, http.StatusOK)
+	}
+
+	// Second exchange with same code fails (code is single-use).
+	tokenResp2 := exchangeToken(t, ts.URL, code, "https://example.com/callback", "")
+	defer func() { _ = tokenResp2.Body.Close() }()
+	if tokenResp2.StatusCode != http.StatusBadRequest {
+		t.Errorf("second exchange status = %d, want %d", tokenResp2.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestOAuthInvalidCode(t *testing.T) {
+	ts := newOAuthTestServer(t, "test-token")
+
+	tokenResp := exchangeToken(t, ts.URL, "nonexistent-code", "https://example.com/callback", "")
+	defer func() { _ = tokenResp.Body.Close() }()
+
+	if tokenResp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", tokenResp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestOAuthMissingRedirectURI(t *testing.T) {
+	ts := newOAuthTestServer(t, "test-token")
+
+	resp := get(t, ts.URL+"/oauth/authorize?client_id=test&state=s")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestOAuthRevoke(t *testing.T) {
+	ts := newOAuthTestServer(t, "test-token")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+"/oauth/revoke",
+		strings.NewReader("token=some-token"))
+	if err != nil {
+		t.Fatalf("new revoke request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestOAuthUnsupportedGrantType(t *testing.T) {
+	ts := newOAuthTestServer(t, "test-token")
+
+	tokenReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+"/oauth/token",
+		strings.NewReader(url.Values{
+			"grant_type": {"client_credentials"},
+		}.Encode()))
+	if err != nil {
+		t.Fatalf("new token request: %v", err)
+	}
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(tokenReq)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "unsupported_grant_type" {
+		t.Errorf("error = %q, want unsupported_grant_type", body.Error)
+	}
+}
+
+func TestOAuthNoAuthToken(t *testing.T) {
+	// Server with no auth token configured -- token exchange should fail.
+	ts := newOAuthTestServer(t, "")
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	authURL := ts.URL + "/oauth/authorize?" + url.Values{
+		"client_id":    {"claude-mobile"},
+		"redirect_uri": {"https://example.com/callback"},
+		"state":        {"s"},
+		"response_type": {"code"},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, authURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("new auth request: %v", err)
+	}
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	code := loc.Query().Get("code")
+
+	tokenResp := exchangeToken(t, ts.URL, code, "https://example.com/callback", "")
+	defer func() { _ = tokenResp.Body.Close() }()
+
+	if tokenResp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (no auth token configured)", tokenResp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+// exchangeToken performs a POST /oauth/token request.
+func exchangeToken(t *testing.T, baseURL, code, redirectURI, codeVerifier string) *http.Response {
+	t.Helper()
+
+	values := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": {redirectURI},
+	}
+	if codeVerifier != "" {
+		values.Set("code_verifier", codeVerifier)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/oauth/token",
+		strings.NewReader(values.Encode()))
+	if err != nil {
+		t.Fatalf("new token request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("token exchange: %v", err)
+	}
+	return resp
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,8 @@ type Server struct {
 
 	mu         sync.Mutex
 	listenAddr string
+
+	oauthCodes oauthCodeStore // short-lived authorization codes for OAuth 2.1 bridge
 }
 
 // New creates a new Server with routes registered.
@@ -127,6 +129,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // registerRoutes wires all HTTP endpoints.
 func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealth)
+
+	// OAuth 2.1 endpoints -- unauthenticated, required by Claude mobile MCP Custom Connector.
+	s.mux.HandleFunc("GET /.well-known/oauth-authorization-server", s.handleOAuthDiscovery)
+	s.mux.HandleFunc("GET /oauth/authorize", s.handleOAuthAuthorize)
+	s.mux.HandleFunc("POST /oauth/token", s.handleOAuthToken)
+	s.mux.HandleFunc("POST /oauth/revoke", s.handleOAuthRevoke)
 
 	if s.cfg.MCPHandler != nil {
 		handler := s.cfg.MCPHandler


### PR DESCRIPTION
Minimal OAuth 2.1 bridge for Claude mobile Custom Connector. PKCE S256, auto-approve authorize, bridges to Bearer token auth. 10 tests.

Closes #479
Co-Authored-By: Claude <noreply@anthropic.com>