### PR TITLE
feat: session-end documentation gate (#466)

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -443,6 +443,8 @@ func (r *Runner) postProcess(ctx context.Context, task Task, response, workDir s
 			return err
 		}
 		if changed {
+			// Check doc gate: warn if code changed without doc updates.
+			r.checkDocGate(ctx, task, workDir)
 			// Post the agent's response as an informational comment.
 			_ = r.postComment(ctx, task, response)
 			return nil
@@ -467,6 +469,30 @@ func (r *Runner) postProcess(ctx context.Context, task Task, response, workDir s
 		return r.postComment(ctx, task, response)
 	default:
 		return r.postComment(ctx, task, response)
+	}
+}
+
+// checkDocGate posts a warning comment if the session modified code/infra
+// files without updating documentation. Best-effort: errors are logged but
+// do not block the task.
+func (r *Runner) checkDocGate(ctx context.Context, task Task, workDir string) {
+	files, err := ChangedFiles(workDir)
+	if err != nil {
+		r.logger.Debug("doc gate: could not list changed files", zap.Error(err))
+		return
+	}
+	needsDoc, codeFiles := CheckDocGate(files)
+	if !needsDoc {
+		return
+	}
+	warning := fmt.Sprintf(
+		"DOC_GATE [dispatcher] [%s]\nThis session modified %d infrastructure/code file(s) without updating documentation:\n%s\nConsider updating docs/ or .samverk/status.md.",
+		time.Now().UTC().Format(time.RFC3339),
+		len(codeFiles),
+		strings.Join(codeFiles, "\n"),
+	)
+	if _, commentErr := r.tracker.AddComment(ctx, task.Issue.Number, warning); commentErr != nil {
+		r.logger.Warn("doc gate: failed to post warning", zap.Error(commentErr))
 	}
 }
 

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -161,6 +161,47 @@ func CommitAndPush(workDir, commitMsg string) (changed bool, err error) {
 	return true, nil
 }
 
+// ChangedFiles returns the list of files changed in the most recent commit
+// relative to the workspace directory.
+func ChangedFiles(workDir string) ([]string, error) {
+	out, err := gitExec(workDir, "diff", "--name-only", "HEAD~1")
+	if err != nil {
+		return nil, fmt.Errorf("git diff: %w", err)
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+// CheckDocGate examines a list of changed files and returns true if
+// infrastructure or code files were modified without corresponding
+// documentation updates. Returns false for test-only or docs-only changes.
+func CheckDocGate(changed []string) (needsDoc bool, codeFiles []string) {
+	var hasCodeChange, hasDocChange bool
+	for _, f := range changed {
+		switch {
+		case strings.HasSuffix(f, "_test.go"):
+			// test-only files don't trigger doc gate
+		case strings.HasPrefix(f, "internal/") ||
+			strings.HasPrefix(f, "cmd/") ||
+			strings.HasPrefix(f, "pkg/") ||
+			strings.HasPrefix(f, "deploy/"):
+			hasCodeChange = true
+			codeFiles = append(codeFiles, f)
+		case strings.HasPrefix(f, "docs/") ||
+			strings.HasPrefix(f, ".samverk/") ||
+			strings.HasSuffix(f, "README.md") ||
+			strings.HasSuffix(f, "CLAUDE.md"):
+			hasDocChange = true
+		}
+	}
+	return hasCodeChange && !hasDocChange, codeFiles
+}
+
 // ReadWorkspaceFiles reads file contents from the given directory for the
 // specified paths. Returns a map of path to content. Files that cannot be read
 // are included with empty content. The total content size is capped at maxBytes.

--- a/internal/agent/workspace_test.go
+++ b/internal/agent/workspace_test.go
@@ -364,3 +364,67 @@ func TestExtractFileContext_NoDir(t *testing.T) {
 		t.Errorf("expected empty content without dir, got %q", result["cmd/samverk/root.go"])
 	}
 }
+
+func TestCheckDocGate(t *testing.T) {
+	tests := []struct {
+		name      string
+		changed   []string
+		wantGate  bool
+		wantFiles int
+	}{
+		{
+			name:     "docs only -- no gate",
+			changed:  []string{"docs/architecture.md", "README.md"},
+			wantGate: false,
+		},
+		{
+			name:     "tests only -- no gate",
+			changed:  []string{"internal/agent/runner_test.go", "internal/store/store_test.go"},
+			wantGate: false,
+		},
+		{
+			name:      "code without docs -- gate fires",
+			changed:   []string{"internal/agent/runner.go", "cmd/samverk/main.go"},
+			wantGate:  true,
+			wantFiles: 2,
+		},
+		{
+			name:     "code with docs -- no gate",
+			changed:  []string{"internal/agent/runner.go", "docs/architecture.md"},
+			wantGate: false,
+		},
+		{
+			name:     "code with status -- no gate",
+			changed:  []string{"internal/server/server.go", ".samverk/status.md"},
+			wantGate: false,
+		},
+		{
+			name:      "deploy without docs -- gate fires",
+			changed:   []string{"deploy/Dockerfile"},
+			wantGate:  true,
+			wantFiles: 1,
+		},
+		{
+			name:     "empty -- no gate",
+			changed:  []string{},
+			wantGate: false,
+		},
+		{
+			name:      "mixed code and tests without docs -- gate fires for code only",
+			changed:   []string{"internal/agent/runner.go", "internal/agent/runner_test.go"},
+			wantGate:  true,
+			wantFiles: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			needsDoc, codeFiles := CheckDocGate(tt.changed)
+			if needsDoc != tt.wantGate {
+				t.Errorf("CheckDocGate() needsDoc = %v, want %v", needsDoc, tt.wantGate)
+			}
+			if tt.wantGate && len(codeFiles) != tt.wantFiles {
+				t.Errorf("CheckDocGate() codeFiles count = %d, want %d", len(codeFiles), tt.wantFiles)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- PostProcess checks if code/infra files were modified without doc updates
- Posts DOC_GATE warning comment when infrastructure changes lack documentation
- Test-only and docs-only changes don't trigger the gate
- 8 table-driven test cases covering all scenarios

Closes #466

## Test plan

- [x] Build passes
- [x] All agent tests pass (14s)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)