### PR TITLE
feat: provider health monitor with proactive checks (#473, #494)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -464,15 +464,17 @@ func dispatchCmd() *cobra.Command {
 
 			// Load provider registry and construct agent pool if config exists.
 			var pool *agent.Pool
+			var providerRegistry *provider.Registry
 			if providersConfig != "" {
-				registry, regErr := provider.LoadRegistry(providersConfig, makeProviderFactory(logger), logger)
+				reg, regErr := provider.LoadRegistry(providersConfig, makeProviderFactory(logger), logger)
 				if regErr != nil {
 					logger.Warn("could not load provider registry, agents disabled", zap.String("path", providersConfig), zap.Error(regErr))
 				} else {
+					providerRegistry = reg
 					costs := cost.NewTracker(st, budget, 24)
-					pool = agent.NewPool(registry, tracker, st, costs, workers, logger)
+					pool = agent.NewPool(reg, tracker, st, costs, workers, logger)
 					defer pool.Shutdown()
-					logger.Info("agent pool started", zap.Int("workers", workers), zap.Int("providers", len(registry.List(ctx))))
+					logger.Info("agent pool started", zap.Int("workers", workers), zap.Int("providers", len(reg.List(ctx))))
 				}
 			}
 
@@ -503,6 +505,15 @@ func dispatchCmd() *cobra.Command {
 				{Owner: owner, Repo: repo, Tracker: tracker},
 			}
 			disp := dispatcher.New(trackerEntries, policy, st, pool, nil, logger)
+
+			// Start health monitor for pre-flight provider health gating.
+			if providerRegistry != nil {
+				hm := provider.NewHealthMonitor(providerRegistry, provider.DefaultHealthCheckInterval, logger)
+				hm.Start(ctx)
+				disp.SetHealthMonitor(hm)
+				logger.Info("provider health monitor started")
+			}
+
 			logger.Info("starting dispatcher", zap.String("owner", owner), zap.String("repo", repo))
 
 			g, gctx := errgroup.WithContext(ctx)

--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -316,6 +316,15 @@ func (p *Pool) fetchLatest() {
 	FetchLatest(p.repoDir, p.logger)
 }
 
+// RegistryRouting returns the routing table from the underlying provider registry.
+// Used by the dispatcher for pre-flight health gate checks.
+func (p *Pool) RegistryRouting() map[string][]string {
+	if p.registry == nil {
+		return nil
+	}
+	return p.registry.Routing()
+}
+
 // SetOnComplete registers a callback invoked after each task finishes.
 func (p *Pool) SetOnComplete(fn func(TaskResult)) {
 	p.onComplete.Store(&fn)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/herbhall/samverk/internal/loganalyst"
 	"github.com/herbhall/samverk/internal/logstore"
 	"github.com/herbhall/samverk/internal/metrics"
+	"github.com/herbhall/samverk/internal/provider"
 	"github.com/herbhall/samverk/internal/store"
 )
 
@@ -41,6 +42,7 @@ type API struct {
 	hostMetrics    *hostmetrics.Collector   // may be nil if collector not started
 	capacity       *capacityDTO            // may be nil if no providers configured
 	logAnalyst     *loganalyst.Analyst      // may be nil if logstore not configured
+	healthMonitor  *provider.HealthMonitor  // may be nil if health monitor not started
 	workers        *workerRegistry         // in-memory registry of PC agent workers
 	scalingEnabled bool                    // true when autoscaler was configured
 	scalingMin     int
@@ -122,6 +124,7 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/workers/heartbeat", a.handleWorkerHeartbeat)
 	mux.HandleFunc("GET /api/v1/metrics/host", a.handleHostMetrics)
 	mux.HandleFunc("GET /api/v1/failures", a.handleFailureSummary)
+	mux.HandleFunc("GET /api/v1/providers/health", a.handleProviderHealth)
 	mux.HandleFunc("GET /api/v1/logs", a.handleListLogs)
 	mux.HandleFunc("GET /api/v1/logs/summary", a.handleLogSummary)
 }

--- a/internal/api/provider_health.go
+++ b/internal/api/provider_health.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+// SetHealthMonitor attaches the provider health monitor for the
+// GET /api/v1/providers/health endpoint. Call from the serve or
+// dispatch command after creating the HealthMonitor.
+func (a *API) SetHealthMonitor(hm *provider.HealthMonitor) {
+	a.healthMonitor = hm
+}
+
+// handleProviderHealth returns the cached health status for all providers.
+func (a *API) handleProviderHealth(w http.ResponseWriter, _ *http.Request) {
+	if a.healthMonitor == nil {
+		writeError(w, http.StatusServiceUnavailable, "health monitor not configured")
+		return
+	}
+
+	health := a.healthMonitor.AllHealth()
+	writeJSON(w, http.StatusOK, health)
+}

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/herbhall/samverk/internal/autonomy"
 	"github.com/herbhall/samverk/internal/forge"
 	"github.com/herbhall/samverk/internal/metrics"
+	"github.com/herbhall/samverk/internal/provider"
 	"github.com/herbhall/samverk/internal/store"
 )
 
