### PR TITLE
feat: add doc-audit CLI for documentation drift detection (#467)

### DIFF
--- a/cmd/samverk/main.go
+++ b/cmd/samverk/main.go
@@ -1098,13 +1098,13 @@ func docAuditCmd() *cobra.Command {
 			}
 
 			if len(findings) == 0 {
-				fmt.Fprintln(os.Stdout, "No documentation issues found.")
+				_, _ = fmt.Fprintln(os.Stdout, "No documentation issues found.")
 				return nil
 			}
 
 			// Print findings as a table.
-			fmt.Fprintf(os.Stdout, "%-8s | %-40s | %s\n", "SEVERITY", "FILE", "MESSAGE")
-			fmt.Fprintf(os.Stdout, "%-8s | %-40s | %s\n", "--------", "----------------------------------------", "-------")
+			_, _ = fmt.Fprintf(os.Stdout, "%-8s | %-40s | %s\n", "SEVERITY", "FILE", "MESSAGE")
+			_, _ = fmt.Fprintf(os.Stdout, "%-8s | %-40s | %s\n", "--------", "----------------------------------------", "-------")
 			hasError := false
 			for i := range findings {
 				f := &findings[i]
@@ -1112,7 +1112,7 @@ func docAuditCmd() *cobra.Command {
 				if f.Line > 0 {
 					loc = fmt.Sprintf("%s:%d", f.File, f.Line)
 				}
-				fmt.Fprintf(os.Stdout, "%-8s | %-40s | %s\n", string(f.Severity), loc, f.Message)
+				_, _ = fmt.Fprintf(os.Stdout, "%-8s | %-40s | %s\n", string(f.Severity), loc, f.Message)
 				if f.Severity == docaudit.SeverityError {
 					hasError = true
 				}

--- a/internal/docaudit/auditor.go
+++ b/internal/docaudit/auditor.go
@@ -74,7 +74,7 @@ func (a *Auditor) Run() ([]Finding, error) {
 func (a *Auditor) checkStaleStatus() ([]Finding, error) {
 	statusPath := filepath.Join(a.repoRoot, ".samverk", "status.md")
 
-	f, err := os.Open(statusPath)
+	f, err := os.Open(statusPath) //nolint:gosec // G304: path is constructed from trusted repoRoot
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil // handled by checkRequiredDocs
@@ -165,7 +165,7 @@ func (a *Auditor) checkMissingReferences() ([]Finding, error) {
 }
 
 func (a *Auditor) checkFileReferences(absPath, relPath string) ([]Finding, error) {
-	f, err := os.Open(absPath)
+	f, err := os.Open(absPath) //nolint:gosec // G304: path is constructed from trusted repoRoot + docs dir scan
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (a *Auditor) checkFileReferences(absPath, relPath string) ([]Finding, error
 			dir := filepath.Dir(absPath)
 			targetAbs := filepath.Join(dir, linkTarget)
 
-			if _, statErr := os.Stat(targetAbs); os.IsNotExist(statErr) {
+			if _, statErr := os.Stat(targetAbs); os.IsNotExist(statErr) { //nolint:gosec // G703: path is from markdown link resolution within repo
 				findings = append(findings, Finding{
 					File:     relPath,
 					Line:     lineNum,

--- a/internal/docaudit/auditor_test.go
+++ b/internal/docaudit/auditor_test.go
@@ -277,7 +277,7 @@ func TestRunIntegration(t *testing.T) {
 }
 
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+	return len(s) >= len(substr) && (s == substr || s != "" && containsStr(s, substr))
 }
 
 func containsStr(s, sub string) bool {


### PR DESCRIPTION
## Summary

- New `samverk doc-audit` CLI command that detects documentation drift
- Three checks: stale status.md (>7 days), broken markdown links in docs/, missing required docs
- Table output with severity levels, exit code 1 on errors
- New `internal/docaudit/` package with table-driven tests

Closes #467

## Test plan

- [ ] `make ci` passes
- [ ] `samverk doc-audit --root .` runs against the repo and reports findings
- [ ] Tests cover all three check types independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>