### PR TITLE
feat: add cloudflared tunnel health watchdog

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,37 @@
+# Scripts
+
+Operational scripts for Samverk infrastructure.
+
+## Cloudflared Watchdog
+
+Monitors tunnel health every 60s. Restarts cloudflared after 2 consecutive failures.
+
+### Install on CT 201 (Caddy/tunnel host)
+
+````bash
+sudo cp scripts/cloudflared-watchdog.sh /usr/local/bin/
+sudo chmod +x /usr/local/bin/cloudflared-watchdog.sh
+sudo cp scripts/cloudflared-watchdog.service /etc/systemd/system/
+sudo cp scripts/cloudflared-watchdog.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now cloudflared-watchdog.timer
+````
+
+### Configuration
+
+Environment variables (set in a systemd override or `/etc/default/cloudflared-watchdog`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLOUDFLARED_HEALTH_URL` | `http://localhost:8080/healthz` | Health endpoint to check |
+| `CLOUDFLARED_SERVICE` | `cloudflared` | Systemd service name to restart |
+| `CLOUDFLARED_MAX_FAILURES` | `2` | Consecutive failures before restart |
+
+### How it works
+
+1. Timer fires every 60s (first run 120s after boot)
+2. Script checks if cloudflared systemd service is active
+3. Script hits the health endpoint through the tunnel
+4. If both pass, resets the failure counter
+5. If either fails, increments counter
+6. After 2 consecutive failures, restarts the cloudflared service

--- a/scripts/cloudflared-watchdog.service
+++ b/scripts/cloudflared-watchdog.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Cloudflared Tunnel Health Watchdog
+After=cloudflared.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/cloudflared-watchdog.sh

--- a/scripts/cloudflared-watchdog.sh
+++ b/scripts/cloudflared-watchdog.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Cloudflared tunnel health watchdog.
+# Checks if the tunnel is responsive and restarts cloudflared if not.
+# Intended to run as a systemd timer every 60 seconds.
+
+set -euo pipefail
+
+HEALTH_URL="${CLOUDFLARED_HEALTH_URL:-http://localhost:8080/healthz}"
+TUNNEL_SERVICE="${CLOUDFLARED_SERVICE:-cloudflared}"
+MAX_FAILURES="${CLOUDFLARED_MAX_FAILURES:-2}"
+FAILURE_FILE="/tmp/cloudflared-watchdog-failures"
+
+# Initialize failure counter
+if [[ ! -f "$FAILURE_FILE" ]]; then
+    echo 0 > "$FAILURE_FILE"
+fi
+
+# Check tunnel health by hitting the backend through the tunnel's local metrics endpoint
+# If cloudflared is running but the QUIC connection is dead, the tunnel won't proxy
+# So we check both: is the process alive AND can it reach the backend
+if systemctl is-active --quiet "$TUNNEL_SERVICE" && \
+   curl -sf --max-time 10 "$HEALTH_URL" > /dev/null 2>&1; then
+    # Healthy -- reset failure counter
+    echo 0 > "$FAILURE_FILE"
+    exit 0
+fi
+
+# Increment failure counter
+FAILURES=$(cat "$FAILURE_FILE")
+FAILURES=$((FAILURES + 1))
+echo "$FAILURES" > "$FAILURE_FILE"
+
+if [[ "$FAILURES" -ge "$MAX_FAILURES" ]]; then
+    echo "cloudflared-watchdog: $FAILURES consecutive failures, restarting $TUNNEL_SERVICE"
+    systemctl restart "$TUNNEL_SERVICE"
+    echo 0 > "$FAILURE_FILE"
+else
+    echo "cloudflared-watchdog: failure $FAILURES/$MAX_FAILURES (will restart at $MAX_FAILURES)"
+fi

--- a/scripts/cloudflared-watchdog.timer
+++ b/scripts/cloudflared-watchdog.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run cloudflared watchdog every 60s
+
+[Timer]
+OnBootSec=120
+OnUnitActiveSec=60
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Shell script + systemd timer checking tunnel health every 60s. Restarts after 2 consecutive failures.

Closes #478
Co-Authored-By: Claude <noreply@anthropic.com>