@@ -45,6 +46,7 @@ type Dispatcher struct {
 	policy         autonomy.AutonomyPolicy
 	store          store.Store
 	pool           *agent.Pool
+	healthMonitor  *provider.HealthMonitor
 	decomposer     Decomposer
 	projects       ProjectResolver
 	config         *Config
@@ -120,6 +122,13 @@ func New(trackers []TrackerEntry, policy autonomy.AutonomyPolicy, st store.Store
 // child issues before routing.
 func (d *Dispatcher) SetDecomposer(dec Decomposer) {
 	d.decomposer = dec
+}
+
+// SetHealthMonitor configures the provider health monitor for pre-flight
+// health gating. When set, route() checks that at least one provider in
+// the routing chain is healthy before claiming an issue.
+func (d *Dispatcher) SetHealthMonitor(hm *provider.HealthMonitor) {
+	d.healthMonitor = hm
 }
 
 // SetProjectResolver configures the cross-project dependency resolver.

--- a/internal/dispatcher/router.go
+++ b/internal/dispatcher/router.go
@@ -168,6 +168,26 @@ func (d *Dispatcher) route(ctx context.Context, owner, repo string, issue *forge
 		return fmt.Errorf("no tracker for %s/%s", owner, repo)
 	}
 
+	// Pre-flight health gate: check if the routing chain has any healthy
+	// provider before claiming the issue. This prevents the tight
+	// claim-fail-requeue loop when all providers are down.
+	if d.healthMonitor != nil && d.pool != nil {
+		providerKey, _ := selectProviderKey(issue, agentType)
+		routing := d.pool.RegistryRouting()
+		chain, ok := routing[providerKey]
+		if !ok {
+			chain = routing["default"]
+		}
+		if len(chain) > 0 && !d.healthMonitor.ChainHealthy(chain) {
+			d.logger.Warn("no healthy providers for chain, deferring issue",
+				zap.Int("issue", issue.Number),
+				zap.String("chain", providerKey),
+				zap.Strings("providers", chain),
+			)
+			return nil
+		}
+	}
+
 	// Human-typed issues are tracked but never submitted to the agent pool.
 	if agentType == models.AgentTypeHuman {
 		d.logger.Info("issue classified as human", zap.Int("issue", issue.Number))

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -1,0 +1,185 @@
+package provider
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DefaultHealthCheckInterval is the default interval between health probe cycles.
+const DefaultHealthCheckInterval = 60 * time.Second
+
+// ProviderHealth describes the health status of a single provider.
+type ProviderHealth struct {
+	Name        string    `json:"name"`
+	Healthy     bool      `json:"healthy"`
+	LastChecked time.Time `json:"last_checked"`
+	LastHealthy time.Time `json:"last_healthy"`
+	Error       string    `json:"error,omitempty"`
+	// Ollama-specific fields (zero values for non-Ollama providers).
+	ModelLoaded bool  `json:"model_loaded,omitempty"`
+	VRAMFree    int64 `json:"vram_free_bytes,omitempty"`
+	VRAMTotal   int64 `json:"vram_total_bytes,omitempty"`
+}
+
+// HealthDetailer is an optional interface that providers may implement
+// to expose richer health information (e.g., model load status, VRAM usage).
+type HealthDetailer interface {
+	HealthDetail(ctx context.Context) (*HealthDetail, error)
+}
+
+// HealthDetail contains extended health information from providers that
+// support it (currently Ollama).
+type HealthDetail struct {
+	ModelLoaded bool
+	VRAMFree    int64
+	VRAMTotal   int64
+}
+
+// HealthMonitor runs periodic health checks against all providers in
+// a Registry and caches the results for fast, lock-free reads by the
+// dispatcher and API layer.
+type HealthMonitor struct {
+	registry *Registry
+	interval time.Duration
+	logger   *zap.Logger
+
+	mu     sync.RWMutex
+	health map[string]*ProviderHealth // keyed by provider name
+}
+
+// NewHealthMonitor creates a HealthMonitor that probes all providers in
+// the registry at the given interval. Use Start to begin the probe loop.
+func NewHealthMonitor(registry *Registry, interval time.Duration, logger *zap.Logger) *HealthMonitor {
+	if interval <= 0 {
+		interval = DefaultHealthCheckInterval
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &HealthMonitor{
+		registry: registry,
+		interval: interval,
+		logger:   logger,
+		health:   make(map[string]*ProviderHealth),
+	}
+}
+
+// Start runs the health check loop in a goroutine. It performs an initial
+// probe immediately and then repeats at the configured interval. The loop
+// exits when ctx is cancelled.
+func (hm *HealthMonitor) Start(ctx context.Context) {
+	// Initial probe before starting the ticker so that callers can rely
+	// on health data being available shortly after Start returns.
+	hm.probeAll(ctx)
+
+	go func() {
+		ticker := time.NewTicker(hm.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				hm.probeAll(ctx)
+			}
+		}
+	}()
+}
+
+// GetHealth returns the cached health status for a named provider.
+// Returns a zero-value ProviderHealth (Healthy=false) if the provider
+// has not been probed yet.
+func (hm *HealthMonitor) GetHealth(name string) ProviderHealth {
+	hm.mu.RLock()
+	defer hm.mu.RUnlock()
+
+	if h, ok := hm.health[name]; ok {
+		return *h
+	}
+	return ProviderHealth{Name: name}
+}
+
+// AllHealth returns cached health for all probed providers.
+func (hm *HealthMonitor) AllHealth() []ProviderHealth {
+	hm.mu.RLock()
+	defer hm.mu.RUnlock()
+
+	out := make([]ProviderHealth, 0, len(hm.health))
+	for _, h := range hm.health {
+		out = append(out, *h)
+	}
+	return out
+}
+
+// ChainHealthy returns true if at least one provider in the named
+// routing chain is healthy according to cached probe results.
+func (hm *HealthMonitor) ChainHealthy(chain []string) bool {
+	hm.mu.RLock()
+	defer hm.mu.RUnlock()
+
+	for _, name := range chain {
+		if h, ok := hm.health[name]; ok && h.Healthy {
+			return true
+		}
+	}
+	return false
+}
+
+// probeAll checks every registered provider and updates the cache.
+func (hm *HealthMonitor) probeAll(ctx context.Context) {
+	providers := hm.registry.List(ctx)
+
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	now := time.Now()
+	for i := range providers {
+		info := &providers[i]
+		name := info.Name
+
+		existing, ok := hm.health[name]
+		if !ok {
+			existing = &ProviderHealth{Name: name}
+			hm.health[name] = existing
+		}
+
+		existing.LastChecked = now
+		existing.Healthy = info.Healthy
+		existing.Error = ""
+
+		if info.Healthy {
+			existing.LastHealthy = now
+		}
+
+		// Attempt extended health detail for providers that support it.
+		p := hm.registry.ProviderByName(name)
+		if p == nil {
+			continue
+		}
+		if hd, ok := p.(HealthDetailer); ok {
+			detail, err := hd.HealthDetail(ctx)
+			if err != nil {
+				existing.Error = err.Error()
+				hm.logger.Debug("health detail probe failed",
+					zap.String("provider", name),
+					zap.Error(err),
+				)
+				continue
+			}
+			if detail != nil {
+				existing.ModelLoaded = detail.ModelLoaded
+				existing.VRAMFree = detail.VRAMFree
+				existing.VRAMTotal = detail.VRAMTotal
+			}
+		}
+	}
+
+	hm.logger.Debug("health probes completed",
+		zap.Int("providers", len(providers)),
+		zap.Time("at", now),
+	)
+}

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -1,0 +1,145 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/herbhall/samverk/internal/provider"
+)
+
+// mockProvider implements provider.Provider for testing.
+type mockProvider struct {
+	name    string
+	healthy bool
+}
+
+func (m *mockProvider) Chat(_ context.Context, _ provider.ChatRequest) (*provider.ChatResponse, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) Healthy(_ context.Context) bool {
+	return m.healthy
+}
+
+func (m *mockProvider) Name() string {
+	return m.name
+}
+
+func TestHealthMonitor_GetHealth(t *testing.T) {
+	reg := provider.NewRegistry(zap.NewNop())
+	p := &mockProvider{name: "test-ollama", healthy: true}
+	reg.Register("test-ollama", "ollama", p, "qwen2.5:7b")
+
+	hm := provider.NewHealthMonitor(reg, time.Hour, zap.NewNop())
+
+	// Before Start, GetHealth returns zero value.
+	h := hm.GetHealth("test-ollama")
+	if h.Healthy {
+		t.Fatal("expected unhealthy before start")
+	}
+
+	// Start runs an initial probe synchronously before the goroutine.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hm.Start(ctx)
+
+	// Give a moment for the initial probe (it runs inline in Start before the goroutine).
+	time.Sleep(50 * time.Millisecond)
+
+	h = hm.GetHealth("test-ollama")
+	if !h.Healthy {
+		t.Fatal("expected healthy after start")
+	}
+	if h.LastChecked.IsZero() {
+		t.Fatal("expected LastChecked to be set")
+	}
+	if h.LastHealthy.IsZero() {
+		t.Fatal("expected LastHealthy to be set")
+	}
+}
+
+func TestHealthMonitor_UnhealthyProvider(t *testing.T) {
+	reg := provider.NewRegistry(zap.NewNop())
+	p := &mockProvider{name: "bad-provider", healthy: false}
+	reg.Register("bad-provider", "ollama", p, "model")
+
+	hm := provider.NewHealthMonitor(reg, time.Hour, zap.NewNop())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hm.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	h := hm.GetHealth("bad-provider")
+	if h.Healthy {
+		t.Fatal("expected unhealthy")
+	}
+	if h.LastHealthy.IsZero() == false {
+		t.Fatal("expected LastHealthy to remain zero for never-healthy provider")
+	}
+}
+
+func TestHealthMonitor_ChainHealthy(t *testing.T) {
+	reg := provider.NewRegistry(zap.NewNop())
+	reg.Register("healthy-one", "ollama", &mockProvider{name: "healthy-one", healthy: true}, "m1")
+	reg.Register("unhealthy-one", "ollama", &mockProvider{name: "unhealthy-one", healthy: false}, "m2")
+
+	hm := provider.NewHealthMonitor(reg, time.Hour, zap.NewNop())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hm.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	if !hm.ChainHealthy([]string{"unhealthy-one", "healthy-one"}) {
+		t.Fatal("chain should be healthy when at least one provider is healthy")
+	}
+	if hm.ChainHealthy([]string{"unhealthy-one"}) {
+		t.Fatal("chain should be unhealthy when all providers are unhealthy")
+	}
+	if hm.ChainHealthy([]string{"nonexistent"}) {
+		t.Fatal("chain should be unhealthy for unknown providers")
+	}
+}
+
+func TestHealthMonitor_AllHealth(t *testing.T) {
+	reg := provider.NewRegistry(zap.NewNop())
+	reg.Register("p1", "ollama", &mockProvider{name: "p1", healthy: true}, "m1")
+	reg.Register("p2", "claude", &mockProvider{name: "p2", healthy: false}, "m2")
+
+	hm := provider.NewHealthMonitor(reg, time.Hour, zap.NewNop())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hm.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	all := hm.AllHealth()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 health entries, got %d", len(all))
+	}
+
+	healthMap := make(map[string]bool)
+	for i := range all {
+		healthMap[all[i].Name] = all[i].Healthy
+	}
+	if !healthMap["p1"] {
+		t.Fatal("p1 should be healthy")
+	}
+	if healthMap["p2"] {
+		t.Fatal("p2 should be unhealthy")
+	}
+}
+
+func TestHealthMonitor_UnknownProvider(t *testing.T) {
+	reg := provider.NewRegistry(zap.NewNop())
+	hm := provider.NewHealthMonitor(reg, time.Hour, zap.NewNop())
+
+	h := hm.GetHealth("nonexistent")
+	if h.Healthy {
+		t.Fatal("unknown provider should be unhealthy")
+	}
+	if h.Name != "nonexistent" {
+		t.Fatalf("expected name 'nonexistent', got %q", h.Name)
+	}
+}

--- a/internal/provider/ollama/ollama.go
+++ b/internal/provider/ollama/ollama.go
@@ -17,8 +17,11 @@ import (
 	"github.com/herbhall/samverk/internal/provider"
 )
 
-// Compile-time check that Client satisfies provider.Provider.
-var _ provider.Provider = (*Client)(nil)
+// Compile-time checks.
+var (
+	_ provider.Provider       = (*Client)(nil)
+	_ provider.HealthDetailer = (*Client)(nil)
+)
 
 // Client is an HTTP client for the Ollama REST API.
 type Client struct {
@@ -104,10 +107,18 @@ func (c *Client) Chat(ctx context.Context, req provider.ChatRequest) (resp *prov
 	return resp, nil
 }
 
+// healthTimeout is the maximum time for a health probe. Shorter than the
+// default HTTP client timeout (30s) to avoid blocking the health monitor.
+const healthTimeout = 5 * time.Second
+
 // Healthy returns true if the Ollama server is reachable.
 // It checks GET / which returns "Ollama is running" on success.
+// Uses a 5-second timeout independent of the main HTTP client timeout.
 func (c *Client) Healthy(ctx context.Context) bool {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/", http.NoBody)
+	hctx, cancel := context.WithTimeout(ctx, healthTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(hctx, http.MethodGet, c.baseURL+"/", http.NoBody)
 	if err != nil {
 		return false
 	}
@@ -119,6 +130,60 @@ func (c *Client) Healthy(ctx context.Context) bool {
 	_ = resp.Body.Close()
 
 	return resp.StatusCode == http.StatusOK
+}
+
+// OllamaHealth contains detailed health information from an Ollama instance.
+type OllamaHealth struct {
+	ModelLoaded bool   `json:"model_loaded"`
+	VRAMFree    int64  `json:"vram_free"`
+	VRAMTotal   int64  `json:"vram_total"`
+	ModelName   string `json:"model_name,omitempty"`
+}
+
+// tagsResponse wraps the /api/tags response.
+type tagsResponse struct {
+	Models []struct {
+		Name string `json:"name"`
+	} `json:"models"`
+}
+
+// HealthDetail returns extended health information: whether the configured
+// model is available and VRAM usage from running models. Implements
+// provider.HealthDetailer.
+func (c *Client) HealthDetail(ctx context.Context) (*provider.HealthDetail, error) {
+	hctx, cancel := context.WithTimeout(ctx, healthTimeout)
+	defer cancel()
+
+	// Check available models via /api/tags.
+	var tags tagsResponse
+	if err := c.doJSON(hctx, http.MethodGet, "/api/tags", nil, &tags); err != nil {
+		return nil, fmt.Errorf("list models: %w", err)
+	}
+
+	// Check running models via /api/ps for VRAM usage.
+	running, err := c.ListRunning(hctx)
+	if err != nil {
+		return nil, fmt.Errorf("list running: %w", err)
+	}
+
+	detail := &provider.HealthDetail{}
+
+	// Check if any model is loaded (tags lists all pulled models).
+	if len(tags.Models) > 0 {
+		detail.ModelLoaded = true
+	}
+
+	// Sum VRAM usage from running models.
+	var totalVRAM int64
+	for i := range running {
+		totalVRAM += running[i].SizeVRAM
+	}
+	// VRAMTotal is the total VRAM consumed by loaded models.
+	// VRAMFree cannot be determined from Ollama's API alone, so we
+	// report total VRAM in use. The dashboard can interpret this.
+	detail.VRAMTotal = totalVRAM
+
+	return detail, nil
 }
 
 // Name returns the provider identifier.

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -143,6 +143,12 @@ func (r *Registry) Routing() map[string][]string {
 	return out
 }
 
+// ProviderByName returns the raw Provider instance for the given name,
+// or nil if the name is not registered.
+func (r *Registry) ProviderByName(name string) Provider {
+	return r.providers[name]
+}
+
 // List returns info about all registered providers with their health status.
 func (r *Registry) List(ctx context.Context) []ProviderInfo {
 	infos := make([]ProviderInfo, 0, len(r.providers))


### PR DESCRIPTION
## Summary

- New `HealthMonitor` runs periodic probes (60s) against all registered providers
- Ollama health check uses 5s timeout (was 30s), plus `HealthDetail()` for model/VRAM data
- Pre-flight health gate in dispatcher: skips claiming issues when no providers are healthy
- New `GET /api/v1/providers/health` endpoint for dashboard/debugging
- Wired into dispatch command alongside existing provider registry

Closes #473, Closes #494

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] golangci-lint clean (0 issues)
- [x] Cross-compile check (GOOS=linux)
- [ ] CI passes on GitHub Actions
- [ ] Deploy and verify health endpoint returns data
- [ ] Verify dispatcher defers issues when Ollama hosts are down

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>