### PR TITLE
feat: Wake-on-LAN support and model deploy script (#495, #497)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -73,6 +73,7 @@ func run() int {
 	root.AddCommand(digestCmd())
 	root.AddCommand(keyCmd())
 	root.AddCommand(statusCmd())
+	root.AddCommand(wakeCmd())
 	root.AddCommand(versionCmd())
 
 	if err := root.Execute(); err != nil {
@@ -281,7 +282,8 @@ func serveCmd() *cobra.Command {
 				regCfg, pcErr := provider.LoadRegistryConfig(providersConfigServe)
 				if pcErr == nil {
 					pdtos := make([]api.ProviderDTO, 0, len(regCfg.Providers))
-					for name, pcfg := range regCfg.Providers {
+					for name := range regCfg.Providers {
+						pcfg := regCfg.Providers[name]
 						pdtos = append(pdtos, api.ProviderDTO{
 							Name:       name,
 							Type:       pcfg.Type,
@@ -509,6 +511,25 @@ func dispatchCmd() *cobra.Command {
 			// Start health monitor for pre-flight provider health gating.
 			if providerRegistry != nil {
 				hm := provider.NewHealthMonitor(providerRegistry, provider.DefaultHealthCheckInterval, logger)
+
+				// Wire WoL targets from provider config.
+				if providersConfig != "" {
+					regCfg, wolErr := provider.LoadRegistryConfig(providersConfig)
+					if wolErr == nil {
+						wolTargets := make(map[string]provider.WoLConfig)
+						for pName := range regCfg.Providers {
+							pcfg := regCfg.Providers[pName]
+							if pcfg.WoLMAC != "" {
+								wolTargets[pName] = provider.WoLConfig{MAC: pcfg.WoLMAC}
+							}
+						}
+						if len(wolTargets) > 0 {
+							hm.SetWoLTargets(wolTargets)
+							logger.Info("Wake-on-LAN targets configured", zap.Int("count", len(wolTargets)))
+						}
+					}
+				}
+
 				hm.Start(ctx)
 				disp.SetHealthMonitor(hm)
 				logger.Info("provider health monitor started")
@@ -1020,6 +1041,43 @@ func statusCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&write, "write", false, "Write to .samverk/status.md instead of stdout")
 	cmd.Flags().StringVar(&healthURL, "health-url", "http://localhost:8080/healthz", "Health check URL")
 
+	return cmd
+}
+
+func wakeCmd() *cobra.Command {
+	var providersConfigWake string
+
+	cmd := &cobra.Command{
+		Use:   "wake <provider-name>",
+		Short: "Send a Wake-on-LAN packet to a provider's host",
+		Long:  "Reads the wol_mac field from the provider's YAML config and sends a magic packet.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			providerName := args[0]
+
+			cfg, err := provider.LoadRegistryConfig(providersConfigWake)
+			if err != nil {
+				return fmt.Errorf("load providers config: %w", err)
+			}
+
+			pcfg, ok := cfg.Providers[providerName]
+			if !ok {
+				return fmt.Errorf("provider %q not found in config", providerName)
+			}
+			if pcfg.WoLMAC == "" {
+				return fmt.Errorf("provider %q has no wol_mac configured", providerName)
+			}
+
+			fmt.Printf("Sending Wake-on-LAN packet to %s (MAC: %s)...\n", providerName, pcfg.WoLMAC)
+			if err := provider.WakeOnLAN(pcfg.WoLMAC); err != nil {
+				return fmt.Errorf("wake-on-LAN failed: %w", err)
+			}
+			fmt.Println("Magic packet sent successfully.")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&providersConfigWake, "providers-config", ".samverk/providers.yaml", "Path to provider registry YAML config")
 	return cmd
 }
 

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -48,6 +48,9 @@ type HealthMonitor struct {
 
 	mu     sync.RWMutex
 	health map[string]*ProviderHealth // keyed by provider name
+
+	wolTargets  map[string]WoLConfig // provider name -> WoL config
+	wolCooldown *wolCooldownTracker
 }
 
 // NewHealthMonitor creates a HealthMonitor that probes all providers in
@@ -60,11 +63,20 @@ func NewHealthMonitor(registry *Registry, interval time.Duration, logger *zap.Lo
 		logger = zap.NewNop()
 	}
 	return &HealthMonitor{
-		registry: registry,
-		interval: interval,
-		logger:   logger,
-		health:   make(map[string]*ProviderHealth),
+		registry:    registry,
+		interval:    interval,
+		logger:      logger,
+		health:      make(map[string]*ProviderHealth),
+		wolTargets:  make(map[string]WoLConfig),
+		wolCooldown: newWoLCooldownTracker(),
 	}
+}
+
+// SetWoLTargets configures Wake-on-LAN targets for providers. When a
+// provider with a configured WoL target is unhealthy, the monitor sends
+// a magic packet (subject to a 5-minute cooldown per target).
+func (hm *HealthMonitor) SetWoLTargets(targets map[string]WoLConfig) {
+	hm.wolTargets = targets
 }
 
 // Start runs the health check loop in a goroutine. It performs an initial
@@ -153,6 +165,10 @@ func (hm *HealthMonitor) probeAll(ctx context.Context) {
 
 		if info.Healthy {
 			existing.LastHealthy = now
+		} else {
+			// Send WoL packet if the provider is unhealthy and has a
+			// configured target, subject to cooldown.
+			hm.tryWakeOnLAN(name)
 		}
 
 		// Attempt extended health detail for providers that support it.
@@ -182,4 +198,33 @@ func (hm *HealthMonitor) probeAll(ctx context.Context) {
 		zap.Int("providers", len(providers)),
 		zap.Time("at", now),
 	)
+}
+
+// tryWakeOnLAN sends a WoL magic packet for the named provider if it has
+// a configured WoL target and the cooldown has expired.
+func (hm *HealthMonitor) tryWakeOnLAN(name string) {
+	wol, ok := hm.wolTargets[name]
+	if !ok || wol.MAC == "" {
+		return
+	}
+
+	if !hm.wolCooldown.shouldSend(wol.MAC) {
+		hm.logger.Debug("WoL cooldown active, skipping",
+			zap.String("provider", name),
+			zap.String("mac", wol.MAC),
+		)
+		return
+	}
+
+	hm.logger.Info("sending Wake-on-LAN packet for unhealthy provider",
+		zap.String("provider", name),
+		zap.String("mac", wol.MAC),
+	)
+	if err := WakeOnLAN(wol.MAC); err != nil {
+		hm.logger.Warn("Wake-on-LAN failed",
+			zap.String("provider", name),
+			zap.String("mac", wol.MAC),
+			zap.Error(err),
+		)
+	}
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -23,6 +23,7 @@ type ProviderConfig struct {
 	AccountURL     string `yaml:"account_url"`     // billing/credits page URL
 	AllowedTools   string `yaml:"allowed_tools"`   // claude-cli: comma-separated tool list (e.g. "Bash,Read,Edit,Write,Glob,Grep")
 	MaxTurns       int    `yaml:"max_turns"`       // claude-cli: max agentic turns per session; 0 means no limit
+	WoLMAC         string `yaml:"wol_mac"`         // optional Wake-on-LAN MAC address (e.g. "AA:BB:CC:DD:EE:FF")
 }
 
 // RegistryConfig is the top-level YAML structure for provider configuration.
@@ -197,7 +198,8 @@ func LoadRegistry(path string, factory ProviderFactory, logger *zap.Logger) (*Re
 
 	reg := NewRegistry(logger)
 
-	for name, pcfg := range cfg.Providers {
+	for name := range cfg.Providers {
+		pcfg := cfg.Providers[name]
 		p, err := factory(name, pcfg)
 		if err != nil {
 			return nil, fmt.Errorf("create provider %q: %w", name, err)

--- a/internal/provider/wol.go
+++ b/internal/provider/wol.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// WoLConfig describes Wake-on-LAN settings for a provider host.
+type WoLConfig struct {
+	MAC string `yaml:"wol_mac"` // e.g., "AA:BB:CC:DD:EE:FF"
+}
+
+// wolCooldownDuration is the minimum interval between WoL packets for the
+// same target to avoid flooding the network.
+const wolCooldownDuration = 5 * time.Minute
+
+// WakeOnLAN sends a magic packet to wake a sleeping host.
+// macAddr should be in "AA:BB:CC:DD:EE:FF" format.
+func WakeOnLAN(macAddr string) error {
+	mac, err := net.ParseMAC(macAddr)
+	if err != nil {
+		return fmt.Errorf("parse MAC address %q: %w", macAddr, err)
+	}
+
+	if len(mac) != 6 {
+		return fmt.Errorf("MAC address %q has %d bytes, expected 6", macAddr, len(mac))
+	}
+
+	packet := buildMagicPacket(mac)
+
+	conn, err := net.DialUDP("udp4", nil, &net.UDPAddr{
+		IP:   net.IPv4bcast,
+		Port: 9, // standard WoL port
+	})
+	if err != nil {
+		return fmt.Errorf("dial UDP broadcast: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err = conn.Write(packet); err != nil {
+		return fmt.Errorf("send magic packet: %w", err)
+	}
+	return nil
+}
+
+// buildMagicPacket constructs a 102-byte Wake-on-LAN magic packet:
+// 6 bytes of 0xFF followed by the MAC address repeated 16 times.
+func buildMagicPacket(mac net.HardwareAddr) []byte {
+	packet := make([]byte, 102)
+
+	// 6 bytes of 0xFF header.
+	for i := 0; i < 6; i++ {
+		packet[i] = 0xFF
+	}
+
+	// MAC address repeated 16 times.
+	for i := 0; i < 16; i++ {
+		copy(packet[6+i*6:], mac)
+	}
+
+	return packet
+}
+
+// wolCooldownTracker prevents sending WoL packets too frequently to the
+// same MAC address.
+type wolCooldownTracker struct {
+	mu       sync.Mutex
+	lastSent map[string]time.Time
+}
+
+func newWoLCooldownTracker() *wolCooldownTracker {
+	return &wolCooldownTracker{
+		lastSent: make(map[string]time.Time),
+	}
+}
+
+// shouldSend returns true if enough time has passed since the last WoL
+// packet was sent to the given MAC address. If true, it also records
+// the current time as the last send time.
+func (t *wolCooldownTracker) shouldSend(mac string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if last, ok := t.lastSent[mac]; ok {
+		if time.Since(last) < wolCooldownDuration {
+			return false
+		}
+	}
+	t.lastSent[mac] = time.Now()
+	return true
+}

--- a/internal/provider/wol_test.go
+++ b/internal/provider/wol_test.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestBuildMagicPacket_Length(t *testing.T) {
+	mac, err := net.ParseMAC("AA:BB:CC:DD:EE:FF")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packet := buildMagicPacket(mac)
+	if len(packet) != 102 {
+		t.Fatalf("expected 102 bytes, got %d", len(packet))
+	}
+}
+
+func TestBuildMagicPacket_Header(t *testing.T) {
+	mac, err := net.ParseMAC("11:22:33:44:55:66")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packet := buildMagicPacket(mac)
+
+	// First 6 bytes must be 0xFF.
+	for i := 0; i < 6; i++ {
+		if packet[i] != 0xFF {
+			t.Fatalf("byte %d: expected 0xFF, got 0x%02X", i, packet[i])
+		}
+	}
+}
+
+func TestBuildMagicPacket_MACRepeated(t *testing.T) {
+	mac, err := net.ParseMAC("11:22:33:44:55:66")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packet := buildMagicPacket(mac)
+
+	// MAC address should be repeated 16 times starting at offset 6.
+	for rep := 0; rep < 16; rep++ {
+		offset := 6 + rep*6
+		for b := 0; b < 6; b++ {
+			if packet[offset+b] != mac[b] {
+				t.Fatalf("repetition %d, byte %d: expected 0x%02X, got 0x%02X",
+					rep, b, mac[b], packet[offset+b])
+			}
+		}
+	}
+}
+
+func TestWakeOnLAN_InvalidMAC(t *testing.T) {
+	tests := []struct {
+		name string
+		mac  string
+	}{
+		{name: "empty", mac: ""},
+		{name: "garbage", mac: "not-a-mac"},
+		{name: "too_short", mac: "AA:BB:CC"},
+		{name: "invalid_hex", mac: "GG:HH:II:JJ:KK:LL"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := WakeOnLAN(tc.mac)
+			if err == nil {
+				t.Fatal("expected error for invalid MAC")
+			}
+		})
+	}
+}
+
+func TestWakeOnLAN_ValidMACFormats(t *testing.T) {
+	// These should parse successfully (though sending may fail on CI
+	// without a real NIC -- we only test that parsing works).
+	tests := []struct {
+		name string
+		mac  string
+	}{
+		{name: "colon_separated", mac: "AA:BB:CC:DD:EE:FF"},
+		{name: "dash_separated", mac: "AA-BB-CC-DD-EE-FF"},
+		{name: "lowercase", mac: "aa:bb:cc:dd:ee:ff"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mac, err := net.ParseMAC(tc.mac)
+			if err != nil {
+				t.Fatalf("expected valid MAC parse, got: %v", err)
+			}
+			if len(mac) != 6 {
+				t.Fatalf("expected 6 bytes, got %d", len(mac))
+			}
+		})
+	}
+}
+
+func TestWoLCooldownTracker(t *testing.T) {
+	tracker := newWoLCooldownTracker()
+
+	// First send should be allowed.
+	if !tracker.shouldSend("AA:BB:CC:DD:EE:FF") {
+		t.Fatal("first send should be allowed")
+	}
+
+	// Immediate second send should be blocked by cooldown.
+	if tracker.shouldSend("AA:BB:CC:DD:EE:FF") {
+		t.Fatal("second immediate send should be blocked")
+	}
+
+	// Different MAC should be independent.
+	if !tracker.shouldSend("11:22:33:44:55:66") {
+		t.Fatal("different MAC should be allowed independently")
+	}
+}
+
+func TestWoLCooldownTracker_ExpiredCooldown(t *testing.T) {
+	tracker := newWoLCooldownTracker()
+
+	// Set a past timestamp to simulate expired cooldown.
+	tracker.mu.Lock()
+	tracker.lastSent["AA:BB:CC:DD:EE:FF"] = time.Now().Add(-10 * time.Minute)
+	tracker.mu.Unlock()
+
+	if !tracker.shouldSend("AA:BB:CC:DD:EE:FF") {
+		t.Fatal("send should be allowed after cooldown expires")
+	}
+}

--- a/scripts/deploy-models.sh
+++ b/scripts/deploy-models.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Deploy Ollama models to all configured hosts.
+# Reads model assignments from a manifest file.
+# Usage: ./scripts/deploy-models.sh [--check|--pull]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="${SCRIPT_DIR}/model-manifest.yaml"
+
+# Colors (disable if not a terminal).
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BOLD='\033[1m'
+    RESET='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BOLD=''
+    RESET=''
+fi
+
+usage() {
+    echo "Usage: $0 [--check|--pull]"
+    echo ""
+    echo "  --check   Compare current models on each host vs manifest, report drift"
+    echo "  --pull    Pull missing models on each host via Ollama API"
+    echo ""
+    echo "Reads model assignments from: ${MANIFEST}"
+    exit 1
+}
+
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+MODE="$1"
+case "${MODE}" in
+    --check|--pull) ;;
+    *) usage ;;
+esac
+
+if [ ! -f "${MANIFEST}" ]; then
+    echo -e "${RED}Error: manifest not found: ${MANIFEST}${RESET}"
+    exit 1
+fi
+
+# Parse YAML manifest without external dependencies.
+# Extracts host entries as: hostname url model1,model2,...
+parse_manifest() {
+    local current_host=""
+    local current_url=""
+    local current_models=""
+
+    while IFS= read -r line; do
+        # Skip comments and empty lines.
+        [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]] && continue
+
+        # Match host name (e.g., "  ollama-nzxt:").
+        if [[ "${line}" =~ ^[[:space:]]{2}([a-zA-Z0-9_-]+):[[:space:]]*$ ]]; then
+            # Emit previous host if any.
+            if [ -n "${current_host}" ] && [ -n "${current_url}" ]; then
+                echo "${current_host}|${current_url}|${current_models}"
+            fi
+            current_host="${BASH_REMATCH[1]}"
+            current_url=""
+            current_models=""
+            continue
+        fi
+
+        # Match url field.
+        if [[ "${line}" =~ ^[[:space:]]+url:[[:space:]]*(.+)$ ]]; then
+            current_url="${BASH_REMATCH[1]}"
+            continue
+        fi
+
+        # Match model entry (e.g., "      - qwen2.5-coder:7b").
+        if [[ "${line}" =~ ^[[:space:]]+-[[:space:]]+(.+)$ ]]; then
+            local model="${BASH_REMATCH[1]}"
+            if [ -n "${current_models}" ]; then
+                current_models="${current_models},${model}"
+            else
+                current_models="${model}"
+            fi
+            continue
+        fi
+    done < "${MANIFEST}"
+
+    # Emit last host.
+    if [ -n "${current_host}" ] && [ -n "${current_url}" ]; then
+        echo "${current_host}|${current_url}|${current_models}"
+    fi
+}
+
+# Get list of models currently on a host via Ollama API.
+get_remote_models() {
+    local url="$1"
+    local response
+    response=$(curl -s --connect-timeout 5 --max-time 10 "${url}/api/tags" 2>/dev/null) || {
+        echo "ERROR"
+        return
+    }
+
+    # Extract model names from JSON response using simple pattern matching.
+    # Ollama returns {"models":[{"name":"model:tag",...},...]}
+    echo "${response}" | tr ',' '\n' | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"//' || true
+}
+
+# Pull a model on a remote host via Ollama API.
+pull_model() {
+    local url="$1"
+    local model="$2"
+
+    echo -e "  ${YELLOW}Pulling ${model}...${RESET}"
+    local status_code
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 600 \
+        -X POST "${url}/api/pull" \
+        -H "Content-Type: application/json" \
+        -d "{\"name\":\"${model}\",\"stream\":false}" 2>/dev/null) || {
+        echo -e "  ${RED}Failed to pull ${model} (connection error)${RESET}"
+        return 1
+    }
+
+    if [ "${status_code}" = "200" ]; then
+        echo -e "  ${GREEN}Pulled ${model} successfully${RESET}"
+        return 0
+    else
+        echo -e "  ${RED}Failed to pull ${model} (HTTP ${status_code})${RESET}"
+        return 1
+    fi
+}
+
+drift_found=0
+
+while IFS='|' read -r host_name host_url host_models; do
+    echo -e "${BOLD}${host_name}${RESET} (${host_url})"
+
+    # Get remote models.
+    remote_models=$(get_remote_models "${host_url}")
+    if [ "${remote_models}" = "ERROR" ]; then
+        echo -e "  ${RED}Unreachable${RESET}"
+        drift_found=1
+        echo ""
+        continue
+    fi
+
+    # Check each expected model.
+    IFS=',' read -ra expected_models <<< "${host_models}"
+    for model in "${expected_models[@]}"; do
+        if echo "${remote_models}" | grep -qF "${model}"; then
+            echo -e "  ${GREEN}OK${RESET}  ${model}"
+        else
+            echo -e "  ${RED}MISSING${RESET}  ${model}"
+            drift_found=1
+
+            if [ "${MODE}" = "--pull" ]; then
+                pull_model "${host_url}" "${model}" || true
+            fi
+        fi
+    done
+    echo ""
+done < <(parse_manifest)
+
+if [ "${MODE}" = "--check" ] && [ "${drift_found}" -ne 0 ]; then
+    echo -e "${RED}Drift detected. Run with --pull to fix.${RESET}"
+    exit 1
+fi
+
+if [ "${MODE}" = "--check" ] && [ "${drift_found}" -eq 0 ]; then
+    echo -e "${GREEN}All hosts match manifest.${RESET}"
+fi

--- a/scripts/model-manifest.yaml
+++ b/scripts/model-manifest.yaml
@@ -1,0 +1,17 @@
+# Model assignments per Ollama host.
+# Used by deploy-models.sh to ensure consistent model versions.
+hosts:
+  ollama-nzxt:
+    url: http://192.168.1.202:11434
+    models:
+      - qwen3-coder:30b
+      - nomic-embed-text:latest
+  ollama-vm300:
+    url: http://192.168.1.207:11434
+    models:
+      - qwen2.5-coder:14b
+      - nomic-embed-text:latest
+  ollama-cmasus:
+    url: http://100.88.37.47:11434
+    models:
+      - qwen2.5-coder:7b


### PR DESCRIPTION
## Summary

- **Wake-on-LAN**: `WakeOnLAN(mac)` sends magic packet via UDP broadcast. Integrated into HealthMonitor with 5-min cooldown per target. New `samverk wake <provider>` CLI command. Config via `wol_mac` in providers.yaml.
- **Model deploy script**: `scripts/deploy-models.sh --check` detects drift, `--pull` pulls missing models. Reads from `scripts/model-manifest.yaml`. Color output, curl-only.
- Fixed 3 `rangeValCopy` lint warnings from ProviderConfig growing past 128 bytes.

Closes #495, Closes #497

## Test plan

- [x] Build passes
- [x] All tests pass (including WoL packet construction tests)
- [x] golangci-lint clean
- [x] Cross-compile check
- [ ] CI passes
- [ ] Test `samverk wake` with real MAC address
- [ ] Test `deploy-models.sh --check` against live hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)